### PR TITLE
chore: set build env for windows to match nimbus

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -72,7 +72,7 @@ runs:
         steps.windows-dlls-cache.outputs.cache-hit != 'true' &&
         inputs.os == 'Windows'
       run: |
-        mkdir external
+        mkdir -p external
         curl -L "https://nim-lang.org/download/windeps.zip" -o external/windeps.zip
         7z x external/windeps.zip -oexternal/dlls
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           - platform:
               os: windows
             builder: windows-2022
-            shell: msys2 {0}
+            shell: bash
 
     defaults:
       run:
@@ -65,6 +65,42 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
+      - name: Restore llvm-mingw (Windows) from cache
+        if: runner.os == 'Windows'
+        id: windows-mingw-cache
+        uses: actions/cache@v4
+        with:
+          path: external/mingw-${{ matrix.target.cpu }}
+          key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
+
+      - name: Install llvm-mingw dependency (Windows)
+        if: >
+          steps.windows-mingw-cache.outputs.cache-hit != 'true' &&
+          runner.os == 'Windows'
+        run: |
+          mkdir -p external
+          MINGW_BASE="https://github.com/mstorsjo/llvm-mingw/releases/download/20230905"
+          MINGW_URL="$MINGW_BASE/llvm-mingw-20230905-ucrt-x86_64.zip"
+          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.target.cpu }}.zip"
+          7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
+          mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
+
+      - name: Path to cached dependencies (Windows)
+        if: >
+          runner.os == 'Windows'
+        run: |
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
+          # for miniupnp that runs "wingenminiupnpcstrings.exe" from the current dir
+          echo "." >> $GITHUB_PATH
+
+      - name: Install nasm (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install nasm --no-progress -y
+          "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup Nim
         uses: "./.github/actions/install_nim"
@@ -83,10 +119,6 @@ jobs:
           # The change happened on Nimble v0.14.0. Also forcing the deps to be reinstalled on each os and cpu.
           key: nimbledeps-${{ matrix.nim.ref }}-${{ matrix.builder }}-${{ matrix.platform.cpu }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
 
-      - name: Install deps (windows)
-        if: ${{ matrix.platform.os == 'windows'}}
-        run: |
-          pacman -S --noconfirm base-devel gcc nasm
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
@@ -108,5 +140,10 @@ jobs:
           nimble --version
           gcc --version
 
-          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
+          export NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
+
+          if [[ '${{ runner.os }}' == 'Windows' ]]; then
+            export NIMFLAGS="${NIMFLAGS} --cc:clang"
+          fi
+
           nimble test --styleCheck:off --verbose --debug

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,8 @@ jobs:
         id: windows-mingw-cache
         uses: actions/cache@v4
         with:
-          path: external/mingw-${{ matrix.target.cpu }}
-          key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
+          path: external/mingw-${{ matrix.platform.cpu }}
+          key: 'mingw-llvm-17-${{ matrix.platform.cpu }}'
 
       - name: Install llvm-mingw dependency (Windows)
         if: >
@@ -82,17 +82,15 @@ jobs:
           mkdir -p external
           MINGW_BASE="https://github.com/mstorsjo/llvm-mingw/releases/download/20230905"
           MINGW_URL="$MINGW_BASE/llvm-mingw-20230905-ucrt-x86_64.zip"
-          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.target.cpu }}.zip"
-          7z x -y "external/mingw-${{ matrix.target.cpu }}.zip" -oexternal/mingw-${{ matrix.target.cpu }}/
-          mv external/mingw-${{ matrix.target.cpu }}/**/* ./external/mingw-${{ matrix.target.cpu }}
+          curl -L "$MINGW_URL" -o "external/mingw-${{ matrix.platform.cpu }}.zip"
+          7z x -y "external/mingw-${{ matrix.platform.cpu }}.zip" -oexternal/mingw-${{ matrix.platform.cpu }}/
+          mv external/mingw-${{ matrix.platform.cpu }}/**/* ./external/mingw-${{ matrix.platform.cpu }}
 
       - name: Path to cached dependencies (Windows)
         if: >
           runner.os == 'Windows'
         run: |
-          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.target.cpu }}/bin" >> $GITHUB_PATH
-          echo "${{ github.workspace }}/external/dlls-${{ matrix.target.cpu }}" >> $GITHUB_PATH
-          # for miniupnp that runs "wingenminiupnpcstrings.exe" from the current dir
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.platform.cpu }}/bin" >> $GITHUB_PATH
           echo "." >> $GITHUB_PATH
 
       - name: Install nasm (Windows)

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -3,7 +3,7 @@ version = "0.0.1"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"
-installDirs = @["libs"]
+installDirs = @["libs", "scripts"]
 installFiles = @["lsquic.nim", "boringssl.nim"]
 
 requires "nim >= 2.0.0"

--- a/lsquic/lsquic_ffi.nim
+++ b/lsquic/lsquic_ffi.nim
@@ -4,7 +4,7 @@
 when defined(windows):
   {.passc: "-D_WIN32_WINNT=0x0600".}
   {.passl: "-lws2_32".}
