### PR TITLE
chore: make lpthread optional if using windows with clang

### DIFF
--- a/lsquic/lsquic_ffi.nim
+++ b/lsquic/lsquic_ffi.nim
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-when defined(windows):
-  {.passc: "-D_WIN32_WINNT=0x0600".}
-  {.passl: "-lws2_32".}
+when defined(windows) and defined(clang):
   {.passl: "-lpthread".}
 
 import std/[os, strformat, strutils]

--- a/lsquic/lsquic_ffi.nim
+++ b/lsquic/lsquic_ffi.nim
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-when defined(windows) and defined(clang):
-  {.passl: "-lpthread".}
+when defined(windows):
+  {.passl: "-lws2_32".}
+  when defined(clang):
+    {.passl: "-lpthread".}
 
 import std/[os, strformat, strutils]
 import chronos/osdefs

--- a/prelude.nim
+++ b/prelude.nim
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-when defined(windows):
-  {.passc: "-D_WIN32_WINNT=0x0600".}
-  {.passl: "-lws2_32".}
+when defined(windows) and defined(clang):
   {.passl: "-lpthread".}
 
 import std/[os, strformat, strutils]

--- a/prelude.nim
+++ b/prelude.nim
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-when defined(windows) and defined(clang):
-  {.passl: "-lpthread".}
+when defined(windows):
+  {.passl: "-lws2_32".}
+  when defined(clang):
+    {.passl: "-lpthread".}
 
 import std/[os, strformat, strutils]
 import chronos/osdefs


### PR DESCRIPTION
Also removes _WIN32_WINNT as it is not needed
as seen in https://github.com/status-im/nimbus-eth2/pull/8025

cc: @tersec 