### PR TITLE
fix: shutdown and stream lifecycle handling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check NPH formatting
         uses: arnetheduck/nph-action@v1
         with:
-          version: 0.6.1
+          version: 0.7.0
           options: "./. *.nim*"
           fail: true
           suggest: true

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -164,26 +164,24 @@ proc toJson*(r: RunResult): JsonNode =
             "cumulative_bytes": s.cumulativeBytes,
           }
         )
-      var streamNode =
-        %*{
-          "upload_bytes": sr.uploadBytes,
-          "download_bytes": sr.downloadBytes,
-          "duration_ns": sr.durationNs,
-          "latency_samples_ns": latArr,
-        }
+      var streamNode = %*{
+        "upload_bytes": sr.uploadBytes,
+        "download_bytes": sr.downloadBytes,
+        "duration_ns": sr.durationNs,
+        "latency_samples_ns": latArr,
+      }
       if sr.rampUpSamples.len > 0:
         streamNode["ramp_up_samples"] = rampArr
         streamNode["time_to_p90_ns"] = %sr.timeToP90Ns
       streamArr.add(streamNode)
     connArr.add(%*{"streams": streamArr, "duration_ns": cr.durationNs})
-  result =
-    %*{
-      "mode": $r.mode,
-      "connections": r.connections,
-      "streams_per_conn": r.streamsPerConn,
-      "upload_size": r.uploadSize,
-      "download_size": r.downloadSize,
-      "chunk_size": r.chunkSize,
-      "duration_ns": r.durationNs,
-      "connections_results": connArr,
-    }
+  result = %*{
+    "mode": $r.mode,
+    "connections": r.connections,
+    "streams_per_conn": r.streamsPerConn,
+    "upload_size": r.uploadSize,
+    "download_size": r.downloadSize,
+    "chunk_size": r.chunkSize,
+    "duration_ns": r.durationNs,
+    "connections_results": connArr,
+  }

--- a/lsquic/certificates.nim
+++ b/lsquic/certificates.nim
@@ -6,13 +6,16 @@ import ./lsquic_ffi
 import ./helpers/sequninit
 
 proc x509toDERBytes*(cert: ptr X509): Opt[seq[byte]] =
+  if cert.isNil:
+    return Opt.none(seq[byte])
+
   let derBuf: ptr uint8 = nil
   let derLen = i2d_X509(cert, addr derBuf)
   defer:
     if derBuf != nil:
       OPENSSL_free(derBuf)
 
-  if derLen != 0:
+  if derLen > 0:
     let outp = newSeqUninit[byte](derLen)
     copyMem(addr outp[0], derBuf, derLen)
     return Opt.some(outp)

--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -84,11 +84,15 @@ proc stop*(self: QuicClient) {.async: (raises: [CancelledError]).} =
   # lsquic engine. Maybe there's a callback that one can hook to and safely
   # stop the udp transport.
   await noCancel sleepAsync(300.milliseconds)
+  if not self.ctx4.isNil:
+    self.ctx4.stop()
+  if not self.ctx6.isNil:
+    self.ctx6.stop()
   if not self.udp4.isNil:
     await noCancel self.udp4.closeWait()
   if not self.ctx4.isNil:
-    self.ctx4.stop()
+    self.ctx4.destroy()
   if not self.udp6.isNil:
     await noCancel self.udp6.closeWait()
   if not self.ctx6.isNil:
