### PR TITLE
fix: handle closed accepts and client redials

### DIFF
--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -1,5 +1,5 @@
 packageName = "lsquic"
-version = "0.4.2"
+version = "0.4.3"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -109,6 +109,7 @@ method dial*(
     return err("could not dial: " & $remote)
 
   quicClientConn.lsquicConn = conn
+  ctx.processWhenReady()
 
   ok(quicClientConn)
 

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -58,19 +58,24 @@ proc waitForIncoming(
 proc accept*(
     listener: Listener
 ): Future[Connection] {.async: (raises: [CancelledError, TransportError]).} =
-  let
-    incomingFut = listener.waitForIncoming()
-    closedFut = listener.connman.closed
-    raceFut = await race(closedFut, incomingFut)
+  while true:
+    let
+      incomingFut = listener.waitForIncoming()
+      closedFut = listener.connman.closed
+      raceFut = await race(closedFut, incomingFut)
 
-  if raceFut == closedFut:
-    await incomingFut.cancelAndWait()
-    raise newException(TransportError, "listener is stopped")
+    if raceFut == closedFut:
+      await incomingFut.cancelAndWait()
+      raise newException(TransportError, "listener is stopped")
 
-  let quicConn = await incomingFut
-  let conn = newIncomingConnection(listener.quicContext, quicConn)
-  listener.connman.addConnection(conn)
-  conn
+    let quicConn = await incomingFut
+    if quicConn.lsquicConn.isNil:
+      debug "Dropping already closed incoming connection"
+      continue
+
+    let conn = newIncomingConnection(listener.quicContext, quicConn)
+    listener.connman.addConnection(conn)
+    return conn
 
 proc localAddress*(
     listener: Listener

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -77,12 +77,11 @@ suite "lifecycle":
     check (await peers.incoming.closedFuture().withTimeout(2.seconds))
     check peers.incoming.isClosed
 
-  asyncTest "accept skips connections closed before wrapping":
+  asyncTest "accept skips closed connection and client redials":
     let server = makeServer()
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     let address = listener.localAddress()
-    let staleClient = makeClient()
-    let goodClient = makeClient()
+    let client = makeClient()
     var accepted: Future[Connection]
     var incomingStream: Future[Stream]
     defer:
@@ -90,14 +89,14 @@ suite "lifecycle":
         await accepted.cancelAndWait()
       if not incomingStream.isNil and not incomingStream.finished:
         await incomingStream.cancelAndWait()
-      await allFutures(staleClient.stop(), goodClient.stop(), listener.stop())
+      await allFutures(client.stop(), listener.stop())
 
-    let stale = await staleClient.dial(address)
+    let stale = await client.dial(address)
     stale.abort()
     check (await stale.closedFuture().withTimeout(2.seconds))
 
     accepted = listener.accept()
-    let outgoing = await goodClient.dial(address)
+    let outgoing = await client.dial(address)
     check (await accepted.withTimeout(2.seconds))
     let incoming = await accepted
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -77,6 +77,45 @@ suite "lifecycle":
     check (await peers.incoming.closedFuture().withTimeout(2.seconds))
     check peers.incoming.isClosed
 
+  asyncTest "accept skips connections closed before wrapping":
+    let server = makeServer()
+    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let address = listener.localAddress()
+    let staleClient = makeClient()
+    let goodClient = makeClient()
+    var accepted: Future[Connection]
+    var incomingStream: Future[Stream]
+    defer:
+      if not accepted.isNil and not accepted.finished:
+        await accepted.cancelAndWait()
+      if not incomingStream.isNil and not incomingStream.finished:
+        await incomingStream.cancelAndWait()
+      await allFutures(staleClient.stop(), goodClient.stop(), listener.stop())
+
+    let stale = await staleClient.dial(address)
+    stale.abort()
+    check (await stale.closedFuture().withTimeout(2.seconds))
+
+    accepted = listener.accept()
+    let outgoing = await goodClient.dial(address)
+    check (await accepted.withTimeout(2.seconds))
+    let incoming = await accepted
+
+    incomingStream = incoming.incomingStream()
+    let outgoingStream = await outgoing.openStream()
+    await outgoingStream.write(@[1'u8])
+    check (await incomingStream.withTimeout(2.seconds))
+
+    let acceptedStream = await incomingStream
+    var buf = newSeq[byte](1)
+    check (await acceptedStream.readOnce(buf)) == 1
+    check buf[0] == 1
+
+    await outgoingStream.close()
+    await acceptedStream.close()
+    outgoing.close()
+    incoming.close()
+
   asyncTest "client stop closes active connections":
     let peers = await connectPeers()
 


### PR DESCRIPTION
## Summary
- skip already closed incoming connections in Listener.accept()
- process the client engine immediately after lsquic_engine_connect()
- add a lifecycle regression covering closed accept queue cleanup plus same-client redial
- bump package version to 0.4.3

## Validation
- nimble test