### PR TITLE
fix(windows): remove unneeded dirs

### DIFF
--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -11,44 +11,47 @@ const rootInstallFiles = @[
   "boringssl.nim",
 ]
 
-const installRoots = @[
+installDirs = @[
   "lsquic",
-  "libs/lsquic",
-  "libs/vac_boringssl",
+  "libs/lsquic/include",
+  "libs/lsquic/src/lshpack",
+  "libs/lsquic/wincompat",
+]
+
+const filteredInstallRoots = @[
+  "libs/lsquic/src/liblsquic",
+  "libs/vac_boringssl/include",
+  "libs/vac_boringssl/crypto",
+  "libs/vac_boringssl/decrepit",
+  "libs/vac_boringssl/gen",
+  "libs/vac_boringssl/ssl",
+  "libs/vac_boringssl/third_party/fiat",
 ]
 
 const skippedInstallDirs = @[
-  "libs/lsquic/bin",
   "libs/lsquic/docs",
-  "libs/lsquic/qir",
   "libs/lsquic/tests",
   "libs/lsquic/tools",
   "libs/lsquic/src/liblsquic/ls-qpack/bin",
   "libs/lsquic/src/liblsquic/ls-qpack/fuzz",
   "libs/lsquic/src/liblsquic/ls-qpack/test",
   "libs/lsquic/src/liblsquic/ls-qpack/tools",
-  "libs/lsquic/src/lshpack/bin",
   "libs/lsquic/src/lshpack/test",
-  "libs/vac_boringssl/.bcr",
-  "libs/vac_boringssl/.github",
-  "libs/vac_boringssl/bench",
   "libs/vac_boringssl/cmake",
   "libs/vac_boringssl/crypto/cipher/test",
   "libs/vac_boringssl/crypto/fipsmodule/policydocs",
+  "libs/vac_boringssl/crypto/evp/test",
+  "libs/vac_boringssl/crypto/fipsmodule/bn/test",
+  "libs/vac_boringssl/crypto/pkcs7/test",
+  "libs/vac_boringssl/crypto/pkcs8/test",
+  "libs/vac_boringssl/crypto/rsa/test",
   "libs/vac_boringssl/crypto/test",
   "libs/vac_boringssl/crypto/x509/test",
   "libs/vac_boringssl/docs",
   "libs/vac_boringssl/fuzz",
   "libs/vac_boringssl/gen/test_support",
-  "libs/vac_boringssl/infra",
-  "libs/vac_boringssl/pki",
-  "libs/vac_boringssl/rust",
   "libs/vac_boringssl/ssl/test",
-  "libs/vac_boringssl/third_party/benchmark",
-  "libs/vac_boringssl/third_party/googletest",
   "libs/vac_boringssl/third_party/wycheproof_testvectors",
-  "libs/vac_boringssl/tool",
-  "libs/vac_boringssl/util",
 ]
 
 proc normalizeInstallPath(path: string): string =
@@ -84,7 +87,7 @@ proc collectInstallFiles(root: string) =
       discard
 
 installFiles = rootInstallFiles
-for root in installRoots:
+for root in filteredInstallRoots:
   collectInstallFiles(root)
 
 requires "nim >= 2.0.0"

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -3,8 +3,89 @@ version = "0.0.1"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"
-installDirs = @["libs", "scripts"]
-installFiles = @["lsquic.nim", "boringssl.nim"]
+
+import os, strutils
+
+const rootInstallFiles = @[
+  "lsquic.nim",
+  "boringssl.nim",
+]
+
+const installRoots = @[
+  "lsquic",
+  "libs/lsquic",
+  "libs/vac_boringssl",
+]
+
+const skippedInstallDirs = @[
+  "libs/lsquic/bin",
+  "libs/lsquic/docs",
+  "libs/lsquic/qir",
+  "libs/lsquic/tests",
+  "libs/lsquic/tools",
+  "libs/lsquic/src/liblsquic/ls-qpack/bin",
+  "libs/lsquic/src/liblsquic/ls-qpack/fuzz",
+  "libs/lsquic/src/liblsquic/ls-qpack/test",
+  "libs/lsquic/src/liblsquic/ls-qpack/tools",
+  "libs/lsquic/src/lshpack/bin",
+  "libs/lsquic/src/lshpack/test",
+  "libs/vac_boringssl/.bcr",
+  "libs/vac_boringssl/.github",
+  "libs/vac_boringssl/bench",
+  "libs/vac_boringssl/cmake",
+  "libs/vac_boringssl/crypto/cipher/test",
+  "libs/vac_boringssl/crypto/fipsmodule/policydocs",
+  "libs/vac_boringssl/crypto/test",
+  "libs/vac_boringssl/crypto/x509/test",
+  "libs/vac_boringssl/docs",
+  "libs/vac_boringssl/fuzz",
+  "libs/vac_boringssl/gen/test_support",
+  "libs/vac_boringssl/infra",
+  "libs/vac_boringssl/pki",
+  "libs/vac_boringssl/rust",
+  "libs/vac_boringssl/ssl/test",
+  "libs/vac_boringssl/third_party/benchmark",
+  "libs/vac_boringssl/third_party/googletest",
+  "libs/vac_boringssl/third_party/wycheproof_testvectors",
+  "libs/vac_boringssl/tool",
+  "libs/vac_boringssl/util",
+]
+
+proc normalizeInstallPath(path: string): string =
+  path.replace('\\', '/')
+
+proc isHiddenPath(path: string): bool =
+  let norm = normalizeInstallPath(path)
+  let tail = norm.splitPath.tail
+  tail.len > 0 and tail[0] == '.'
+
+proc isSkippedInstallPath(path: string): bool =
+  let norm = normalizeInstallPath(path)
+  if isHiddenPath(norm):
+    return true
+
+  for skipped in skippedInstallDirs:
+    if norm == skipped or norm.startsWith(skipped & "/"):
+      return true
+
+  false
+
+proc collectInstallFiles(root: string) =
+  for kind, path in walkDir(root):
+    let norm = normalizeInstallPath(path)
+    case kind
+    of pcDir:
+      if not isSkippedInstallPath(norm):
+        collectInstallFiles(norm)
+    of pcFile:
+      if not isSkippedInstallPath(norm):
+        installFiles.add(norm)
+    else:
+      discard
+
+installFiles = rootInstallFiles
+for root in installRoots:
+  collectInstallFiles(root)
 
 requires "nim >= 2.0.0"
 requires "zlib"
@@ -13,8 +94,6 @@ requires "chronos >= 4.0.4"
 requires "nimcrypto >= 0.6.0"
 requires "unittest2"
 requires "chronicles >= 0.11.0"
-
-import os, strutils, sequtils
 
 var flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -4,32 +4,12 @@ author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"
 
-import os, strutils
-
-const rootInstallFiles = @[
-  "lsquic.nim",
-  "boringssl.nim",
-]
-
-installDirs = @[
-  "lsquic",
-  "libs/lsquic/include",
-  "libs/lsquic/src/lshpack",
-  "libs/lsquic/wincompat",
-]
-
-const filteredInstallRoots = @[
-  "libs/lsquic/src/liblsquic",
-  "libs/vac_boringssl/include",
-  "libs/vac_boringssl/crypto",
-  "libs/vac_boringssl/decrepit",
-  "libs/vac_boringssl/gen",
-  "libs/vac_boringssl/ssl",
-  "libs/vac_boringssl/third_party/fiat",
-]
-
-const skippedInstallDirs = @[
+skipDirs = @[
+  "benchmarks",
+  "tests",
+  "libs/lsquic/bin",
   "libs/lsquic/docs",
+  "libs/lsquic/qir",
   "libs/lsquic/tests",
   "libs/lsquic/tools",
   "libs/lsquic/src/liblsquic/ls-qpack/bin",
@@ -37,11 +17,15 @@ const skippedInstallDirs = @[
   "libs/lsquic/src/liblsquic/ls-qpack/test",
   "libs/lsquic/src/liblsquic/ls-qpack/tools",
   "libs/lsquic/src/lshpack/test",
+  "libs/lsquic/src/lshpack/bin",
+  "libs/vac_boringssl/.bcr",
+  "libs/vac_boringssl/.github",
+  "libs/vac_boringssl/bench",
   "libs/vac_boringssl/cmake",
   "libs/vac_boringssl/crypto/cipher/test",
-  "libs/vac_boringssl/crypto/fipsmodule/policydocs",
   "libs/vac_boringssl/crypto/evp/test",
   "libs/vac_boringssl/crypto/fipsmodule/bn/test",
+  "libs/vac_boringssl/crypto/fipsmodule/policydocs",
   "libs/vac_boringssl/crypto/pkcs7/test",
   "libs/vac_boringssl/crypto/pkcs8/test",
   "libs/vac_boringssl/crypto/rsa/test",
@@ -50,45 +34,26 @@ const skippedInstallDirs = @[
   "libs/vac_boringssl/docs",
   "libs/vac_boringssl/fuzz",
   "libs/vac_boringssl/gen/test_support",
+  "libs/vac_boringssl/infra",
+  "libs/vac_boringssl/pki",
+  "libs/vac_boringssl/rust",
   "libs/vac_boringssl/ssl/test",
+  "libs/vac_boringssl/third_party/benchmark",
+  "libs/vac_boringssl/third_party/googletest",
   "libs/vac_boringssl/third_party/wycheproof_testvectors",
+  "libs/vac_boringssl/tool",
+  "libs/vac_boringssl/util",
 ]
 
-proc normalizeInstallPath(path: string): string =
-  path.replace('\\', '/')
-
-proc isHiddenPath(path: string): bool =
-  let norm = normalizeInstallPath(path)
-  let tail = norm.splitPath.tail
-  tail.len > 0 and tail[0] == '.'
-
-proc isSkippedInstallPath(path: string): bool =
-  let norm = normalizeInstallPath(path)
-  if isHiddenPath(norm):
-    return true
-
-  for skipped in skippedInstallDirs:
-    if norm == skipped or norm.startsWith(skipped & "/"):
-      return true
-
-  false
-
-proc collectInstallFiles(root: string) =
-  for kind, path in walkDir(root):
-    let norm = normalizeInstallPath(path)
-    case kind
-    of pcDir:
-      if not isSkippedInstallPath(norm):
-        collectInstallFiles(norm)
-    of pcFile:
-      if not isSkippedInstallPath(norm):
-        installFiles.add(norm)
-    else:
-      discard
-
-installFiles = rootInstallFiles
-for root in filteredInstallRoots:
-  collectInstallFiles(root)
+skipFiles = @[
+  "extras.nim",
+  "generate_lsquic_ffi.nim",
+  "build.sh",
+  "libs/vac_boringssl/ssl/ssl_c_test.c",
+  "libs/vac_boringssl/ssl/ssl_internal_test.cc",
+  "libs/vac_boringssl/ssl/ssl_test.cc",
+  "libs/vac_boringssl/ssl/span_test.cc",
+]
 
 requires "nim >= 2.0.0"
 requires "zlib"

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -55,6 +55,11 @@ skipFiles = @[
   "libs/vac_boringssl/ssl/span_test.cc",
 ]
 
+installFiles = @[
+  "lsquic.nim",
+  "boringssl.nim",
+]
+
 requires "nim >= 2.0.0"
 requires "zlib"
 requires "stew >= 0.4.0"


### PR DESCRIPTION
This is because otherwise, with latest nimble, you can end up exceeding 260 characters, thus ending up with an error due to path being too long