### PR TITLE
feat: benchmarks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+benchmarks/results
+benchmarks/bench_server
+benchmarks/bench_client
+nimbledeps
+nimcache

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,3 @@
+results/
+bench_server
+bench_client

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,0 +1,46 @@
+# Multi-stage build for nim-lsquic benchmarks
+# Stage 1: Build the benchmark binaries
+FROM ubuntu:22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    curl gcc g++ git make xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Nim via choosenim
+ENV CHOOSENIM_CHOOSE_VERSION=2.2.4
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
+ENV PATH="/root/.nimble/bin:${PATH}"
+
+WORKDIR /src
+
+# Copy repo (expects docker build context = repo root)
+COPY . .
+
+# Make sure submodules are present
+RUN git submodule update --init --recursive 2>/dev/null || true
+
+# Register local package + install deps
+RUN nimble develop -y && nimble install -y --depsOnly
+
+# Compile both binaries (--path:/src ensures local lsquic is found)
+RUN nim c --threads:on -d:release --path:/src --out:benchmarks/bench_server benchmarks/bench_server.nim
+RUN nim c --threads:on -d:release --path:/src --out:benchmarks/bench_client benchmarks/bench_client.nim
+
+# Stage 2: Minimal runtime image
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# iproute2 for tc/netem network shaping
+RUN apt-get update && apt-get install -y \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/benchmarks/bench_server /usr/local/bin/bench_server
+COPY --from=builder /src/benchmarks/bench_client /usr/local/bin/bench_client
+COPY benchmarks/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,338 @@
+# nim-lsquic Benchmark Harness
+
+Docker-based harness for measuring bandwidth and latency of nim-lsquic under
+various network conditions. Runs a QUIC server and client in separate containers
+connected via a Docker bridge network, with configurable latency, bandwidth
+limits, and packet loss via `tc netem`.
+
+## Defaults
+
+| Parameter | CLI default | Docker Compose default |
+|-----------|-------------|----------------------|
+| Mode | `throughput` | `throughput` |
+| Port | `14555` | `14555` |
+| Upload size | 100 KB (`100000`) | 100 KB (`100000`) |
+| Download size | 100 MB (`100000000`) | 10 MB (`10000000`) |
+| Chunk size | 64 KB (`65536`) | 64 KB (`65536`) |
+| Runs | `10` | `5` |
+| Streams/conn | `4` | `4` |
+| Connections | `4` | `4` |
+
+> The Docker Compose defaults use a smaller download size and fewer runs to keep
+> container-based benchmarks practical. Adjust via environment variables as needed.
+
+## Benchmark Modes
+
+| Mode | Connections | Streams/conn | What it measures |
+|------|-------------|-------------|------------------|
+| `throughput` | 1 | 1 | Baseline upload/download bandwidth |
+| `latency` | 1 | 1 | Baseline RTT (ping/pong echo) |
+| `multistream` | 1 | K (default: 4) | Stream contention within a single connection |
+| `multiconn` | N (default: 4) | 1 | Connection contention across separate QUIC connections |
+| `stress` | N (default: 4) | K (default: 4) | Combined connection + stream contention |
+
+### `throughput`
+
+Opens a single connection with a single stream. The client uploads a configurable
+amount of data, then the server sends back a configurable download payload. This
+gives you the baseline maximum bandwidth nim-lsquic can push through one stream
+with no contention. Use this to establish an upper bound before testing with
+concurrent load.
+
+### `latency`
+
+Opens a single connection with a single stream dedicated to ping/pong. The client
+sends a small 64-byte payload, the server echoes it back, and the client measures
+the round-trip time. Repeats for the configured number of runs. This gives you
+the baseline RTT with no competing traffic — the floor against which you compare
+the other modes.
+
+### `multistream`
+
+Opens a single connection with K streams. K-1 streams do bulk throughput
+transfers (upload + download) while 1 stream acts as a **latency probe** running
+the same ping/pong as the `latency` mode. All streams share the same QUIC
+connection, meaning they share one congestion window, one flow control context,
+and one `engine_process` call. This answers the question: *does bulk traffic on
+other streams within the same connection degrade latency?* If the latency probe
+p50/p95 increases significantly compared to the `latency` baseline, it points to
+stream-level contention inside lsquic (stream scheduling, flow control
+head-of-line blocking, or engine processing overhead).
+
+### `multiconn`
+
+Opens N separate QUIC connections, each with a single stream. N-1 connections do
+bulk throughput transfers while 1 connection runs the latency probe. Each
+connection gets its own congestion state, but on the server side they still share
+the same UDP socket and the same lsquic engine (one `engine_process` call handles
+all connections). This answers: *does load from other connections degrade latency
+on a separate connection?* Degradation here points to server-side engine
+contention or UDP socket bottlenecks rather than stream-level issues.
+
+### `stress`
+
+The most realistic scenario. Opens N connections with K streams each. On every
+connection, K-1 streams do bulk transfers and 1 stream runs the latency probe.
+This combines the contention from both `multistream` and `multiconn` — stream
+scheduling pressure within each connection, plus engine-level pressure across
+connections. Compare the latency probe results against the `latency`, `multistream`,
+and `multiconn` baselines to isolate where degradation comes from.
+
+## Network Scenarios
+
+The matrix runner (`run.sh`) tests across these predefined network conditions
+(all 5 used in full mode, only `lan` in `--quick` mode):
+
+| Scenario | Latency | Bandwidth | Packet Loss |
+|----------|---------|-----------|-------------|
+| `lan` | 0ms | unlimited | 0% |
+| `wan` | 25ms | 100 Mbit | 0% |
+| `constrained` | 50ms | 10 Mbit | 0.1% |
+| `lossy` | 25ms | 50 Mbit | 2% |
+| `mobile` | 75ms | 5 Mbit | 1% |
+
+### `run.sh` Matrix Defaults
+
+**Full mode** (`./benchmarks/run.sh`):
+
+| Mode | Runs | Streams | Connections | Upload | Download |
+|------|------|---------|-------------|--------|----------|
+| `throughput` | 5 | 1 | 1 | 100 KB | 10 MB |
+| `latency` | 100 | 1 | 1 | — | — |
+| `multistream` | 2 | 4 | 1 | 100 KB | 10 MB |
+| `multiconn` | 2 | 1 | 4 | 100 KB | 10 MB |
+| `stress` | 1 | 4 | 4 | 100 KB | 10 MB |
+
+**Quick mode** (`./benchmarks/run.sh --quick`) — LAN scenario only:
+
+| Mode | Runs | Streams | Connections | Upload | Download |
+|------|------|---------|-------------|--------|----------|
+| `throughput` | 3 | 1 | 1 | 100 KB | 1 MB |
+| `latency` | 20 | 1 | 1 | — | — |
+| `multistream` | 1 | 4 | 1 | 100 KB | 1 MB |
+| `multiconn` | 1 | 1 | 3 | 100 KB | 1 MB |
+| `stress` | 1 | 3 | 3 | 100 KB | 1 MB |
+
+## Prerequisites
+
+- Docker (with Compose V2)
+- `NET_ADMIN` capability (needed for `tc netem` inside containers)
+
+## Quick Start
+
+```bash
+# Run the full matrix (5 scenarios x 5 modes = 25 benchmarks)
+./benchmarks/run.sh
+
+# Quick mode: LAN only, smaller payloads, fewer runs
+./benchmarks/run.sh --quick
+
+# Single scenario or mode
+./benchmarks/run.sh --scenario wan --mode latency
+
+# Skip Docker image rebuild (if already built)
+./benchmarks/run.sh --quick --no-build
+```
+
+## Direct Docker Compose Usage
+
+For more control, run Docker Compose directly with environment variables:
+
+```bash
+# Throughput test with 50ms latency and 10Mbit bandwidth cap
+BENCH_MODE=throughput BENCH_RUNS=5 \
+BENCH_UPLOAD_SIZE=100000 BENCH_DOWNLOAD_SIZE=10000000 \
+LATENCY_MS=50 BANDWIDTH_MBIT=10 \
+  docker compose -f benchmarks/docker-compose.yml up \
+    --abort-on-container-exit --exit-code-from bench-client
+
+# Stress test: 8 connections x 8 streams, lossy network
+BENCH_MODE=stress BENCH_CONNECTIONS=8 BENCH_STREAMS=8 \
+LATENCY_MS=25 PACKET_LOSS_PCT=2 BANDWIDTH_MBIT=50 \
+  docker compose -f benchmarks/docker-compose.yml up \
+    --abort-on-container-exit --exit-code-from bench-client
+
+# Clean up after
+docker compose -f benchmarks/docker-compose.yml down --remove-orphans
+```
+
+### Environment Variables
+
+**Benchmark parameters:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BENCH_MODE` | `throughput` | Benchmark mode |
+| `BENCH_RUNS` | `5` | Number of iterations |
+| `BENCH_CONNECTIONS` | `4` | Number of QUIC connections (multiconn/stress) |
+| `BENCH_STREAMS` | `4` | Streams per connection (multistream/stress) |
+| `BENCH_UPLOAD_SIZE` | `100000` | Bytes to upload per stream (100 KB) |
+| `BENCH_DOWNLOAD_SIZE` | `10000000` | Bytes to download per stream (10 MB) |
+| `BENCH_CHUNK_SIZE` | `65536` | I/O chunk size (64 KB) |
+
+**Network shaping (applied on client side):**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LATENCY_MS` | `0` | One-way delay in milliseconds |
+| `BANDWIDTH_MBIT` | `0` | Bandwidth limit in Mbit/s (0 = unlimited) |
+| `PACKET_LOSS_PCT` | `0` | Packet loss percentage |
+| `JITTER_MS` | `0` | Delay jitter in milliseconds |
+
+## Running Locally (Without Docker)
+
+You can compile and run the benchmarks directly for loopback testing:
+
+```bash
+# Compile
+nim c --threads:on -d:release --out:benchmarks/bench_server benchmarks/bench_server.nim
+nim c --threads:on -d:release --out:benchmarks/bench_client benchmarks/bench_client.nim
+
+# Run server in background
+./benchmarks/bench_server --port 14555 &
+
+# Run client
+./benchmarks/bench_client --mode stress --server 127.0.0.1 --port 14555 \
+  --connections 4 --streams 4 --runs 3 --json
+
+# Kill server when done
+kill %1
+```
+
+### Server CLI Options
+
+```
+--listen, -l       Listen address (default: 0.0.0.0)
+--port, -p         Port (default: 14555)
+```
+
+### Client CLI Options
+
+```
+--mode, -m         Benchmark mode (default: throughput)
+                   Options: throughput|latency|multistream|multiconn|stress
+--server, -s       Server address (default: 127.0.0.1)
+--port, -p         Server port (default: 14555)
+--upload-size      Bytes to upload per stream (default: 100000 = 100 KB)
+--download-size    Bytes to download per stream (default: 100000000 = 100 MB)
+--chunk-size       I/O chunk size (default: 65536 = 64 KB)
+--runs, -r         Number of iterations (default: 10)
+--streams, -k      Streams per connection (default: 4)
+--connections, -n  Number of connections (default: 4)
+--json             Output results as JSON (default: human-readable)
+```
+
+## Output
+
+### Summary Table
+
+`run.sh` prints a summary table and saves it to `benchmarks/results/`:
+
+```
+Scenario        Mode           Conns  Strms  Upload          Download        Lat p50      Lat p95      Duration
+========================================================================================================================
+lan             throughput     1      1      178.18 Mbit/s   1.78 Gbit/s     -            -            13.470ms
+lan             latency        1      1      -               -               28.110us     406.816us    997.421us
+lan             multistream    1      4      91.69 Mbit/s    916.87 Mbit/s   37.590us     1.429ms      26.176ms
+lan             multiconn      3      1      96.43 Mbit/s    964.31 Mbit/s   20.937us     753.864us    16.592ms
+lan             stress         3      3      186.57 Mbit/s   1.87 Gbit/s     22.795us     2.706ms      25.727ms
+wan             throughput     1      1      810.67 Kbit/s   81.07 Mbit/s    -            -            4.934s
+wan             latency        1      1      -               -               25.283ms     25.420ms     2.529s
+wan             multistream    1      4      1.81 Mbit/s     180.50 Mbit/s   25.166ms     26.293ms     2.659s
+wan             multiconn      4      1      1.88 Mbit/s     188.34 Mbit/s   25.112ms     25.762ms     2.549s
+wan             stress         4      4      6.64 Mbit/s     664.45 Mbit/s   25.171ms     27.585ms     1.445s
+```
+
+**Columns:**
+
+- **Scenario** — network condition profile applied via `tc netem` (see
+  [Network Scenarios](#network-scenarios) above for the exact latency, bandwidth,
+  and loss values each name maps to)
+- **Mode** — benchmark mode that was run
+- **Conns** — number of QUIC connections used
+- **Strms** — number of streams per connection
+- **Upload** — aggregate upload throughput across all streams, computed as total
+  bytes uploaded divided by total wall-clock duration. Shows `-` for latency-only
+  modes where no bulk data is transferred.
+- **Download** — same as Upload but for the download direction
+- **Lat p50** — median (50th percentile) round-trip time from the latency probe
+  stream. This is the RTT of a small ping/pong echo measured alongside any bulk
+  transfers. Shows `-` for pure throughput mode which has no latency probe.
+- **Lat p95** — 95th percentile RTT. Useful for spotting tail latency spikes
+  caused by contention or packet loss.
+- **Duration** — total wall-clock time for the entire benchmark run (all
+  iterations, all streams)
+
+### Human-Readable Output
+
+Without `--json`, the client prints a detailed breakdown:
+
+```
+=== Benchmark Results ===
+Mode: stress
+Connections: 3, Streams/conn: 3
+Total duration: 11.079ms
+
+  Connection #1:
+    Stream #1 [throughput]:
+      Upload:   10000 bytes -> 41.39 Mbit/s
+      Download: 50000 bytes -> 206.96 Mbit/s
+      Duration: 1.933ms
+    Stream #2 [throughput]:
+      Upload:   10000 bytes -> 19.48 Mbit/s
+      Download: 50000 bytes -> 97.38 Mbit/s
+      Duration: 4.108ms
+    Stream #3 [latency] (50 samples):
+      Mean:  213.898us
+      p50:   90.164us
+      p95:   456.471us
+      p99:   801.782us
+      Min:   51.400us
+      Max:   3.967ms
+  Connection #2:
+    ...
+```
+
+### JSON Output
+
+With `--json`, the client outputs machine-readable JSON with per-stream latency
+samples (in nanoseconds) for further analysis:
+
+```json
+{
+  "mode": "latency",
+  "connections": 1,
+  "streams_per_conn": 1,
+  "duration_ns": 253988269,
+  "connections_results": [
+    {
+      "streams": [
+        {
+          "upload_bytes": 0,
+          "download_bytes": 0,
+          "duration_ns": 253906378,
+          "latency_samples_ns": [25814400, 25296524, 25294871, ...]
+        }
+      ],
+      "duration_ns": 253988269
+    }
+  ]
+}
+```
+
+## How It Works
+
+1. **Server** listens for QUIC connections and handles two stream protocols:
+   - **Throughput** (type `0x01`): reads upload data, sends back requested download size
+   - **Latency** (type `0x02`): echoes length-prefixed payloads back immediately
+
+2. **Client** opens connections/streams based on the selected mode. In multi-stream
+   and multi-connection modes, it runs bulk transfers alongside a latency probe
+   to measure contention effects.
+
+3. **Network shaping** is applied via `tc netem` in the Docker entrypoint (requires
+   `NET_ADMIN` capability). Delay, bandwidth limits, and packet loss are applied
+   on the client side.
+
+4. **Results** are collected as JSON per run and aggregated into a summary table
+   by `run.sh`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,7 +3,7 @@
 Docker-based harness for measuring bandwidth and latency of nim-lsquic under
 various network conditions. Runs a QUIC server and client in separate containers
 connected via a Docker bridge network, with configurable latency, bandwidth
-limits, and packet loss via `tc netem`.
+limits, packet loss, and packet reordering via `tc netem`.
 
 ## Defaults
 
@@ -30,6 +30,7 @@ limits, and packet loss via `tc netem`.
 | `multistream` | 1 | K (default: 4) | Stream contention within a single connection |
 | `multiconn` | N (default: 4) | 1 | Connection contention across separate QUIC connections |
 | `stress` | N (default: 4) | K (default: 4) | Combined connection + stream contention |
+| `rampup` | 1 | 1 | Congestion control ramp-up: throughput over time from cold start |
 
 ### `throughput`
 
@@ -78,18 +79,48 @@ scheduling pressure within each connection, plus engine-level pressure across
 connections. Compare the latency probe results against the `latency`, `multistream`,
 and `multiconn` baselines to isolate where degradation comes from.
 
+### `rampup`
+
+Opens a single connection with a single stream and starts a large download.
+Instead of reporting a single aggregate throughput number, it samples throughput
+in 50ms time windows and plots how bandwidth evolves from the start. This shows
+CUBIC slow-start behavior: how quickly the congestion window grows, how long it
+takes to reach steady state, and whether the connection fully utilizes the
+available bandwidth.
+
+The key metric is **time to 90% of peak throughput** — the point where
+slow-start has essentially finished. Under high-latency or lossy conditions, this
+ramp-up time grows significantly because CUBIC's window growth depends on RTT.
+Compare across network scenarios to see how network conditions affect convergence
+time.
+
+Example output (100MB download over WAN with 25ms latency, 100 Mbit cap):
+
+```
+Stream #1 [ramp-up] (20 windows, 50ms each):
+  Time to 90% peak: 150.000ms
+  Peak throughput:  83.48 Mbit/s
+  Timeline:
+       50ms |    12.3 Mbit/s | ######
+      100ms |    68.7 Mbit/s | #################################
+      150ms |    83.5 Mbit/s | ########################################
+      200ms |    82.9 Mbit/s | #######################################
+      ...
+```
+
 ## Network Scenarios
 
 The matrix runner (`run.sh`) tests across these predefined network conditions
-(all 5 used in full mode, only `lan` in `--quick` mode):
+(all 6 used in full mode, only `lan` in `--quick` mode):
 
-| Scenario | Latency | Bandwidth | Packet Loss |
-|----------|---------|-----------|-------------|
-| `lan` | 0ms | unlimited | 0% |
-| `wan` | 25ms | 100 Mbit | 0% |
-| `constrained` | 50ms | 10 Mbit | 0.1% |
-| `lossy` | 25ms | 50 Mbit | 2% |
-| `mobile` | 75ms | 5 Mbit | 1% |
+| Scenario | Latency | Bandwidth | Packet Loss | Reorder |
+|----------|---------|-----------|-------------|---------|
+| `lan` | 0ms | unlimited | 0% | 0% |
+| `wan` | 25ms | 100 Mbit | 0% | 0% |
+| `constrained` | 50ms | 10 Mbit | 0.1% | 0% |
+| `lossy` | 25ms | 50 Mbit | 2% | 0% |
+| `mobile` | 75ms | 5 Mbit | 1% | 0% |
+| `reorder` | 25ms | 100 Mbit | 0% | 25% |
 
 ### `run.sh` Matrix Defaults
 
@@ -102,6 +133,7 @@ The matrix runner (`run.sh`) tests across these predefined network conditions
 | `multistream` | 2 | 4 | 1 | 100 KB | 10 MB |
 | `multiconn` | 2 | 1 | 4 | 100 KB | 10 MB |
 | `stress` | 1 | 4 | 4 | 100 KB | 10 MB |
+| `rampup` | 1 | 1 | 1 | — | 100 MB |
 
 **Quick mode** (`./benchmarks/run.sh --quick`) — LAN scenario only:
 
@@ -112,6 +144,7 @@ The matrix runner (`run.sh`) tests across these predefined network conditions
 | `multistream` | 1 | 4 | 1 | 100 KB | 1 MB |
 | `multiconn` | 1 | 1 | 3 | 100 KB | 1 MB |
 | `stress` | 1 | 3 | 3 | 100 KB | 1 MB |
+| `rampup` | 1 | 1 | 1 | — | 10 MB |
 
 ## Prerequisites
 
@@ -121,7 +154,7 @@ The matrix runner (`run.sh`) tests across these predefined network conditions
 ## Quick Start
 
 ```bash
-# Run the full matrix (5 scenarios x 5 modes = 25 benchmarks)
+# Run the full matrix (6 scenarios x 6 modes = 36 benchmarks)
 ./benchmarks/run.sh
 
 # Quick mode: LAN only, smaller payloads, fewer runs
@@ -178,6 +211,7 @@ docker compose -f benchmarks/docker-compose.yml down --remove-orphans
 | `BANDWIDTH_MBIT` | `0` | Bandwidth limit in Mbit/s (0 = unlimited) |
 | `PACKET_LOSS_PCT` | `0` | Packet loss percentage |
 | `JITTER_MS` | `0` | Delay jitter in milliseconds |
+| `REORDER_PCT` | `0` | Packet reorder percentage (requires `LATENCY_MS` > 0) |
 
 ## Running Locally (Without Docker)
 
@@ -210,7 +244,7 @@ kill %1
 
 ```
 --mode, -m         Benchmark mode (default: throughput)
-                   Options: throughput|latency|multistream|multiconn|stress
+                   Options: throughput|latency|multistream|multiconn|stress|rampup
 --server, -s       Server address (default: 127.0.0.1)
 --port, -p         Server port (default: 14555)
 --upload-size      Bytes to upload per stream (default: 100000 = 100 KB)
@@ -224,24 +258,52 @@ kill %1
 
 ## Output
 
-### Summary Table
+### Sample Run
 
-`run.sh` prints a summary table and saves it to `benchmarks/results/`:
+Full matrix run (`./benchmarks/run.sh`) across all 6 scenarios and 6 modes:
 
 ```
 Scenario        Mode           Conns  Strms  Upload          Download        Lat p50      Lat p95      Duration
 ========================================================================================================================
-lan             throughput     1      1      178.18 Mbit/s   1.78 Gbit/s     -            -            13.470ms
-lan             latency        1      1      -               -               28.110us     406.816us    997.421us
-lan             multistream    1      4      91.69 Mbit/s    916.87 Mbit/s   37.590us     1.429ms      26.176ms
-lan             multiconn      3      1      96.43 Mbit/s    964.31 Mbit/s   20.937us     753.864us    16.592ms
-lan             stress         3      3      186.57 Mbit/s   1.87 Gbit/s     22.795us     2.706ms      25.727ms
-wan             throughput     1      1      810.67 Kbit/s   81.07 Mbit/s    -            -            4.934s
-wan             latency        1      1      -               -               25.283ms     25.420ms     2.529s
-wan             multistream    1      4      1.81 Mbit/s     180.50 Mbit/s   25.166ms     26.293ms     2.659s
-wan             multiconn      4      1      1.88 Mbit/s     188.34 Mbit/s   25.112ms     25.762ms     2.549s
-wan             stress         4      4      6.64 Mbit/s     664.45 Mbit/s   25.171ms     27.585ms     1.445s
+lan             throughput     1      1      10.99 Mbit/s    1.10 Gbit/s     -            -            363.907ms
+lan             latency        1      1      -               -               57.966us     173.932us    7.530ms
+lan             multistream    1      4      11.15 Mbit/s    1.11 Gbit/s     1.277ms      10.798ms     430.670ms
+lan             multiconn      4      1      11.82 Mbit/s    1.18 Gbit/s     293.599us    15.731ms     406.153ms
+lan             stress         4      4      13.90 Mbit/s    1.39 Gbit/s     8.207ms      37.689ms     690.415ms
+lan             rampup         1      1      -               1.09 Gbit/s     150.000ms    p90          736.432ms
+wan             throughput     1      1      900.16 Kbit/s   90.02 Mbit/s    -            -            4.444s
+wan             latency        1      1      -               -               25.660ms     25.761ms     2.565s
+wan             multistream    1      4      703.95 Kbit/s   70.39 Mbit/s    25.697ms     220.947ms    6.819s
+wan             multiconn      4      1      750.57 Kbit/s   75.06 Mbit/s    36.330ms     36.402ms     6.395s
+wan             stress         4      4      573.97 Kbit/s   57.40 Mbit/s    25.731ms     1.029s       16.726s
+wan             rampup         1      1      -               94.22 Mbit/s    150.000ms    p90          8.491s
+constrained     throughput     1      1      92.32 Kbit/s    9.23 Mbit/s     -            -            43.327s
+constrained     latency        1      1      -               -               50.792ms     50.977ms     5.082s
+constrained     multistream    1      4      94.25 Kbit/s    9.43 Mbit/s     94.594ms     163.685ms    50.928s
+constrained     multiconn      4      1      93.94 Kbit/s    9.39 Mbit/s     96.019ms     100.841ms    51.096s
+constrained     stress         4      4      92.25 Kbit/s    9.22 Mbit/s     50.928ms     122.342ms    104.068s
+constrained     rampup         1      1      -               9.49 Mbit/s     900.000ms    p90          84.324s
+lossy           throughput     1      1      405.86 Kbit/s   40.59 Mbit/s    -            -            9.856s
+lossy           latency        1      1      -               -               25.695ms     25.902ms     2.571s
+lossy           multistream    1      4      346.40 Kbit/s   34.64 Mbit/s    25.724ms     824.939ms    13.857s
+lossy           multiconn      4      1      339.58 Kbit/s   33.96 Mbit/s    47.512ms     47.747ms     14.135s
+lossy           stress         4      4      320.42 Kbit/s   32.04 Mbit/s    25.762ms     995.620ms    29.961s
+lossy           rampup         1      1      -               41.33 Mbit/s    150.000ms    p90          19.356s
+mobile          throughput     1      1      45.32 Kbit/s    4.53 Mbit/s     -            -            88.260s
+mobile          latency        1      1      -               -               75.919ms     76.187ms     7.902s
+mobile          multistream    1      4      46.90 Kbit/s    4.69 Mbit/s     123.369ms    614.949ms    102.349s
+mobile          multiconn      4      1      46.61 Kbit/s    4.66 Mbit/s     119.147ms    351.425ms    102.988s
+mobile          stress         4      4      46.42 Kbit/s    4.64 Mbit/s     121.724ms    453.206ms    206.803s
+mobile          rampup         1      1      -               4.74 Mbit/s     3.350s       p90          168.757s
+reorder         throughput     1      1      672.33 Kbit/s   67.23 Mbit/s    -            -            5.949s
+reorder         latency        1      1      -               -               25.690ms     25.896ms     2.417s
+reorder         multistream    1      4      636.49 Kbit/s   63.65 Mbit/s    25.677ms     441.939ms    7.541s
+reorder         multiconn      4      1      664.28 Kbit/s   66.43 Mbit/s    36.302ms     36.407ms     7.226s
+reorder         stress         4      4      746.94 Kbit/s   74.69 Mbit/s    25.704ms     934.372ms    12.852s
+reorder         rampup         1      1      -               90.96 Mbit/s    100.000ms    p90          8.795s
 ```
+
+#### Reading the results
 
 **Columns:**
 
@@ -253,15 +315,85 @@ wan             stress         4      4      6.64 Mbit/s     664.45 Mbit/s   25.
 - **Strms** — number of streams per connection
 - **Upload** — aggregate upload throughput across all streams, computed as total
   bytes uploaded divided by total wall-clock duration. Shows `-` for latency-only
-  modes where no bulk data is transferred.
+  modes where no bulk data is transferred. Note: in throughput mode the upload is
+  small relative to the download, so this number reflects the fraction of time
+  spent uploading rather than burst upload speed.
 - **Download** — same as Upload but for the download direction
 - **Lat p50** — median (50th percentile) round-trip time from the latency probe
   stream. This is the RTT of a small ping/pong echo measured alongside any bulk
   transfers. Shows `-` for pure throughput mode which has no latency probe.
+  For `rampup` mode, this column shows the **time to 90% of peak throughput**
+  instead (labeled `p90` in the Lat p95 column).
 - **Lat p95** — 95th percentile RTT. Useful for spotting tail latency spikes
-  caused by contention or packet loss.
+  caused by contention or packet loss. Shows `p90` for `rampup` mode to indicate
+  the Lat p50 column contains the time-to-90%-peak metric.
 - **Duration** — total wall-clock time for the entire benchmark run (all
   iterations, all streams)
+
+#### Analysis by scenario
+
+**LAN** (no shaping) — establishes the upper bound. Single-stream download reaches
+1.10 Gbit/s on the Docker bridge. With parallel streams and connections, aggregate
+throughput climbs to 1.1-1.4 Gbit/s as multiplexing improves pipeline utilization.
+Latency starts at 58us but grows to 8.2ms p50 / 37.7ms p95 under stress, showing
+the cost of engine processing contention when handling 16 concurrent streams across
+4 connections.
+
+**WAN** (25ms, 100 Mbit) — throughput reaches 90 Mbit/s, below the 100 Mbit cap
+because CUBIC needs multiple RTTs to grow the congestion window, and each of the 5
+sequential runs starts cold. Latency baseline is 25.7ms, matching the netem delay
+exactly. Under multiconn the probe latency rises to 36ms (+11ms), pointing to
+engine-level contention across connections. Stress p95 hits 1.03s from head-of-line
+blocking cascades across 16 concurrent streams. Rampup takes 150ms (6 RTTs) to
+reach 90% of peak.
+
+**Constrained** (50ms, 10 Mbit, 0.1% loss) — all modes saturate at ~9.2 Mbit/s,
+confirming the 10 Mbit link is the bottleneck rather than the engine. Contention
+modes show nearly identical throughput because there simply isn't more bandwidth
+to fight over. The main effect of contention is on latency: multistream p95 reaches
+164ms and stress p95 hits 122ms. Rampup takes 900ms (18 RTTs at 50ms) to reach
+steady state, consistent with CUBIC slow-start behavior.
+
+**Lossy** (25ms, 50 Mbit, 2% loss) — the most punishing scenario for throughput.
+Single-stream reaches only 40.6 Mbit/s (81% of cap) because 2% loss causes frequent
+congestion window reductions. Baseline latency p50 is 25.7ms, matching the netem
+delay, with p95 at 25.9ms. Stress p95 reaches 996ms as loss and congestion combine
+into retransmission cascades across 16 concurrent streams.
+
+**Mobile** (75ms, 5 Mbit, 1% loss) — throughput settles at 4.5 Mbit/s (90% of
+cap). The tight bandwidth means contention modes show nearly identical throughput
+(~4.6 Mbit/s) since the link is fully saturated regardless. The contention effect
+shows up in latency instead: multistream p95 reaches 615ms from within-connection
+scheduling pressure under the narrow pipe. Rampup takes 3.35s to converge — longer
+than expected from RTT alone, likely due to a loss event during slow-start forcing
+a window reduction on this narrow, lossy link.
+
+**Reorder** (25ms, 100 Mbit, 25% reorder) — throughput drops to 67.2 Mbit/s, 25%
+lower than WAN (90 Mbit/s) despite the same bandwidth cap. Reordered packets
+trigger duplicate ACKs that CUBIC interprets as loss, shrinking the congestion
+window unnecessarily. This is a known weakness of loss-based congestion control.
+However, reordering is less damaging than actual loss: 25% reorder yields 67.2
+Mbit/s while 2% real loss (lossy scenario) yields only 40.6 Mbit/s, because
+reordered packets eventually arrive and don't require retransmission.
+
+#### Key takeaways
+
+- **Bandwidth caps are enforced bidirectionally** — download throughput stays below
+  the configured cap in all scenarios (shaping is applied on both client and server
+  egress via `tc netem`).
+- **Latency baselines match netem delays exactly** — 25.7ms for WAN/lossy/reorder
+  (25ms configured), 50.8ms for constrained (50ms), 75.9ms for mobile (75ms).
+- **Contention degrades latency more than throughput** — under constrained/mobile
+  scenarios the link is fully saturated regardless of mode, but p95 latency grows
+  2-6x from baseline under stress.
+- **Packet loss is more damaging than reordering** — 2% loss (lossy) reduces
+  throughput to 81% of cap and drives stress p95 to 996ms, while 25% reorder
+  reduces throughput to only 67% and stress p95 to 934ms. Lost packets require
+  actual retransmission and RTO backoff; reordered packets just trigger spurious
+  duplicate ACKs.
+- **CUBIC ramp-up scales with RTT** — time-to-90% grows from 150ms (LAN/WAN)
+  to 900ms (50ms RTT) to 3.35s (75ms RTT + 1% loss), with loss events during
+  slow-start significantly extending convergence on narrow, lossy links.
 
 ### Human-Readable Output
 
@@ -331,8 +463,10 @@ samples (in nanoseconds) for further analysis:
    to measure contention effects.
 
 3. **Network shaping** is applied via `tc netem` in the Docker entrypoint (requires
-   `NET_ADMIN` capability). Delay, bandwidth limits, and packet loss are applied
-   on the client side.
+   `NET_ADMIN` capability). Since `tc qdisc` only shapes egress (outbound) traffic,
+   bandwidth limits are applied on **both** the client and server sides so that
+   uploads and downloads are both capped. Latency, packet loss, and reordering are
+   applied on the client side only to avoid doubling the delay.
 
 4. **Results** are collected as JSON per run and aggregated into a summary table
    by `run.sh`.