-    self.ctx6.stop()
+    self.ctx6.destroy()

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -124,6 +124,7 @@ proc openStream*(
     connection.quicContext.processWhenReady()
   let created = connection.quicConn.addPendingStream(s)
   connection.quicContext.makeStream(connection.quicConn)
+  connection.quicContext.processWhenReady()
   await created
   s
 

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -104,6 +104,7 @@ method dial*(
     0,
   )
   if conn.isNil:
+    GC_unref(quicClientConn)
     return err("could not dial: " & $remote)
 
   quicClientConn.lsquicConn = conn
@@ -116,6 +117,7 @@ const Adaptive = 3
 proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
   var ctx = ClientContext()
   ctx.tlsConfig = tlsConfig
+  ctx.running = true
   ctx.setupSSLContext()
 
   lsquic_engine_init_settings(addr ctx.settings, 0)

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -70,7 +70,7 @@ proc destroy*(ctx: QuicContext) {.raises: [].} =
   if not ctx.engine.isNil:
     lsquic_engine_destroy(ctx.engine)
     ctx.engine = nil
-    
+
   if not ctx.sslCtx.isNil:
     SSL_CTX_free(ctx.sslCtx)
     ctx.sslCtx = nil

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -23,8 +23,11 @@ type QuicContext* = ref object of RootObj
   processing: bool
   running*: bool
 
+proc isRunning*(ctx: QuicContext): bool {.raises: [].} =
+  not ctx.isNil and ctx.running and not ctx.engine.isNil
+
 proc engine_process*(ctx: QuicContext) =
-  if ctx.isNil or not ctx.running or ctx.engine.isNil:
+  if not ctx.isRunning():
     return
 
   if ctx.processing:
@@ -52,15 +55,12 @@ proc engine_process*(ctx: QuicContext) =
 proc stop*(ctx: QuicContext) {.raises: [].} =
   ## Quiesce the context before closing the UDP transport so late datagrams and
   ## timer callbacks cannot enter the native engine.
-  if ctx.isNil or not ctx.running:
+  if not ctx.isRunning():
     return
 
   ctx.running = false
   if not ctx.tickTimeout.isNil:
     ctx.tickTimeout.stop()
-
-proc isRunning*(ctx: QuicContext): bool {.raises: [].} =
-  not ctx.isNil and ctx.running and not ctx.engine.isNil
 
 proc destroy*(ctx: QuicContext) {.raises: [].} =
   ## Release native resources after the UDP transport has been closed.

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -129,8 +129,17 @@ proc popPendingStream*(
   Opt.some(pending.stream)
 
 proc cancelPending*(quicConn: QuicConnection) =
-  for pending in quicConn.pendingStreams:
-    pending.created.fail(newException(ConnectionError, "can't open new streams"))
+  while quicConn.pendingStreams.len > 0:
+    let pending = quicConn.pendingStreams.popFirst()
+    if not pending.created.finished:
+      pending.created.fail(newException(ConnectionError, "can't open new streams"))
+
+    pending.stream.closedByEngine = true
+    pending.stream.closeWrite = true
+    pending.stream.isEof = true
+    if not pending.stream.closed.isSet():
+      pending.stream.closed.fire()
+    GC_unref(pending.stream)
 
 proc alpnSelectProtoCB(
     ssl: ptr SSL,

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -21,9 +21,10 @@ type QuicContext* = ref object of RootObj
   sslCtx*: ptr SSL_CTX
   fd*: cint
   processing: bool
+  running*: bool
 
 proc engine_process*(ctx: QuicContext) =
-  if ctx.isNil or ctx.engine.isNil:
+  if ctx.isNil or not ctx.running or ctx.engine.isNil:
     return
 
   if ctx.processing:
@@ -47,6 +48,32 @@ proc engine_process*(ctx: QuicContext) =
   let delta =
     if diff < 0: LSQUIC_DF_CLOCK_GRANULARITY.microseconds else: diff.microseconds
   ctx.tickTimeout.set(delta)
+
+proc stop*(ctx: QuicContext) {.raises: [].} =
+  ## Quiesce the context before closing the UDP transport so late datagrams and
+  ## timer callbacks cannot enter the native engine.
+  if ctx.isNil or not ctx.running:
+    return
+
+  ctx.running = false
+  if not ctx.tickTimeout.isNil:
+    ctx.tickTimeout.stop()
+
+proc isRunning*(ctx: QuicContext): bool {.raises: [].} =
+  not ctx.isNil and ctx.running and not ctx.engine.isNil
+
+proc destroy*(ctx: QuicContext) {.raises: [].} =
+  ## Release native resources after the UDP transport has been closed.
+  if ctx.isNil:
+    return
+
+  if not ctx.engine.isNil:
+    lsquic_engine_destroy(ctx.engine)
+    ctx.engine = nil
+    
+  if not ctx.sslCtx.isNil:
+    SSL_CTX_free(ctx.sslCtx)
+    ctx.sslCtx = nil
 
 type PendingStream = object
   stream: Stream
@@ -213,27 +240,13 @@ proc getSSLCtx*(peer_ctx: pointer, sockaddr: ptr SockAddr): ptr SSL_CTX {.cdecl.
   let quicCtx = cast[QuicContext](peer_ctx)
   quicCtx.sslCtx
 
-proc stop*(ctx: QuicContext) {.raises: [].} =
-  if not ctx.tickTimeout.isNil:
-    ctx.tickTimeout.stop()
-  if not ctx.engine.isNil:
-    lsquic_engine_destroy(ctx.engine)
-    ctx.engine = nil
-  if not ctx.sslCtx.isNil:
-    SSL_CTX_free(ctx.sslCtx)
-    ctx.sslCtx = nil
-
 proc close*(ctx: QuicContext, conn: QuicConnection) =
-  if ctx.isNil or ctx.engine.isNil:
-    return
-  if conn != nil and conn.lsquicConn != nil:
+  if ctx.isRunning() and conn != nil and conn.lsquicConn != nil:
     lsquic_conn_close(conn.lsquicConn)
     ctx.processWhenReady()
 
 proc abort*(ctx: QuicContext, conn: QuicConnection) =
-  if ctx.isNil or ctx.engine.isNil:
-    return
-  if conn != nil and conn.lsquicConn != nil:
+  if ctx.isRunning() and conn != nil and conn.lsquicConn != nil:
     lsquic_conn_abort(conn.lsquicConn)
     ctx.processWhenReady()
 
@@ -250,7 +263,7 @@ proc makeStream*(
     ctx: QuicContext, quicConn: QuicConnection
 ) {.raises: [ConnectionClosedError].} =
   debug "Creating stream"
-  if ctx.isNil or ctx.engine.isNil or quicConn.isNil or quicConn.lsquicConn.isNil:
+  if not ctx.isRunning() or quicConn.isNil or quicConn.lsquicConn.isNil:
     debug "Cannot create stream: connection is nil"
     raise newException(ConnectionClosedError, "connection closed")
   lsquic_conn_make_stream(quicConn.lsquicConn)

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -59,7 +59,7 @@ proc receive*(
     local: TransportAddress,
     remote: TransportAddress,
 ) =
-  if ctx.isNil or ctx.engine.isNil or datagram.len == 0:
+  if datagram.len == 0 or not ctx.isRunning():
     return
 
   var

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -42,6 +42,7 @@ proc onConnClosed(conn: ptr lsquic_conn_t) {.cdecl.} =
   let conn_ctx = lsquic_conn_get_ctx(conn)
   if not conn_ctx.isNil:
     let quicConn = cast[QuicConnection](conn_ctx)
+    quicConn.cancelPending()
     quicConn.onClose()
     quicConn.lsquicConn = nil
     GC_unref(quicConn)
@@ -53,6 +54,7 @@ const Adaptive = 3
 proc new*(T: typedesc[ServerContext], tlsConfig: TLSConfig): Result[T, string] =
   var ctx = ServerContext()
   ctx.tlsConfig = tlsConfig
+  ctx.running = true
   ctx.incoming = newAsyncQueue[QuicConnection]()
   ctx.setupSSLContext()
 

--- a/lsquic/context/stream.nim
+++ b/lsquic/context/stream.nim
@@ -62,6 +62,10 @@ proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.
   if n == 0:
     streamCtx.isEof = true
 
+  if lsquic_stream_wantread(stream, 0) == -1:
+    error "could not set stream wantread", streamId = lsquic_stream_id(stream)
+    streamCtx.abort()
+
   task.doneFut.complete(int(n))
 
   streamCtx.toRead = Opt.none(ReadTask)
@@ -70,7 +74,7 @@ proc onWrite*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
   trace "onWrite"
 
   if ctx.isNil:
-    debug "stream_ctx is nil onClose"
+    debug "stream_ctx is nil onWrite"
     return
 
   let streamCtx = cast[Stream](ctx)

--- a/lsquic/helpers/transportaddr.nim
+++ b/lsquic/helpers/transportaddr.nim
@@ -23,7 +23,7 @@ proc sockAddrLen*(family: int): SockLen {.inline.} =
   of fixed_AF_INET6.int: # use fixed const
     sizeof(Sockaddr_in6).uint32
   else:
-    raiseAssert "invalid socket address faimily"
+    raiseAssert "invalid socket address family"
 
 proc toTransportAddress*(sock: ptr SockAddr): TransportAddress =
   var destAddress: Sockaddr_storage

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -33,7 +33,7 @@ proc newListener*(
       let datagram = Datagram(data: udp.getMessage())
       quicContext.receive(datagram, udp.localAddress(), remote)
     except TransportError as e:
-      error "Unexpect transport error", errorMsg = e.msg
+      error "Unexpected transport error", errorMsg = e.msg
 
   var udp: DatagramTransport
   case address.family
@@ -85,8 +85,9 @@ proc stop*(listener: Listener) {.async: (raises: [CancelledError]).} =
   # lsquic engine. Maybe there's a callback that one can hook to and safely
   # stop the udp transport.
   await noCancel sleepAsync(300.milliseconds)
-  await noCancel listener.udp.closeWait()
   listener.quicContext.stop()
+  await noCancel listener.udp.closeWait()
+  listener.quicContext.destroy()
 
 proc listen*(
     self: QuicServer, address: TransportAddress

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -83,8 +83,11 @@ proc close*(stream: Stream) {.async: (raises: [StreamError, CancelledError]).} =
         raise newException(StreamError, "could not close the stream")
       stream.doProcess()
 
-    stream.abortPendingWrites("steam closed")
+    stream.abortPendingWrites("stream closed")
     stream.closeWrite = true
+  else:
+    raise newException(StreamError, "could not close the stream")
+
 
 proc readOnce*(
     stream: Stream, dst: ptr byte, dstLen: int
@@ -172,20 +175,22 @@ proc write*(
   if n >= data.len:
     if lsquic_stream_flush(stream.quicStream) != 0:
       stream.abort()
-    else:
-      stream.doProcess()
+      raise newException(StreamError, "could not flush stream")
+    stream.doProcess()
     return
   elif n < 0:
     error "could not write to stream", streamId = lsquic_stream_id(stream.quicStream), n
     raise newException(StreamError, "could not write")
 
   # Enqueue otherwise
+  if lsquic_stream_wantwrite(stream.quicStream, 1) == -1:
+    stream.abort()
+    raise newException(StreamError, "could not set wantwrite")
+
   let doneFut = Future[void].Raising([CancelledError, StreamError]).init("Stream.write")
   stream.toWrite = Opt.some(
     WriteTask(data: data[0].addr, dataLen: data.len, doneFut: doneFut, offset: n)
   )
-
-  discard lsquic_stream_wantwrite(stream.quicStream, 1)
 
   stream.doProcess()
 

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -88,7 +88,6 @@ proc close*(stream: Stream) {.async: (raises: [StreamError, CancelledError]).} =
   else:
     raise newException(StreamError, "could not close the stream")
 
-
 proc readOnce*(
     stream: Stream, dst: ptr byte, dstLen: int
 ): Future[int] {.async: (raises: [CancelledError, StreamError]).} =

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -198,12 +198,11 @@ suite "lifecycle":
     check (await stream.readOnce(empty)) == 0
 
   asyncTest "late datagrams are ignored after context stops":
-    let verifier: CertificateVerifier =
-      CustomCertificateVerifier.init(
-        proc(serverName: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
-          discard serverName
-          derCertificates.len > 0
-      )
+    let verifier: CertificateVerifier = CustomCertificateVerifier.init(
+      proc(serverName: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
+        discard serverName
+        derCertificates.len > 0
+    )
     let tlsConfig = TLSConfig.new(
       testCertificate(), testPrivateKey(), @["test"].toHashSet(), Opt.some(verifier)
     )

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -3,9 +3,12 @@
 
 {.used.}
 
+import std/sets
 import chronos, chronos/unittest2/asynctests, results, chronicles
 import lsquic
-import ./helpers/[clientserver, stream]
+import lsquic/[datagram]
+import lsquic/context/[client, context, io]
+import ./helpers/[certificate, clientserver, stream]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -193,3 +196,26 @@ suite "lifecycle":
     var empty: seq[byte] = @[]
 
     check (await stream.readOnce(empty)) == 0
+
+  asyncTest "late datagrams are ignored after context stops":
+    let verifier: CertificateVerifier =
+      CustomCertificateVerifier.init(
+        proc(serverName: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
+          discard serverName
+          derCertificates.len > 0
+      )
+    let tlsConfig = TLSConfig.new(
+      testCertificate(), testPrivateKey(), @["test"].toHashSet(), Opt.some(verifier)
+    )
+    let ctx = ClientContext.new(tlsConfig).valueOr:
+      raiseAssert error
+    let local = initTAddress("127.0.0.1:12345")
+    let remote = initTAddress("127.0.0.1:54321")
+
+    ctx.stop()
+    ctx.receive(Datagram(data: @[1'u8, 2, 3]), local, remote)
+    ctx.processWhenReady()
+
+    ctx.destroy()
+    ctx.receive(Datagram(data: @[4'u8, 5, 6]), local, remote)
+    ctx.processWhenReady()

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -115,6 +115,21 @@ suite "lifecycle":
     expect ConnectionClosedError:
       discard await incomingWaiting
 
+  asyncTest "cancel pending outgoing streams clears queue":
+    let quicConn = QuicConnection(incoming: newAsyncQueue[Stream]())
+    let stream1 = Stream.new()
+    let stream2 = Stream.new()
+    let pending1 = quicConn.addPendingStream(stream1)
+    let pending2 = quicConn.addPendingStream(stream2)
+
+    quicConn.cancelPending()
+
+    expect ConnectionError:
+      await pending1
+    expect ConnectionError:
+      await pending2
+    check quicConn.popPendingStream(nil).isNone()
+
   asyncTest "abort after open stream still closes connection":
     let peers = await connectPeers()
     defer:

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -7,6 +7,7 @@ import std/sets
 import results
 import unittest2
 import lsquic
+import lsquic/certificates
 import lsquic/lsquic_ffi
 import ./helpers/certificate
 
@@ -40,7 +41,14 @@ suite "tls config":
       nil
     check not cert.isNil
     if not cert.isNil:
+      check cert.x509toDERBytes().isSome()
+    if not cert.isNil:
       X509_free(cert)
+
+  test "nil x509 DER conversion is rejected":
+    let cert: ptr X509 = nil
+
+    check cert.x509toDERBytes().isNone()
 
   test "valid pem key parses":
     let parsed = testPrivateKey().toPKey()


### PR DESCRIPTION
Improves QUIC context shutdown safety and stream lifecycle behavior. 

- Added explicit QUIC context running state.
- Split context shutdown from native resource destruction.
- Ignored late datagrams after context shutdown starts.
- Guarded engine operations when the context is no longer running.
- Fixed pending stream cleanup on server connection close.
- Improved stream EOF, blocked read, write, and flush error handling.
- Released GC refs when client dial creation fails.
- Fixed certificate DER conversion for nil/invalid X509 values.
- Added lifecycle and TLS coverage for the new shutdown and stream edge cases.