-  # ls-quic requires windows specific pthread otherwise the compiler will complain
+  # lsquic requires windows specific pthread otherwise the compiler will complain
   # about missing pthread functions
   {.passl: "-lwinpthread".}
 
@@ -35,11 +35,7 @@ when defined(windows):
 {.passc: fmt"-I{xxhash}".}
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
-const XXH_HEADER_NAME =
-  when defined(windows) and defined(clang):
-    "-DXXH_HEADER_NAME=<lsquic_xxhash.h>"
-  else:
-    "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
+const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\"<lsquic_xxhash.h>\""
 
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_xxhash.c".}
 {.compile("../libs/lsquic/src/liblsquic/ls-qpack/lsqpack.c", XXH_HEADER_NAME).}

--- a/lsquic/lsquic_ffi.nim
+++ b/lsquic/lsquic_ffi.nim
@@ -32,11 +32,7 @@ when defined(windows):
 {.passc: fmt"-I{xxhash}".}
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
-
-when defined(windows) and defined(clang):
-  const XXH_HEADER_NAME = "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
-else:
-  const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\\\"lsquic_xxhash.h\\\""
+const XXH_HEADER_NAME = "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
 
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_xxhash.c".}
 {.compile("../libs/lsquic/src/liblsquic/ls-qpack/lsqpack.c", XXH_HEADER_NAME).}

--- a/lsquic/lsquic_ffi.nim
+++ b/lsquic/lsquic_ffi.nim
@@ -4,6 +4,9 @@
 when defined(windows):
   {.passc: "-D_WIN32_WINNT=0x0600".}
   {.passl: "-lws2_32".}
+  # ls-quic requires windows specific pthread otherwise the compiler will complain
+  # about missing pthread functions
+  {.passl: "-lwinpthread".}
 
 import std/[os, strformat, strutils]
 import chronos/osdefs
@@ -32,7 +35,11 @@ when defined(windows):
 {.passc: fmt"-I{xxhash}".}
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
-const XXH_HEADER_NAME = "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
+const XXH_HEADER_NAME =
+  when defined(windows) and defined(clang):
+    "-DXXH_HEADER_NAME=<lsquic_xxhash.h>"
+  else:
+    "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
 
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_xxhash.c".}
 {.compile("../libs/lsquic/src/liblsquic/ls-qpack/lsqpack.c", XXH_HEADER_NAME).}

--- a/prelude.nim
+++ b/prelude.nim
@@ -4,7 +4,7 @@
 when defined(windows):
   {.passc: "-D_WIN32_WINNT=0x0600".}
   {.passl: "-lws2_32".}
-  # ls-quic requires windows specific pthread otherwise the compiler will complain
+  # lsquic requires windows specific pthread otherwise the compiler will complain
   # about missing pthread functions
   {.passl: "-lwinpthread".}
 
@@ -35,11 +35,7 @@ when defined(windows):
 {.passc: fmt"-I{xxhash}".}
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
-const XXH_HEADER_NAME =
-  when defined(windows) and defined(clang):
-    "-DXXH_HEADER_NAME=<lsquic_xxhash.h>"
-  else:
-    "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
+const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\"<lsquic_xxhash.h>\""
 
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_xxhash.c".}
 {.compile("../libs/lsquic/src/liblsquic/ls-qpack/lsqpack.c", XXH_HEADER_NAME).}

--- a/prelude.nim
+++ b/prelude.nim
@@ -32,11 +32,7 @@ when defined(windows):
 {.passc: fmt"-I{xxhash}".}
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
-
-when defined(windows) and defined(clang):
-  const XXH_HEADER_NAME = "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
-else:
-  const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\\\"lsquic_xxhash.h\\\""
+const XXH_HEADER_NAME = "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
 
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_xxhash.c".}
 {.compile("../libs/lsquic/src/liblsquic/ls-qpack/lsqpack.c", XXH_HEADER_NAME).}

--- a/prelude.nim
+++ b/prelude.nim
@@ -4,6 +4,9 @@
 when defined(windows):
   {.passc: "-D_WIN32_WINNT=0x0600".}
   {.passl: "-lws2_32".}
+  # ls-quic requires windows specific pthread otherwise the compiler will complain
+  # about missing pthread functions
+  {.passl: "-lwinpthread".}
 
 import std/[os, strformat, strutils]
 import chronos/osdefs
@@ -32,7 +35,11 @@ when defined(windows):
 {.passc: fmt"-I{xxhash}".}
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
-const XXH_HEADER_NAME = "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
+const XXH_HEADER_NAME =
+  when defined(windows) and defined(clang):
+    "-DXXH_HEADER_NAME=<lsquic_xxhash.h>"
+  else:
+    "-DXXH_HEADER_NAME='<lsquic_xxhash.h>'"
 
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_xxhash.c".}
 {.compile("../libs/lsquic/src/liblsquic/ls-qpack/lsqpack.c", XXH_HEADER_NAME).}


### PR DESCRIPTION
CI will now use the same compiler (clang) as nimbus for windows, and that way guarantee there is no compilation errors happening when nim-lsquic lands on nimbus. Will do a similar PR for libp2p.