--- a/benchmarks/bench_client.nim
+++ b/benchmarks/bench_client.nim
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Benchmark client for nim-lsquic.
+## Supports 5 benchmark modes:
+##   throughput   - 1 conn, 1 stream: baseline bandwidth
+##   latency      - 1 conn, 1 stream: baseline RTT
+##   multistream  - 1 conn, K streams: stream contention
+##   multiconn    - N conns, 1 stream each: connection contention
+##   stress       - N conns, K streams each: realistic worst case
+
+import ./bench_common
+
+# -- Throughput on a single stream --
+
+proc runThroughputStream(
+    conn: Connection, uploadSize: int, downloadSize: int, chunkSize: int
+): Future[StreamResult] {.async.} =
+  let start = Moment.now()
+  let stream = await conn.openStream()
+
+  # Send type header
+  await stream.write(@[MsgThroughput])
+
+  # Send upload size (8 bytes) + download size (8 bytes)
+  await stream.write(toSeq(uploadSize.uint64.toBytesBE()))
+  await stream.write(toSeq(downloadSize.uint64.toBytesBE()))
+
+  # Upload data
+  let chunk = newSeq[byte](chunkSize)
+  var remaining = uploadSize
+  while remaining > 0:
+    let toSend = min(remaining, chunkSize)
+    await stream.write(chunk[0 ..< toSend])
+    remaining -= toSend
+
+  # Signal upload done
+  await stream.close()
+
+  # Download data
+  var buf = newSeq[byte](chunkSize)
+  var totalDown = 0
+  while totalDown < downloadSize:
+    let n = await stream.readOnce(buf[0].addr, buf.len)
+    if n == 0:
+      break
+    totalDown += n
+
+  let duration = Moment.now() - start
+  return StreamResult(
+    uploadBytes: uploadSize,
+    downloadBytes: totalDown,
+    durationNs: duration.nanoseconds,
+  )
+
+# -- Latency ping/pong on a single stream --
+
+proc runLatencyStream(
+    conn: Connection, runs: int
+): Future[StreamResult] {.async.} =
+  let stream = await conn.openStream()
+
+  # Send type header
+  await stream.write(@[MsgLatency])
+
+  let payload = newSeq[byte](64) # small ping payload
+  let payloadLenBytes = toSeq(payload.len.uint32.toBytesBE())
+  var samples: seq[LatencySample]
+
+  for i in 0 ..< runs:
+    let start = Moment.now()
+
+    # Send length-prefixed ping
+    await stream.write(payloadLenBytes & payload)
+
+    # Read response: 4 bytes length + payload
+    var lenBuf = newSeq[byte](4)
+    var read = 0
+    while read < 4:
+      let n = await stream.readOnce(lenBuf[read].addr, 4 - read)
+      if n == 0:
+        break
+      read += n
+
+    if read < 4:
+      break
+
+    let respLen = uint32.fromBytesBE(lenBuf).int
+    var respBuf = newSeq[byte](respLen)
+    read = 0
+    while read < respLen:
+      let n = await stream.readOnce(respBuf[read].addr, respLen - read)
+      if n == 0:
+        break
+      read += n
+
+    let rtt = Moment.now() - start
+    samples.add(LatencySample(rttNs: rtt.nanoseconds))
+
+  await stream.close()
+
+  return StreamResult(
+    latencySamples: samples,
+    durationNs:
+      if samples.len > 0:
+        samples.mapIt(it.rttNs).foldl(a + b, 0'i64)
+      else:
+        0,
+  )
+
+# -- Mode: throughput (1 conn, 1 stream) --
+
+proc modeThroughput(
+    serverAddr: TransportAddress,
+    uploadSize, downloadSize, chunkSize, runs: int,
+): Future[RunResult] {.async.} =
+  var result = RunResult(
+    mode: Throughput,
+    connections: 1,
+    streamsPerConn: 1,
+    uploadSize: uploadSize,
+    downloadSize: downloadSize,
+    chunkSize: chunkSize,
+  )
+
+  let client = makeClient()
+  let conn = await client.dial(serverAddr)
+  let start = Moment.now()
+
+  var connRes = ConnectionResult()
+  for i in 0 ..< runs:
+    let sr = await runThroughputStream(conn, uploadSize, downloadSize, chunkSize)
+    connRes.streamResults.add(sr)
+
+  connRes.durationNs = (Moment.now() - start).nanoseconds
+  result.connResults.add(connRes)
+  result.durationNs = connRes.durationNs
+
+  conn.close()
+  await client.stop()
+  return result
+
+# -- Mode: latency (1 conn, 1 stream) --
+
+proc modeLatency(
+    serverAddr: TransportAddress, runs: int
+): Future[RunResult] {.async.} =
+  var result = RunResult(
+    mode: Latency,
+    connections: 1,
+    streamsPerConn: 1,
+  )
+
+  let client = makeClient()
+  let conn = await client.dial(serverAddr)
+  let start = Moment.now()
+
+  var connRes = ConnectionResult()
+  let sr = await runLatencyStream(conn, runs)
+  connRes.streamResults.add(sr)
+  connRes.durationNs = (Moment.now() - start).nanoseconds
+  result.connResults.add(connRes)
+  result.durationNs = connRes.durationNs
+
+  conn.close()
+  await client.stop()
+  return result
+
+# -- Mode: multistream (1 conn, K streams) --
+
+proc modeMultiStream(
+    serverAddr: TransportAddress,
+    numStreams, uploadSize, downloadSize, chunkSize, runs: int,
+): Future[RunResult] {.async.} =
+  var result = RunResult(
+    mode: MultiStream,
+    connections: 1,
+    streamsPerConn: numStreams,
+    uploadSize: uploadSize,
+    downloadSize: downloadSize,
+    chunkSize: chunkSize,
+  )
+
+  let client = makeClient()
+  let conn = await client.dial(serverAddr)
+  let start = Moment.now()
+
+  var connRes = ConnectionResult()
+
+  for run in 0 ..< runs:
+    # Launch K-1 throughput streams + 1 latency probe in parallel
+    var futs: seq[Future[StreamResult]]
+    for s in 0 ..< numStreams - 1:
+      futs.add(runThroughputStream(conn, uploadSize, downloadSize, chunkSize))
+
+    # Latency probe on the last stream
+    futs.add(runLatencyStream(conn, 50))
+
+    # Wait for all streams to complete
+    for f in futs:
+      let sr = await f
+      connRes.streamResults.add(sr)
+
+  connRes.durationNs = (Moment.now() - start).nanoseconds
+  result.connResults.add(connRes)
+  result.durationNs = connRes.durationNs
+
+  conn.close()
+  await client.stop()
+  return result
+
+# -- Mode: multiconn (N conns, 1 stream each) --
+
+proc modeMultiConn(
+    serverAddr: TransportAddress,
+    numConns, uploadSize, downloadSize, chunkSize, runs: int,
+): Future[RunResult] {.async.} =
+  var result = RunResult(
+    mode: MultiConn,
+    connections: numConns,
+    streamsPerConn: 1,
+    uploadSize: uploadSize,
+    downloadSize: downloadSize,
+    chunkSize: chunkSize,
+  )
+
+  # Create N separate clients (each gets its own engine context)
+  var clients: seq[QuicClient]
+  var conns: seq[Connection]
+  for i in 0 ..< numConns:
+    let client = makeClient()
+    let conn = await client.dial(serverAddr)
+    clients.add(client)
+    conns.add(conn)
+
+  let start = Moment.now()
+
+  for run in 0 ..< runs:
+    # Launch throughput on N-1 connections + latency probe on last
+    var futs: seq[Future[StreamResult]]
+    for i in 0 ..< numConns - 1:
+      futs.add(runThroughputStream(conns[i], uploadSize, downloadSize, chunkSize))
+
+    # Latency probe on last connection
+    futs.add(runLatencyStream(conns[numConns - 1], 50))
+
+    for i, f in futs:
+      let sr = await f
+      # Associate with the right connection result
+      while result.connResults.len <= i:
+        result.connResults.add(ConnectionResult())
+      result.connResults[i].streamResults.add(sr)
+
+  let totalDur = (Moment.now() - start).nanoseconds
+  for cr in result.connResults.mitems:
+    cr.durationNs = totalDur
+  result.durationNs = totalDur
+
+  for conn in conns:
+    conn.close()
+  for client in clients:
+    await client.stop()
+
+  return result
+
+# -- Mode: stress (N conns, K streams each) --
+
+proc modeStress(
+    serverAddr: TransportAddress,
+    numConns, numStreams, uploadSize, downloadSize, chunkSize, runs: int,
+): Future[RunResult] {.async.} =
+  var result = RunResult(
+    mode: Stress,
+    connections: numConns,
+    streamsPerConn: numStreams,
+    uploadSize: uploadSize,
+    downloadSize: downloadSize,
+    chunkSize: chunkSize,
+  )
+
+  var clients: seq[QuicClient]
+  var conns: seq[Connection]
+  for i in 0 ..< numConns:
+    let client = makeClient()
+    let conn = await client.dial(serverAddr)
+    clients.add(client)
+    conns.add(conn)
+
+  let start = Moment.now()
+
+  for run in 0 ..< runs:
+    var allFuts: seq[Future[StreamResult]]
+    var futConnIdx: seq[int] # track which connection each future belongs to
+
+    for ci in 0 ..< numConns:
+      # On each connection: K-1 throughput streams + 1 latency probe
+      let throughputStreams = max(numStreams - 1, 0)
+      for s in 0 ..< throughputStreams:
+        allFuts.add(
+          runThroughputStream(conns[ci], uploadSize, downloadSize, chunkSize)
+        )
+        futConnIdx.add(ci)
+
+      # Latency probe
+      allFuts.add(runLatencyStream(conns[ci], 50))
+      futConnIdx.add(ci)
+
+    # Ensure we have connResults slots
+    while result.connResults.len < numConns:
+      result.connResults.add(ConnectionResult())
+
+    for i, f in allFuts:
+      let sr = await f
+      result.connResults[futConnIdx[i]].streamResults.add(sr)
+
+  let totalDur = (Moment.now() - start).nanoseconds
+  for cr in result.connResults.mitems:
+    cr.durationNs = totalDur
+  result.durationNs = totalDur
+
+  for conn in conns:
+    conn.close()
+  for client in clients:
+    await client.stop()
+
+  return result
+
+# -- Print results --
+
+proc printResults(result: RunResult) =
+  echo ""
+  echo "=== Benchmark Results ==="
+  echo "Mode: ", result.mode
+  echo "Connections: ", result.connections, ", Streams/conn: ", result.streamsPerConn
+  echo "Total duration: ", formatDuration(result.durationNs)
+  echo ""
+
+  for ci, cr in result.connResults:
+    echo "  Connection #", ci + 1, ":"
+
+    for si, sr in cr.streamResults:
+      if sr.uploadBytes > 0 or sr.downloadBytes > 0:
+        echo "    Stream #", si + 1, " [throughput]:"
+        echo "      Upload:   ", sr.uploadBytes, " bytes -> ",
+          formatBps(sr.uploadBytes, sr.durationNs)
+        echo "      Download: ", sr.downloadBytes, " bytes -> ",
+          formatBps(sr.downloadBytes, sr.durationNs)
+        echo "      Duration: ", formatDuration(sr.durationNs)
+
+      if sr.latencySamples.len > 0:
+        let rtts = sr.latencySamples.mapIt(it.rttNs)
+        echo "    Stream #", si + 1, " [latency] (", rtts.len, " samples):"
+        echo "      Mean:  ", formatDuration(int64(rtts.mean()))
+        echo "      p50:   ", formatDuration(rtts.percentile(0.50))
+        echo "      p95:   ", formatDuration(rtts.percentile(0.95))
+        echo "      p99:   ", formatDuration(rtts.percentile(0.99))
+        echo "      Min:   ", formatDuration(rtts.min())
+        echo "      Max:   ", formatDuration(rtts.max())
+
+  echo ""
+
+# -- Main --
+
+when isMainModule:
+  var mode = Throughput
+  var serverHost = "127.0.0.1"
+  var port = DefaultPort
+  var uploadSize = DefaultUploadSize
+  var downloadSize = DefaultDownloadSize
+  var chunkSize = DefaultChunkSize
+  var runs = DefaultRuns
+  var numStreams = DefaultStreams
+  var numConns = DefaultConnections
+  var jsonOutput = false
+
+  var i = 1
+  while i <= paramCount():
+    let arg = paramStr(i)
+    case arg
+    of "--mode", "-m":
+      inc i
+      case paramStr(i).toLowerAscii()
+      of "throughput":
+        mode = Throughput
+      of "latency":
+        mode = Latency
+      of "multistream":
+        mode = MultiStream
+      of "multiconn":
+        mode = MultiConn
+      of "stress":
+        mode = Stress
+      else:
+        echo "Unknown mode: ", paramStr(i)
+        quit(1)
+    of "--server", "-s":
+      inc i
+      serverHost = paramStr(i)
+    of "--port", "-p":
+      inc i
+      port = parseInt(paramStr(i))
+    of "--upload-size":
+      inc i
+      uploadSize = parseInt(paramStr(i))
+    of "--download-size":
+      inc i
+      downloadSize = parseInt(paramStr(i))
+    of "--chunk-size":
+      inc i
+      chunkSize = parseInt(paramStr(i))
+    of "--runs", "-r":
+      inc i
+      runs = parseInt(paramStr(i))
+    of "--streams", "-k":
+      inc i
+      numStreams = parseInt(paramStr(i))
+    of "--connections", "-n":
+      inc i
+      numConns = parseInt(paramStr(i))
+    of "--json":
+      jsonOutput = true
+    of "--help", "-h":
+      echo "Usage: bench_client [OPTIONS]"
+      echo ""
+      echo "Modes:"
+      echo "  throughput   - 1 conn, 1 stream: baseline bandwidth"
+      echo "  latency      - 1 conn, 1 stream: baseline RTT"
+      echo "  multistream  - 1 conn, K streams: stream contention"
+      echo "  multiconn    - N conns, 1 stream each: connection contention"
+      echo "  stress       - N conns, K streams each: worst case"
+      echo ""
+      echo "Options:"
+      echo "  --mode, -m         Benchmark mode (default: throughput)"
+      echo "  --server, -s       Server address (default: 127.0.0.1)"
+      echo "  --port, -p         Server port (default: ", DefaultPort, ")"
+      echo "  --upload-size      Bytes to upload (default: ", DefaultUploadSize, ")"
+      echo "  --download-size    Bytes to download (default: ", DefaultDownloadSize, ")"
+      echo "  --chunk-size       Chunk size (default: ", DefaultChunkSize, ")"
+      echo "  --runs, -r         Number of runs (default: ", DefaultRuns, ")"
+      echo "  --streams, -k      Streams per connection (default: ", DefaultStreams, ")"
+      echo "  --connections, -n  Number of connections (default: ", DefaultConnections, ")"
+      echo "  --json             Output results as JSON"
+      quit(0)
+    else:
+      echo "Unknown argument: ", arg
+      quit(1)
+    inc i
+
+  initializeLsquic(true, true)
+
+  let serverAddr = initTAddress(serverHost & ":" & $port)
+
+  echo "Connecting to ", serverHost, ":", port, " mode=", mode
+
+  let benchResult =
+    case mode
+    of Throughput:
+      waitFor modeThroughput(serverAddr, uploadSize, downloadSize, chunkSize, runs)
+    of Latency:
+      waitFor modeLatency(serverAddr, runs)
+    of MultiStream:
+      waitFor modeMultiStream(
+        serverAddr, numStreams, uploadSize, downloadSize, chunkSize, runs
+      )
+    of MultiConn:
+      waitFor modeMultiConn(
+        serverAddr, numConns, uploadSize, downloadSize, chunkSize, runs
+      )
+    of Stress:
+      waitFor modeStress(
+        serverAddr, numConns, numStreams, uploadSize, downloadSize, chunkSize, runs
+      )
+
+  if jsonOutput:
+    echo benchResult.toJson().pretty()
+  else:
+    printResults(benchResult)
+
+  cleanupLsquic()

--- a/benchmarks/bench_client.nim
+++ b/benchmarks/bench_client.nim
@@ -48,16 +48,12 @@ proc runThroughputStream(
 
   let duration = Moment.now() - start
   return StreamResult(
-    uploadBytes: uploadSize,
-    downloadBytes: totalDown,
-    durationNs: duration.nanoseconds,
+    uploadBytes: uploadSize, downloadBytes: totalDown, durationNs: duration.nanoseconds
   )
 
 # -- Latency ping/pong on a single stream --
 
-proc runLatencyStream(
-    conn: Connection, runs: int
-): Future[StreamResult] {.async.} =
+proc runLatencyStream(conn: Connection, runs: int): Future[StreamResult] {.async.} =
   let stream = await conn.openStream()
 
   # Send type header
@@ -111,8 +107,7 @@ proc runLatencyStream(
 # -- Mode: throughput (1 conn, 1 stream) --
 
 proc modeThroughput(
-    serverAddr: TransportAddress,
-    uploadSize, downloadSize, chunkSize, runs: int,
+    serverAddr: TransportAddress, uploadSize, downloadSize, chunkSize, runs: int
 ): Future[RunResult] {.async.} =
   var result = RunResult(
     mode: Throughput,
@@ -142,14 +137,8 @@ proc modeThroughput(
 
 # -- Mode: latency (1 conn, 1 stream) --
 
-proc modeLatency(
-    serverAddr: TransportAddress, runs: int
-): Future[RunResult] {.async.} =
-  var result = RunResult(
-    mode: Latency,
-    connections: 1,
-    streamsPerConn: 1,
-  )
+proc modeLatency(serverAddr: TransportAddress, runs: int): Future[RunResult] {.async.} =
+  var result = RunResult(mode: Latency, connections: 1, streamsPerConn: 1)
 
   let client = makeClient()
   let conn = await client.dial(serverAddr)
@@ -296,9 +285,7 @@ proc modeStress(
       # On each connection: K-1 throughput streams + 1 latency probe
       let throughputStreams = max(numStreams - 1, 0)
       for s in 0 ..< throughputStreams:
-        allFuts.add(
-          runThroughputStream(conns[ci], uploadSize, downloadSize, chunkSize)
-        )
+        allFuts.add(runThroughputStream(conns[ci], uploadSize, downloadSize, chunkSize))
         futConnIdx.add(ci)
 
       # Latency probe
@@ -325,6 +312,118 @@ proc modeStress(
 
   return result
 
+# -- Mode: rampup (1 conn, 1 stream, measure throughput over time) --
+
+const
+  RampUpWindowMs = 50 ## sample window in milliseconds
+  RampUpDownloadSize = 100_000_000 ## 100MB default for rampup
+
+proc modeRampUp(
+    serverAddr: TransportAddress, downloadSize: int, chunkSize: int
+): Future[RunResult] {.async.} =
+  var result = RunResult(
+    mode: RampUp,
+    connections: 1,
+    streamsPerConn: 1,
+    downloadSize: downloadSize,
+    chunkSize: chunkSize,
+  )
+
+  let client = makeClient()
+  let conn = await client.dial(serverAddr)
+
+  let stream = await conn.openStream()
+
+  # Send throughput header: no upload, just download
+  await stream.write(@[MsgThroughput])
+  await stream.write(toSeq(0'u64.toBytesBE())) # upload size = 0
+  await stream.write(toSeq(downloadSize.uint64.toBytesBE()))
+  await stream.close() # signal no upload data
+
+  # Now read download data, recording (timestamp, cumulative bytes)
+  type DataPoint = object
+    elapsedNs: int64
+    cumulativeBytes: int
+
+  var buf = newSeq[byte](chunkSize)
+  var totalDown = 0
+  var points: seq[DataPoint]
+
+  let start = Moment.now()
+
+  while totalDown < downloadSize:
+    let n = await stream.readOnce(buf[0].addr, buf.len)
+    if n == 0:
+      break
+    totalDown += n
+    let elapsed = Moment.now() - start
+    points.add(DataPoint(elapsedNs: elapsed.nanoseconds, cumulativeBytes: totalDown))
+
+  let totalDuration = Moment.now() - start
+
+  # Bucket into time windows
+  var samples: seq[RampUpSample]
+  let windowNs = RampUpWindowMs.int64 * 1_000_000
+
+  if points.len > 0:
+    var windowStart: int64 = 0
+    var prevBytes = 0
+    var pi = 0
+
+    while windowStart < totalDuration.nanoseconds:
+      let windowEnd = windowStart + windowNs
+      # Advance to last point within this window
+      while pi < points.len and points[pi].elapsedNs <= windowEnd:
+        inc pi
+
+      let cumBytes =
+        if pi > 0:
+          points[pi - 1].cumulativeBytes
+        else:
+          0
+      let bytesInWindow = cumBytes - prevBytes
+      let mbps = float(bytesInWindow) * 8.0 / float(windowNs) * 1e9 / 1e6
+
+      samples.add(
+        RampUpSample(
+          elapsedMs: (windowStart + windowNs) div 1_000_000,
+          throughputMbps: mbps,
+          cumulativeBytes: cumBytes,
+        )
+      )
+
+      prevBytes = cumBytes
+      windowStart = windowEnd
+
+  # Find peak throughput and time to reach 90% of peak
+  var peakMbps = 0.0
+  for s in samples:
+    if s.throughputMbps > peakMbps:
+      peakMbps = s.throughputMbps
+
+  var timeToP90Ns: int64 = totalDuration.nanoseconds
+  let threshold = peakMbps * 0.9
+  for s in samples:
+    if s.throughputMbps >= threshold:
+      timeToP90Ns = s.elapsedMs * 1_000_000
+      break
+
+  var sr = StreamResult(
+    downloadBytes: totalDown,
+    durationNs: totalDuration.nanoseconds,
+    rampUpSamples: samples,
+    timeToP90Ns: timeToP90Ns,
+  )
+
+  var connRes =
+    ConnectionResult(streamResults: @[sr], durationNs: totalDuration.nanoseconds)
+  result.connResults.add(connRes)
+  result.durationNs = totalDuration.nanoseconds
+
+  conn.close()
+  await client.stop()
+  return result
+
 # -- Print results --
 
 proc printResults(result: RunResult) =
@@ -341,10 +440,10 @@ proc printResults(result: RunResult) =
     for si, sr in cr.streamResults:
       if sr.uploadBytes > 0 or sr.downloadBytes > 0:
         echo "    Stream #", si + 1, " [throughput]:"
-        echo "      Upload:   ", sr.uploadBytes, " bytes -> ",
-          formatBps(sr.uploadBytes, sr.durationNs)
-        echo "      Download: ", sr.downloadBytes, " bytes -> ",
-          formatBps(sr.downloadBytes, sr.durationNs)
+        echo "      Upload:   ",
+          sr.uploadBytes, " bytes -> ", formatBps(sr.uploadBytes, sr.durationNs)
+        echo "      Download: ",
+          sr.downloadBytes, " bytes -> ", formatBps(sr.downloadBytes, sr.durationNs)
         echo "      Duration: ", formatDuration(sr.durationNs)
 
       if sr.latencySamples.len > 0:
@@ -356,6 +455,27 @@ proc printResults(result: RunResult) =
         echo "      p99:   ", formatDuration(rtts.percentile(0.99))
         echo "      Min:   ", formatDuration(rtts.min())
         echo "      Max:   ", formatDuration(rtts.max())
+
+      if sr.rampUpSamples.len > 0:
+        echo "    Stream #",
+          si + 1,
+          " [ramp-up] (",
+          sr.rampUpSamples.len,
+          " windows, ",
+          RampUpWindowMs,
+          "ms each):"
+        echo "      Time to 90% peak: ", formatDuration(sr.timeToP90Ns)
+        let peakMbps = sr.rampUpSamples.mapIt(it.throughputMbps).foldl(max(a, b), 0.0)
+        echo "      Peak throughput:  ", peakMbps.formatFloat(ffDecimal, 2), " Mbit/s"
+        echo "      Timeline:"
+        for s in sr.rampUpSamples:
+          let bar = "#".repeat(min(int(s.throughputMbps / peakMbps * 40.0), 40))
+          echo "        ",
+            align($s.elapsedMs & "ms", 8),
+            " | ",
+            align(s.throughputMbps.formatFloat(ffDecimal, 1) & " Mbit/s", 15),
+            " | ",
+            bar
 
   echo ""
 
@@ -390,6 +510,8 @@ when isMainModule:
         mode = MultiConn
       of "stress":
         mode = Stress
+      of "rampup":
+        mode = RampUp
       else:
         echo "Unknown mode: ", paramStr(i)
         quit(1)
@@ -428,6 +550,7 @@ when isMainModule:
       echo "  multistream  - 1 conn, K streams: stream contention"
       echo "  multiconn    - N conns, 1 stream each: connection contention"
       echo "  stress       - N conns, K streams each: worst case"
+      echo "  rampup       - 1 conn, 1 stream: congestion ramp-up timeline"
       echo ""
       echo "Options:"
       echo "  --mode, -m         Benchmark mode (default: throughput)"
@@ -438,7 +561,8 @@ when isMainModule:
       echo "  --chunk-size       Chunk size (default: ", DefaultChunkSize, ")"
       echo "  --runs, -r         Number of runs (default: ", DefaultRuns, ")"
       echo "  --streams, -k      Streams per connection (default: ", DefaultStreams, ")"
-      echo "  --connections, -n  Number of connections (default: ", DefaultConnections, ")"
+      echo "  --connections, -n  Number of connections (default: ",
+        DefaultConnections, ")"
       echo "  --json             Output results as JSON"
       quit(0)
     else:
@@ -470,6 +594,8 @@ when isMainModule:
       waitFor modeStress(
         serverAddr, numConns, numStreams, uploadSize, downloadSize, chunkSize, runs
       )
+    of RampUp:
+      waitFor modeRampUp(serverAddr, downloadSize, chunkSize)
 
   if jsonOutput:
     echo benchResult.toJson().pretty()

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import std/[json, sets, sequtils, os, algorithm, math, strutils]
+import chronos, results, stew/endians2, chronicles
+import lsquic
+
+export json, sets, sequtils, os, algorithm, math, strutils
+export chronos, results, endians2, chronicles
+export lsquic
+
+trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
+
+const
+  # Protocol message types
+  MsgThroughput* = 0x01'u8
+  MsgLatency* = 0x02'u8
+
+  # Defaults
+  DefaultChunkSize* = 65536 # 64KB
+  DefaultUploadSize* = 100_000 # 100KB
+  DefaultDownloadSize* = 100_000_000 # 100MB
+  DefaultRuns* = 10
+  DefaultStreams* = 4
+  DefaultConnections* = 4
+  DefaultPort* = 14555
+
+type
+  BenchMode* = enum
+    Throughput = "throughput"
+    Latency = "latency"
+    MultiStream = "multistream"
+    MultiConn = "multiconn"
+    Stress = "stress"
+
+  LatencySample* = object
+    rttNs*: int64
+
+  StreamResult* = object
+    uploadBytes*: int
+    downloadBytes*: int
+    durationNs*: int64
+    latencySamples*: seq[LatencySample]
+
+  ConnectionResult* = object
+    streamResults*: seq[StreamResult]
+    durationNs*: int64
+
+  RunResult* = object
+    mode*: BenchMode
+    connections*: int
+    streamsPerConn*: int
+    uploadSize*: int
+    downloadSize*: int
+    chunkSize*: int
+    connResults*: seq[ConnectionResult]
+    durationNs*: int64
+
+# Certificate loading - embedded test certs
+const certDir = parentDir(parentDir(currentSourcePath())) / "tests" / "helpers"
+const certificateStr = staticRead(certDir / "testCertificate.pem")
+const privateKeyStr = staticRead(certDir / "testPrivateKey.pem")
+
+proc strToSeq(val: string): seq[byte] =
+  toSeq(val.toOpenArrayByte(0, val.high))
+
+proc testCertificate*(): seq[byte] =
+  strToSeq(certificateStr)
+
+proc testPrivateKey*(): seq[byte] =
+  strToSeq(privateKeyStr)
+
+proc certificateCb(
+    serverName: string, derCertificates: seq[seq[byte]]
+): bool {.gcsafe.} =
+  return derCertificates.len > 0
+
+proc makeClient*(): QuicClient {.
+    raises: [QuicConfigError, QuicError, TransportOsError]
+.} =
+  let customCertVerif: CertificateVerifier =
+    CustomCertificateVerifier.init(certificateCb)
+  let clientTLSConfig = TLSConfig.new(
+    testCertificate(),
+    testPrivateKey(),
+    @["bench"].toHashSet(),
+    Opt.some(customCertVerif),
+  )
+  return QuicClient.new(clientTLSConfig)
+
+proc makeServer*(): QuicServer {.raises: [QuicConfigError].} =
+  let customCertVerif: CertificateVerifier =
+    CustomCertificateVerifier.init(certificateCb)
+  let serverTLSConfig = TLSConfig.new(
+    testCertificate(),
+    testPrivateKey(),
+    @["bench"].toHashSet(),
+    Opt.some(customCertVerif),
+  )
+  return QuicServer.new(serverTLSConfig)
+
+# Stats helpers
+proc percentile*(samples: seq[int64], p: float): int64 =
+  if samples.len == 0:
+    return 0
+  var sorted = samples
+  sorted.sort()
+  let idx = min(int(float(sorted.len - 1) * p), sorted.len - 1)
+  sorted[idx]
+
+proc mean*(samples: seq[int64]): float =
+  if samples.len == 0:
+    return 0.0
+  var total: float = 0.0
+  for s in samples:
+    total += float(s)
+  total / float(samples.len)
+
+proc formatBps*(bytes: int, durationNs: int64): string =
+  if durationNs <= 0:
+    return "N/A"
+  let bitsPerSec = float(bytes) * 8.0 * 1e9 / float(durationNs)
+  if bitsPerSec >= 1e9:
+    return $(bitsPerSec / 1e9).formatFloat(ffDecimal, 2) & " Gbit/s"
+  elif bitsPerSec >= 1e6:
+    return $(bitsPerSec / 1e6).formatFloat(ffDecimal, 2) & " Mbit/s"
+  elif bitsPerSec >= 1e3:
+    return $(bitsPerSec / 1e3).formatFloat(ffDecimal, 2) & " Kbit/s"
+  else:
+    return $bitsPerSec.formatFloat(ffDecimal, 2) & " bit/s"
+
+proc formatDuration*(ns: int64): string =
+  if ns >= 1_000_000_000:
+    return $(float(ns) / 1e9).formatFloat(ffDecimal, 3) & "s"
+  elif ns >= 1_000_000:
+    return $(float(ns) / 1e6).formatFloat(ffDecimal, 3) & "ms"
+  elif ns >= 1000:
+    return $(float(ns) / 1e3).formatFloat(ffDecimal, 3) & "us"
+  else:
+    return $ns & "ns"
+
+proc toJson*(r: RunResult): JsonNode =
+  var connArr = newJArray()
+  for cr in r.connResults:
+    var streamArr = newJArray()
+    for sr in cr.streamResults:
+      var latArr = newJArray()
+      for l in sr.latencySamples:
+        latArr.add(%l.rttNs)
+      streamArr.add(%*{
+        "upload_bytes": sr.uploadBytes,
+        "download_bytes": sr.downloadBytes,
+        "duration_ns": sr.durationNs,
+        "latency_samples_ns": latArr,
+      })
+    connArr.add(%*{
+      "streams": streamArr,
+      "duration_ns": cr.durationNs,
+    })
+  result = %*{
+    "mode": $r.mode,
+    "connections": r.connections,
+    "streams_per_conn": r.streamsPerConn,
+    "upload_size": r.uploadSize,
+    "download_size": r.downloadSize,
+    "chunk_size": r.chunkSize,
+    "duration_ns": r.durationNs,
+    "connections_results": connArr,
+  }

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -32,15 +32,23 @@ type
     MultiStream = "multistream"
     MultiConn = "multiconn"
     Stress = "stress"
+    RampUp = "rampup"
 
   LatencySample* = object
     rttNs*: int64
+
+  RampUpSample* = object
+    elapsedMs*: int64 ## ms since download start
+    throughputMbps*: float ## throughput in this window (Mbit/s)
+    cumulativeBytes*: int ## total bytes received so far
 
   StreamResult* = object
     uploadBytes*: int
     downloadBytes*: int
     durationNs*: int64
     latencySamples*: seq[LatencySample]
+    rampUpSamples*: seq[RampUpSample]
+    timeToP90Ns*: int64 ## time to reach 90% of peak throughput (rampup only)
 
   ConnectionResult* = object
     streamResults*: seq[StreamResult]
@@ -147,23 +155,35 @@ proc toJson*(r: RunResult): JsonNode =
       var latArr = newJArray()
       for l in sr.latencySamples:
         latArr.add(%l.rttNs)
-      streamArr.add(%*{
-        "upload_bytes": sr.uploadBytes,
-        "download_bytes": sr.downloadBytes,
-        "duration_ns": sr.durationNs,
-        "latency_samples_ns": latArr,
-      })
-    connArr.add(%*{
-      "streams": streamArr,
-      "duration_ns": cr.durationNs,
-    })
-  result = %*{
-    "mode": $r.mode,
-    "connections": r.connections,
-    "streams_per_conn": r.streamsPerConn,
-    "upload_size": r.uploadSize,
-    "download_size": r.downloadSize,
-    "chunk_size": r.chunkSize,
-    "duration_ns": r.durationNs,
-    "connections_results": connArr,
-  }
+      var rampArr = newJArray()
+      for s in sr.rampUpSamples:
+        rampArr.add(
+          %*{
+            "elapsed_ms": s.elapsedMs,
+            "throughput_mbps": s.throughputMbps,
+            "cumulative_bytes": s.cumulativeBytes,
+          }
+        )
+      var streamNode =
+        %*{
+          "upload_bytes": sr.uploadBytes,
+          "download_bytes": sr.downloadBytes,
+          "duration_ns": sr.durationNs,
+          "latency_samples_ns": latArr,
+        }
+      if sr.rampUpSamples.len > 0:
+        streamNode["ramp_up_samples"] = rampArr
+        streamNode["time_to_p90_ns"] = %sr.timeToP90Ns
+      streamArr.add(streamNode)
+    connArr.add(%*{"streams": streamArr, "duration_ns": cr.durationNs})
+  result =
+    %*{
+      "mode": $r.mode,
+      "connections": r.connections,
+      "streams_per_conn": r.streamsPerConn,
+      "upload_size": r.uploadSize,
+      "download_size": r.downloadSize,
+      "chunk_size": r.chunkSize,
+      "duration_ns": r.durationNs,
+      "connections_results": connArr,
+    }

--- a/benchmarks/bench_server.nim
+++ b/benchmarks/bench_server.nim
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Benchmark server for nim-lsquic.
+## Handles two stream protocols:
+##   MsgThroughput (0x01): read upload, send download
+##   MsgLatency (0x02): echo ping/pong until EOF
+
+import ./bench_common
+
+proc handleThroughputStream(stream: Stream) {.async.} =
+  # Read 8 bytes: upload size
+  var uploadSizeBuf = newSeq[byte](8)
+  var read = 0
+  while read < 8:
+    let n = await stream.readOnce(uploadSizeBuf[read].addr, 8 - read)
+    if n == 0:
+      return
+    read += n
+
+  # Read 8 bytes: download size
+  var downloadSizeBuf = newSeq[byte](8)
+  read = 0
+  while read < 8:
+    let n = await stream.readOnce(downloadSizeBuf[read].addr, 8 - read)
+    if n == 0:
+      return
+    read += n
+
+  let downloadSize = uint64.fromBytesBE(downloadSizeBuf)
+
+  # Read all upload data until EOF
+  var buf = newSeq[byte](DefaultChunkSize)
+  while true:
+    let n = await stream.readOnce(buf[0].addr, buf.len)
+    if n == 0:
+      break
+
+  # Send download data
+  let chunk = newSeq[byte](DefaultChunkSize)
+  var remaining = downloadSize
+  while remaining > 0:
+    let toSend = min(remaining, DefaultChunkSize.uint64)
+    try:
+      await stream.write(chunk[0 ..< toSend.int])
+    except StreamError:
+      return
+    remaining -= toSend
+
+  await stream.close()
+
+proc handleLatencyStream(stream: Stream) {.async.} =
+  # Echo loop: read a 4-byte length-prefixed payload, send it back
+  var lenBuf = newSeq[byte](4)
+  while true:
+    var read = 0
+    while read < 4:
+      let n = await stream.readOnce(lenBuf[read].addr, 4 - read)
+      if n == 0:
+        # Client closed
+        await stream.close()
+        return
+      read += n
+
+    let payloadLen = uint32.fromBytesBE(lenBuf).int
+    if payloadLen == 0:
+      continue
+
+    # Read payload
+    var payload = newSeq[byte](payloadLen)
+    read = 0
+    while read < payloadLen:
+      let n = await stream.readOnce(payload[read].addr, payloadLen - read)
+      if n == 0:
+        await stream.close()
+        return
+      read += n
+
+    # Echo back: length + payload
+    try:
+      await stream.write(lenBuf & payload)
+    except StreamError:
+      return
+
+proc handleStream(stream: Stream) {.async.} =
+  # First byte is the message type
+  var typeBuf = newSeq[byte](1)
+  let n = await stream.readOnce(typeBuf[0].addr, 1)
+  if n == 0:
+    return
+
+  case typeBuf[0]
+  of MsgThroughput:
+    await handleThroughputStream(stream)
+  of MsgLatency:
+    await handleLatencyStream(stream)
+  else:
+    echo "Unknown message type: ", typeBuf[0]
+    stream.abort()
+
+proc handleConnection(conn: Connection) {.async.} =
+  try:
+    while true:
+      let stream = await conn.incomingStream()
+      asyncSpawn handleStream(stream)
+  except ConnectionError:
+    discard
+  except CancelledError:
+    discard
+
+proc runServer(listenAddr: string, port: int) {.async.} =
+  initializeLsquic(true, true)
+
+  let server = makeServer()
+  let address = initTAddress(listenAddr & ":" & $port)
+  let listener = server.listen(address)
+
+  echo "Benchmark server listening on ", listenAddr, ":", port
+
+  try:
+    while true:
+      let conn = await listener.accept()
+      asyncSpawn handleConnection(conn)
+  except CancelledError:
+    discard
+  except TransportError:
+    discard
+
+  await listener.stop()
+  cleanupLsquic()
+
+when isMainModule:
+  var listenAddr = "0.0.0.0"
+  var port = DefaultPort
+
+  var i = 1
+  while i <= paramCount():
+    let arg = paramStr(i)
+    case arg
+    of "--listen", "-l":
+      inc i
+      listenAddr = paramStr(i)
+    of "--port", "-p":
+      inc i
+      port = parseInt(paramStr(i))
+    of "--help", "-h":
+      echo "Usage: bench_server [--listen ADDR] [--port PORT]"
+      echo "  --listen, -l  Listen address (default: 0.0.0.0)"
+      echo "  --port, -p    Port (default: ", DefaultPort, ")"
+      quit(0)
+    else:
+      echo "Unknown argument: ", arg
+      quit(1)
+    inc i
+
+  waitFor runServer(listenAddr, port)

--- a/benchmarks/docker-compose.yml
+++ b/benchmarks/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+  bench-server:
+    build:
+      context: ..
+      dockerfile: benchmarks/Dockerfile
+    command: ["bench_server", "--listen", "0.0.0.0", "--port", "14555"]
+    networks:
+      benchnet:
+        ipv4_address: 172.28.0.10
+    cap_add:
+      - NET_ADMIN
+    environment:
+      # Server-side network shaping (optional)
+      - LATENCY_MS=${SERVER_LATENCY_MS:-0}
+      - BANDWIDTH_MBIT=${SERVER_BANDWIDTH_MBIT:-0}
+      - PACKET_LOSS_PCT=${SERVER_PACKET_LOSS_PCT:-0}
+      - JITTER_MS=${SERVER_JITTER_MS:-0}
+    healthcheck:
+      test: ["CMD-SHELL", "ss -uln | grep -q 14555 || exit 0"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
+  bench-client:
+    build:
+      context: ..
+      dockerfile: benchmarks/Dockerfile
+    depends_on:
+      bench-server:
+        condition: service_started
+    networks:
+      benchnet:
+        ipv4_address: 172.28.0.20
+    cap_add:
+      - NET_ADMIN
+    environment:
+      # Client-side network shaping
+      - LATENCY_MS=${LATENCY_MS:-0}
+      - BANDWIDTH_MBIT=${BANDWIDTH_MBIT:-0}
+      - PACKET_LOSS_PCT=${PACKET_LOSS_PCT:-0}
+      - JITTER_MS=${JITTER_MS:-0}
+    # Override command via run.sh; default = throughput
+    command: >
+      bench_client
+        --server 172.28.0.10
+        --port 14555
+        --mode ${BENCH_MODE:-throughput}
+        --runs ${BENCH_RUNS:-5}
+        --streams ${BENCH_STREAMS:-4}
+        --connections ${BENCH_CONNECTIONS:-4}
+        --upload-size ${BENCH_UPLOAD_SIZE:-100000}
+        --download-size ${BENCH_DOWNLOAD_SIZE:-10000000}
+        --chunk-size ${BENCH_CHUNK_SIZE:-65536}
+        --json
+
+networks:
+  benchnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/benchmarks/docker-compose.yml
+++ b/benchmarks/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   bench-server:
+    image: nim-lsquic-bench:latest
     build:
       context: ..
       dockerfile: benchmarks/Dockerfile
@@ -15,19 +16,22 @@ services:
       - BANDWIDTH_MBIT=${SERVER_BANDWIDTH_MBIT:-0}
       - PACKET_LOSS_PCT=${SERVER_PACKET_LOSS_PCT:-0}
       - JITTER_MS=${SERVER_JITTER_MS:-0}
+      - REORDER_PCT=${SERVER_REORDER_PCT:-0}
     healthcheck:
-      test: ["CMD-SHELL", "ss -uln | grep -q 14555 || exit 0"]
+      test: ["CMD-SHELL", "ss -ulnH | grep -q ':14555'"]
       interval: 1s
       timeout: 5s
-      retries: 10
+      retries: 30
+      start_period: 1s
 
   bench-client:
+    image: nim-lsquic-bench:latest
     build:
       context: ..
       dockerfile: benchmarks/Dockerfile
     depends_on:
       bench-server:
-        condition: service_started
+        condition: service_healthy
     networks:
       benchnet:
         ipv4_address: 172.28.0.20
@@ -39,6 +43,7 @@ services:
       - BANDWIDTH_MBIT=${BANDWIDTH_MBIT:-0}
       - PACKET_LOSS_PCT=${PACKET_LOSS_PCT:-0}
       - JITTER_MS=${JITTER_MS:-0}
+      - REORDER_PCT=${REORDER_PCT:-0}
     # Override command via run.sh; default = throughput
     command: >
       bench_client

--- a/benchmarks/entrypoint.sh
+++ b/benchmarks/entrypoint.sh
@@ -4,10 +4,11 @@ set -e
 # Apply network shaping via tc netem if environment variables are set.
 # Requires NET_ADMIN capability.
 #
-# LATENCY_MS     - one-way delay in milliseconds (default: 0)
-# BANDWIDTH_MBIT - bandwidth limit in Mbit/s (default: unlimited)
+# LATENCY_MS      - one-way delay in milliseconds (default: 0)
+# BANDWIDTH_MBIT  - bandwidth limit in Mbit/s (default: unlimited)
 # PACKET_LOSS_PCT - packet loss percentage (default: 0)
-# JITTER_MS      - delay jitter in milliseconds (default: 0)
+# JITTER_MS       - delay jitter in milliseconds (default: 0)
+# REORDER_PCT     - packet reorder percentage (default: 0, requires LATENCY_MS)
 
 apply_netem() {
   local iface
@@ -35,6 +36,12 @@ apply_netem() {
     has_netem=true
   fi
 
+  if [ -n "$REORDER_PCT" ] && [ "$REORDER_PCT" != "0" ]; then
+    # reorder requires delay to be set (reordered packets skip the delay)
+    netem_args="${netem_args} reorder ${REORDER_PCT}% 50%"
+    has_netem=true
+  fi
+
   # Bandwidth shaping: combine with netem if both are set
   if [ -n "$BANDWIDTH_MBIT" ] && [ "$BANDWIDTH_MBIT" != "0" ]; then
     local rate="${BANDWIDTH_MBIT}mbit"
@@ -59,7 +66,7 @@ apply_netem() {
 }
 
 # Only apply netem if any shaping var is set
-if [ -n "$LATENCY_MS" ] || [ -n "$BANDWIDTH_MBIT" ] || [ -n "$PACKET_LOSS_PCT" ]; then
+if [ -n "$LATENCY_MS" ] || [ -n "$BANDWIDTH_MBIT" ] || [ -n "$PACKET_LOSS_PCT" ] || [ -n "$REORDER_PCT" ]; then
   apply_netem
 fi
 

--- a/benchmarks/entrypoint.sh
+++ b/benchmarks/entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Apply network shaping via tc netem if environment variables are set.
+# Requires NET_ADMIN capability.
+#
+# LATENCY_MS     - one-way delay in milliseconds (default: 0)
+# BANDWIDTH_MBIT - bandwidth limit in Mbit/s (default: unlimited)
+# PACKET_LOSS_PCT - packet loss percentage (default: 0)
+# JITTER_MS      - delay jitter in milliseconds (default: 0)
+
+apply_netem() {
+  local iface
+  iface=$(ip -o link show | awk -F': ' '!/lo/{gsub(/@.*/, "", $2); print $2; exit}')
+
+  if [ -z "$iface" ]; then
+    echo "[entrypoint] WARNING: could not detect network interface, skipping netem"
+    return
+  fi
+
+  local has_netem=false
+
+  # Build netem parameters
+  local netem_args=""
+  if [ -n "$LATENCY_MS" ] && [ "$LATENCY_MS" != "0" ]; then
+    netem_args="delay ${LATENCY_MS}ms"
+    if [ -n "$JITTER_MS" ] && [ "$JITTER_MS" != "0" ]; then
+      netem_args="${netem_args} ${JITTER_MS}ms"
+    fi
+    has_netem=true
+  fi
+
+  if [ -n "$PACKET_LOSS_PCT" ] && [ "$PACKET_LOSS_PCT" != "0" ]; then
+    netem_args="${netem_args} loss ${PACKET_LOSS_PCT}%"
+    has_netem=true
+  fi
+
+  # Bandwidth shaping: combine with netem if both are set
+  if [ -n "$BANDWIDTH_MBIT" ] && [ "$BANDWIDTH_MBIT" != "0" ]; then
+    local rate="${BANDWIDTH_MBIT}mbit"
+    # burst = rate * 1ms; latency = 50ms buffer
+    local burst_bytes=$(( BANDWIDTH_MBIT * 1000 / 8 ))
+    if [ "$burst_bytes" -lt 1600 ]; then
+      burst_bytes=1600
+    fi
+
+    if [ "$has_netem" = true ]; then
+      # Use htb as root, then attach netem + tbf as children
+      echo "[entrypoint] Applying netem + bandwidth on $iface: $netem_args rate=${rate}"
+      tc qdisc add dev "$iface" root handle 1: netem $netem_args rate "$rate"
+    else
+      echo "[entrypoint] Applying bandwidth limit on $iface: ${rate}"
+      tc qdisc add dev "$iface" root tbf rate "$rate" burst "${burst_bytes}" latency 50ms
+    fi
+  elif [ "$has_netem" = true ]; then
+    echo "[entrypoint] Applying netem on $iface: $netem_args"
+    tc qdisc add dev "$iface" root netem $netem_args
+  fi
+}
+
+# Only apply netem if any shaping var is set
+if [ -n "$LATENCY_MS" ] || [ -n "$BANDWIDTH_MBIT" ] || [ -n "$PACKET_LOSS_PCT" ]; then
+  apply_netem
+fi
+
+# Run the actual command
+exec "$@"

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -17,6 +17,39 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 RESULTS_DIR="$SCRIPT_DIR/results"
+LOCK_DIR="$RESULTS_DIR/.run.lock"
+WAIT_TIMEOUT=30
+COMPOSE_ARGS=(-f "$COMPOSE_FILE")
+
+acquire_lock() {
+  local pid
+
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo $$ > "$LOCK_DIR/pid"
+    return
+  fi
+
+  if [ -f "$LOCK_DIR/pid" ]; then
+    pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+      rm -rf "$LOCK_DIR"
+      mkdir "$LOCK_DIR"
+      echo $$ > "$LOCK_DIR/pid"
+      return
+    fi
+  fi
+
+  echo "Another benchmark run is already active. Stop it before starting a new one."
+  exit 1
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM HUP
+  docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "$LOCK_DIR"
+  exit "$status"
+}
 
 QUICK=false
 FILTER_MODE=""
@@ -38,20 +71,26 @@ while [[ $# -gt 0 ]]; do
 done
 
 mkdir -p "$RESULTS_DIR"
+acquire_lock
+trap cleanup EXIT INT TERM HUP
+
+# Start from a clean project state in case a previous run was interrupted.
+docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans >/dev/null 2>&1 || true
 
 # -- Network scenarios --
-# Format: NAME|LATENCY_MS|BANDWIDTH_MBIT|PACKET_LOSS_PCT
+# Format: NAME|LATENCY_MS|BANDWIDTH_MBIT|PACKET_LOSS_PCT|REORDER_PCT
 if [ "$QUICK" = true ]; then
   SCENARIOS=(
-    "lan|0|0|0"
+    "lan|0|0|0|0"
   )
 else
   SCENARIOS=(
-    "lan|0|0|0"
-    "wan|25|100|0"
-    "constrained|50|10|0.1"
-    "lossy|25|50|2"
-    "mobile|75|5|1"
+    "lan|0|0|0|0"
+    "wan|25|100|0|0"
+    "constrained|50|10|0.1|0"
+    "lossy|25|50|2|0"
+    "mobile|75|5|1|0"
+    "reorder|25|100|0|25"
   )
 fi
 
@@ -64,6 +103,7 @@ if [ "$QUICK" = true ]; then
     "multistream|1|4|1|100000|1000000"
     "multiconn|1|1|3|100000|1000000"
     "stress|1|3|3|100000|1000000"
+    "rampup|1|1|1|0|10000000"
   )
 else
   BENCHMARKS=(
@@ -72,13 +112,14 @@ else
     "multistream|2|4|1|100000|10000000"
     "multiconn|2|1|4|100000|10000000"
     "stress|1|4|4|100000|10000000"
+    "rampup|1|1|1|0|100000000"
   )
 fi
 
 # -- Build --
 if [ "$NO_BUILD" = false ]; then
-  echo "Building Docker images..."
-  docker compose -f "$COMPOSE_FILE" build --quiet 2>&1
+  echo "Building Docker image..."
+  docker compose "${COMPOSE_ARGS[@]}" build --quiet bench-server 2>&1
   echo "Build complete."
 fi
 
@@ -96,7 +137,7 @@ run_bench() {
   local scenario_str="$1"
   local bench_str="$2"
 
-  IFS='|' read -r sc_name sc_lat sc_bw sc_loss <<< "$scenario_str"
+  IFS='|' read -r sc_name sc_lat sc_bw sc_loss sc_reorder <<< "$scenario_str"
   IFS='|' read -r bm_mode bm_runs bm_streams bm_conns bm_upload bm_download <<< "$bench_str"
 
   # Apply filters
@@ -110,15 +151,19 @@ run_bench() {
   local run_name="${sc_name}_${bm_mode}"
   echo -n "Running ${run_name}... "
 
-  # Latency is applied half on each side (client sends, server sends)
-  # to simulate realistic RTT. For simplicity, apply full delay on client only.
+  # tc netem only shapes egress (outbound) traffic. To cap bandwidth in both
+  # directions we mirror the bandwidth limit on the server side so that the
+  # server's outgoing download data is also shaped.
+  # Latency/loss/reorder are kept client-only to avoid doubling the delay.
   local env_args=(
     "LATENCY_MS=$sc_lat"
     "BANDWIDTH_MBIT=$sc_bw"
     "PACKET_LOSS_PCT=$sc_loss"
+    "REORDER_PCT=${sc_reorder:-0}"
     "SERVER_LATENCY_MS=0"
-    "SERVER_BANDWIDTH_MBIT=0"
+    "SERVER_BANDWIDTH_MBIT=$sc_bw"
     "SERVER_PACKET_LOSS_PCT=0"
+    "SERVER_REORDER_PCT=0"
     "BENCH_MODE=$bm_mode"
     "BENCH_RUNS=$bm_runs"
     "BENCH_STREAMS=$bm_streams"
@@ -127,29 +172,52 @@ run_bench() {
     "BENCH_DOWNLOAD_SIZE=$bm_download"
   )
 
-  local env_file="$JSON_DIR/.env_${run_name}"
-  printf "%s\n" "${env_args[@]}" > "$env_file"
+  # Make each scenario self-contained even if the previous one was interrupted.
+  env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans \
+    >/dev/null 2>&1 || true
 
-  # Start server, run client, capture JSON output.
-  # Docker compose prefixes lines with "bench-client-1  | ", so we strip that
-  # and reconstruct just the JSON block.
-  local raw_output
+  # Bring up the server first and wait for the healthcheck to pass before
+  # running the client. This removes the client/server startup race.
+  if ! env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" up \
+      -d \
+      --wait \
+      --wait-timeout "$WAIT_TIMEOUT" \
+      bench-server >/dev/null 2>&1; then
+    echo "FAILED (server startup)"
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" \
+      | tee -a "$SUMMARY_FILE"
+    env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans \
+      >/dev/null 2>&1 || true
+    return
+  fi
+
+  # Only attach to bench-client so the output contains bench_client logs only.
+  local raw_output client_status output
+  set +e
   raw_output=$(
-    env "${env_args[@]}" docker compose -f "$COMPOSE_FILE" up \
+    env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" up \
+      --no-deps \
       --abort-on-container-exit \
       --exit-code-from bench-client \
-      2>/dev/null || true
+      --no-color \
+      --no-log-prefix \
+      bench-client 2>/dev/null
   )
+  client_status=$?
+  set -e
 
-  # Extract the JSON from bench-client output lines
-  local output
-  output=$(echo "$raw_output" | sed -n 's/^bench-client-1  | //p' | sed -n '/^{/,/^}/p' || true)
+  output=$(printf "%s\n" "$raw_output" | sed -n '/^{/,/^}/p' || true)
 
-  # Tear down
-  env "${env_args[@]}" docker compose -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
+  env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans \
+    >/dev/null 2>&1 || true
 
   if [ -z "$output" ]; then
-    echo "FAILED (no JSON output)"
+    if [ "$client_status" -ne 0 ]; then
+      echo "FAILED (bench-client exit $client_status)"
+    else
+      echo "FAILED (no JSON output)"
+    fi
     printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
       "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" \
       | tee -a "$SUMMARY_FILE"
@@ -172,7 +240,10 @@ import sys, json
 d = json.load(sys.stdin)
 dur_ns = d['duration_ns']
 
-# Aggregate throughput
+# Aggregate bytes across all streams, then compute throughput as
+# total_bytes / total_run_duration. This is correct for both sequential
+# runs (gives average throughput) and parallel streams/conns (gives
+# aggregate bandwidth).
 total_up = 0
 total_down = 0
 latencies = []
@@ -212,6 +283,15 @@ else:
     lat_p50_str = '-'
     lat_p95_str = '-'
 
+# For rampup mode, show time-to-p90 in the latency columns
+if d.get('mode') == 'rampup':
+    for cr in d.get('connections_results', []):
+        for sr in cr.get('streams', []):
+            t90 = sr.get('time_to_p90_ns', 0)
+            if t90 > 0:
+                lat_p50_str = fmt_dur(t90)
+                lat_p95_str = 'p90'
+
 dur_str = fmt_dur(dur_ns)
 
 print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{dur_str}')
@@ -224,7 +304,6 @@ print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{dur_str}')
       | tee -a "$SUMMARY_FILE"
   }
 
-  rm -f "$env_file"
 }
 
 for scenario in "${SCENARIOS[@]}"; do

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+set -e
+
+# nim-lsquic benchmark runner
+# Runs a matrix of benchmark scenarios via Docker Compose.
+#
+# Usage:
+#   ./benchmarks/run.sh [--quick] [--mode MODE] [--scenario SCENARIO]
+#
+# Options:
+#   --quick       Run minimal scenarios (LAN only, fewer runs)
+#   --mode MODE   Run only one benchmark mode
+#   --scenario SC Run only one network scenario
+#   --no-build    Skip Docker image build
+#   --help        Show this help
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+RESULTS_DIR="$SCRIPT_DIR/results"
+
+QUICK=false
+FILTER_MODE=""
+FILTER_SCENARIO=""
+NO_BUILD=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --quick) QUICK=true; shift ;;
+    --mode) FILTER_MODE="$2"; shift 2 ;;
+    --scenario) FILTER_SCENARIO="$2"; shift 2 ;;
+    --no-build) NO_BUILD=true; shift ;;
+    --help)
+      head -12 "$0" | tail -10
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+mkdir -p "$RESULTS_DIR"
+
+# -- Network scenarios --
+# Format: NAME|LATENCY_MS|BANDWIDTH_MBIT|PACKET_LOSS_PCT
+if [ "$QUICK" = true ]; then
+  SCENARIOS=(
+    "lan|0|0|0"
+  )
+else
+  SCENARIOS=(
+    "lan|0|0|0"
+    "wan|25|100|0"
+    "constrained|50|10|0.1"
+    "lossy|25|50|2"
+    "mobile|75|5|1"
+  )
+fi
+
+# -- Benchmark modes --
+# Format: MODE|RUNS|STREAMS|CONNECTIONS|UPLOAD_SIZE|DOWNLOAD_SIZE
+if [ "$QUICK" = true ]; then
+  BENCHMARKS=(
+    "throughput|3|1|1|100000|1000000"
+    "latency|20|1|1|0|0"
+    "multistream|1|4|1|100000|1000000"
+    "multiconn|1|1|3|100000|1000000"
+    "stress|1|3|3|100000|1000000"
+  )
+else
+  BENCHMARKS=(
+    "throughput|5|1|1|100000|10000000"
+    "latency|100|1|1|0|0"
+    "multistream|2|4|1|100000|10000000"
+    "multiconn|2|1|4|100000|10000000"
+    "stress|1|4|4|100000|10000000"
+  )
+fi
+
+# -- Build --
+if [ "$NO_BUILD" = false ]; then
+  echo "Building Docker images..."
+  docker compose -f "$COMPOSE_FILE" build --quiet 2>&1
+  echo "Build complete."
+fi
+
+# -- Run matrix --
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+SUMMARY_FILE="$RESULTS_DIR/summary_${TIMESTAMP}.txt"
+JSON_DIR="$RESULTS_DIR/json_${TIMESTAMP}"
+mkdir -p "$JSON_DIR"
+
+printf "\n%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
+  "Scenario" "Mode" "Conns" "Strms" "Upload" "Download" "Lat p50" "Lat p95" "Duration" | tee "$SUMMARY_FILE"
+printf "%s\n" "$(printf '=%.0s' {1..120})" | tee -a "$SUMMARY_FILE"
+
+run_bench() {
+  local scenario_str="$1"
+  local bench_str="$2"
+
+  IFS='|' read -r sc_name sc_lat sc_bw sc_loss <<< "$scenario_str"
+  IFS='|' read -r bm_mode bm_runs bm_streams bm_conns bm_upload bm_download <<< "$bench_str"
+
+  # Apply filters
+  if [ -n "$FILTER_MODE" ] && [ "$bm_mode" != "$FILTER_MODE" ]; then
+    return
+  fi
+  if [ -n "$FILTER_SCENARIO" ] && [ "$sc_name" != "$FILTER_SCENARIO" ]; then
+    return
+  fi
+
+  local run_name="${sc_name}_${bm_mode}"
+  echo -n "Running ${run_name}... "
+
+  # Latency is applied half on each side (client sends, server sends)
+  # to simulate realistic RTT. For simplicity, apply full delay on client only.
+  local env_args=(
+    "LATENCY_MS=$sc_lat"
+    "BANDWIDTH_MBIT=$sc_bw"
+    "PACKET_LOSS_PCT=$sc_loss"
+    "SERVER_LATENCY_MS=0"
+    "SERVER_BANDWIDTH_MBIT=0"
+    "SERVER_PACKET_LOSS_PCT=0"
+    "BENCH_MODE=$bm_mode"
+    "BENCH_RUNS=$bm_runs"
+    "BENCH_STREAMS=$bm_streams"
+    "BENCH_CONNECTIONS=$bm_conns"
+    "BENCH_UPLOAD_SIZE=$bm_upload"
+    "BENCH_DOWNLOAD_SIZE=$bm_download"
+  )
+
+  local env_file="$JSON_DIR/.env_${run_name}"
+  printf "%s\n" "${env_args[@]}" > "$env_file"
+
+  # Start server, run client, capture JSON output.
+  # Docker compose prefixes lines with "bench-client-1  | ", so we strip that
+  # and reconstruct just the JSON block.
+  local raw_output
+  raw_output=$(
+    env "${env_args[@]}" docker compose -f "$COMPOSE_FILE" up \
+      --abort-on-container-exit \
+      --exit-code-from bench-client \
+      2>/dev/null || true
+  )
+
+  # Extract the JSON from bench-client output lines
+  local output
+  output=$(echo "$raw_output" | sed -n 's/^bench-client-1  | //p' | sed -n '/^{/,/^}/p' || true)
+
+  # Tear down
+  env "${env_args[@]}" docker compose -f "$COMPOSE_FILE" down --remove-orphans 2>/dev/null || true
+
+  if [ -z "$output" ]; then
+    echo "FAILED (no JSON output)"
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" \
+      | tee -a "$SUMMARY_FILE"
+    return
+  fi
+
+  # Save raw JSON
+  echo "$output" > "$JSON_DIR/${run_name}.json"
+
+  # Parse key metrics with a simple approach
+  local duration_ns upload_bps download_bps lat_p50 lat_p95
+  duration_ns=$(echo "$output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['duration_ns'])" 2>/dev/null || echo "0")
+
+  # Extract throughput from first throughput stream
+  local upload_str="-" download_str="-" lat_p50_str="-" lat_p95_str="-"
+
+  python3 -c "
+import sys, json
+
+d = json.load(sys.stdin)
+dur_ns = d['duration_ns']
+
+# Aggregate throughput
+total_up = 0
+total_down = 0
+latencies = []
+
+for cr in d.get('connections_results', []):
+    for sr in cr.get('streams', []):
+        total_up += sr.get('upload_bytes', 0)
+        total_down += sr.get('download_bytes', 0)
+        latencies.extend(sr.get('latency_samples_ns', []))
+
+# Format throughput
+def fmt_bps(bytes_val, ns):
+    if ns <= 0 or bytes_val <= 0:
+        return '-'
+    bps = bytes_val * 8 * 1e9 / ns
+    if bps >= 1e9: return f'{bps/1e9:.2f} Gbit/s'
+    if bps >= 1e6: return f'{bps/1e6:.2f} Mbit/s'
+    if bps >= 1e3: return f'{bps/1e3:.2f} Kbit/s'
+    return f'{bps:.0f} bit/s'
+
+def fmt_dur(ns):
+    if ns >= 1e9: return f'{ns/1e9:.3f}s'
+    if ns >= 1e6: return f'{ns/1e6:.3f}ms'
+    if ns >= 1e3: return f'{ns/1e3:.3f}us'
+    return f'{ns}ns'
+
+up_str = fmt_bps(total_up, dur_ns)
+down_str = fmt_bps(total_down, dur_ns)
+
+if latencies:
+    latencies.sort()
+    p50 = latencies[int(len(latencies) * 0.50)]
+    p95 = latencies[min(int(len(latencies) * 0.95), len(latencies)-1)]
+    lat_p50_str = fmt_dur(p50)
+    lat_p95_str = fmt_dur(p95)
+else:
+    lat_p50_str = '-'
+    lat_p95_str = '-'
+
+dur_str = fmt_dur(dur_ns)
+
+print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{dur_str}')
+" <<< "$output" 2>/dev/null | {
+    IFS='|' read -r upload_str download_str lat_p50_str lat_p95_str dur_str
+    echo "done"
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "$upload_str" "$download_str" \
+      "$lat_p50_str" "$lat_p95_str" "$dur_str" \
+      | tee -a "$SUMMARY_FILE"
+  }
+
+  rm -f "$env_file"
+}
+
+for scenario in "${SCENARIOS[@]}"; do
+  for bench in "${BENCHMARKS[@]}"; do
+    run_bench "$scenario" "$bench"
+  done
+done
+
+echo ""
+echo "Results saved to: $RESULTS_DIR/"
+echo "  Summary: $SUMMARY_FILE"
+echo "  JSON:    $JSON_DIR/"

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -111,6 +111,7 @@ method dial*(
   ok(quicClientConn)
 
 const Cubic = 1
+const Adaptive = 3
 
 proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
   var ctx = ClientContext()
@@ -125,13 +126,12 @@ proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
   ctx.settings.es_max_plpmtu = 0
   ctx.settings.es_pace_packets = 1
 
-  ctx.settings.es_cfcw = 1 * 1024 * 1024
-  ctx.settings.es_max_cfcw = 2 * 1024 * 1024
-  ctx.settings.es_sfcw = 256 * 1024
-  ctx.settings.es_max_sfcw = 512 * 1024
+  ctx.settings.es_cfcw = 4 * 1024 * 1024
+  ctx.settings.es_max_cfcw = 8 * 1024 * 1024
+  ctx.settings.es_sfcw = 1 * 1024 * 1024
+  ctx.settings.es_max_sfcw = 2 * 1024 * 1024
   ctx.settings.es_init_max_stream_data_bidi_local = ctx.settings.es_sfcw
   ctx.settings.es_init_max_stream_data_bidi_remote = ctx.settings.es_sfcw
-  ctx.settings.es_max_batch_size = 32
 
   ctx.stream_if = struct_lsquic_stream_if(
     on_new_conn: onNewConn,

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -48,6 +48,7 @@ proc onConnClosed(conn: ptr lsquic_conn_t) {.cdecl.} =
   lsquic_conn_set_ctx(conn, nil)
 
 const Cubic = 1
+const Adaptive = 3
 
 proc new*(T: typedesc[ServerContext], tlsConfig: TLSConfig): Result[T, string] =
   var ctx = ServerContext()
@@ -63,13 +64,12 @@ proc new*(T: typedesc[ServerContext], tlsConfig: TLSConfig): Result[T, string] =
   ctx.settings.es_max_plpmtu = 0
   ctx.settings.es_pace_packets = 1
 
-  ctx.settings.es_cfcw = 1 * 1024 * 1024
-  ctx.settings.es_max_cfcw = 2 * 1024 * 1024
-  ctx.settings.es_sfcw = 256 * 1024
-  ctx.settings.es_max_sfcw = 512 * 1024
+  ctx.settings.es_cfcw = 1536 * 1024
+  ctx.settings.es_max_cfcw = 1536 * 1024
+  ctx.settings.es_sfcw = 1 * 1024 * 1024
+  ctx.settings.es_max_sfcw = 1 * 1024 * 1024
   ctx.settings.es_init_max_stream_data_bidi_local = ctx.settings.es_sfcw
   ctx.settings.es_init_max_stream_data_bidi_remote = ctx.settings.es_sfcw
-  ctx.settings.es_max_batch_size = 32
 
   ctx.stream_if = struct_lsquic_stream_if(
     on_new_conn: onNewConn,


### PR DESCRIPTION
This adds a docker benchmark harness to measure nim-lsquic throughput and latency
Also, based on the results (which can be seen in the README.md for the benchmark folder), tunes the flow control windows