### PR TITLE
feat: add shared socket endpoint

### DIFF
--- a/benchmarks/bench_client.nim
+++ b/benchmarks/bench_client.nim
@@ -109,7 +109,7 @@ proc runLatencyStream(conn: Connection, runs: int): Future[StreamResult] {.async
 proc modeThroughput(
     serverAddr: TransportAddress, uploadSize, downloadSize, chunkSize, runs: int
 ): Future[RunResult] {.async.} =
-  var result = RunResult(
+  var runResult = RunResult(
     mode: Throughput,
     connections: 1,
     streamsPerConn: 1,
@@ -128,17 +128,17 @@ proc modeThroughput(
     connRes.streamResults.add(sr)
 
   connRes.durationNs = (Moment.now() - start).nanoseconds
-  result.connResults.add(connRes)
-  result.durationNs = connRes.durationNs
+  runResult.connResults.add(connRes)
+  runResult.durationNs = connRes.durationNs
 
   conn.close()
   await client.stop()
-  return result
+  return runResult
 
 # -- Mode: latency (1 conn, 1 stream) --
 
 proc modeLatency(serverAddr: TransportAddress, runs: int): Future[RunResult] {.async.} =
-  var result = RunResult(mode: Latency, connections: 1, streamsPerConn: 1)
+  var runResult = RunResult(mode: Latency, connections: 1, streamsPerConn: 1)
 
   let client = makeClient()
   let conn = await client.dial(serverAddr)
@@ -148,12 +148,12 @@ proc modeLatency(serverAddr: TransportAddress, runs: int): Future[RunResult] {.a
   let sr = await runLatencyStream(conn, runs)
   connRes.streamResults.add(sr)
   connRes.durationNs = (Moment.now() - start).nanoseconds
-  result.connResults.add(connRes)
-  result.durationNs = connRes.durationNs
+  runResult.connResults.add(connRes)
+  runResult.durationNs = connRes.durationNs
 
   conn.close()
   await client.stop()
-  return result
+  return runResult
 
 # -- Mode: multistream (1 conn, K streams) --
 
@@ -161,7 +161,7 @@ proc modeMultiStream(
     serverAddr: TransportAddress,
     numStreams, uploadSize, downloadSize, chunkSize, runs: int,
 ): Future[RunResult] {.async.} =
-  var result = RunResult(
+  var runResult = RunResult(
     mode: MultiStream,
     connections: 1,
     streamsPerConn: numStreams,
@@ -191,12 +191,12 @@ proc modeMultiStream(
       connRes.streamResults.add(sr)
 
   connRes.durationNs = (Moment.now() - start).nanoseconds
-  result.connResults.add(connRes)
-  result.durationNs = connRes.durationNs
+  runResult.connResults.add(connRes)
+  runResult.durationNs = connRes.durationNs
 
   conn.close()
   await client.stop()
-  return result
+  return runResult
 
 # -- Mode: multiconn (N conns, 1 stream each) --
 
@@ -204,7 +204,7 @@ proc modeMultiConn(
     serverAddr: TransportAddress,
     numConns, uploadSize, downloadSize, chunkSize, runs: int,
 ): Future[RunResult] {.async.} =
-  var result = RunResult(
+  var runResult = RunResult(
     mode: MultiConn,
     connections: numConns,
     streamsPerConn: 1,
@@ -235,22 +235,22 @@ proc modeMultiConn(
 
     for i, f in futs:
       let sr = await f
-      # Associate with the right connection result
-      while result.connResults.len <= i:
-        result.connResults.add(ConnectionResult())
-      result.connResults[i].streamResults.add(sr)
+      # Associate with the right connection metrics
+      while runResult.connResults.len <= i:
+        runResult.connResults.add(ConnectionResult())
+      runResult.connResults[i].streamResults.add(sr)
 
   let totalDur = (Moment.now() - start).nanoseconds
-  for cr in result.connResults.mitems:
+  for cr in runResult.connResults.mitems:
     cr.durationNs = totalDur
-  result.durationNs = totalDur
+  runResult.durationNs = totalDur
 
   for conn in conns:
     conn.close()
   for client in clients:
     await client.stop()
 
-  return result
+  return runResult
 
 # -- Mode: stress (N conns, K streams each) --
 
@@ -258,7 +258,7 @@ proc modeStress(
     serverAddr: TransportAddress,
     numConns, numStreams, uploadSize, downloadSize, chunkSize, runs: int,
 ): Future[RunResult] {.async.} =
-  var result = RunResult(
+  var runResult = RunResult(
     mode: Stress,
     connections: numConns,
     streamsPerConn: numStreams,
@@ -293,24 +293,24 @@ proc modeStress(
       futConnIdx.add(ci)
 
     # Ensure we have connResults slots
-    while result.connResults.len < numConns:
-      result.connResults.add(ConnectionResult())
+    while runResult.connResults.len < numConns:
+      runResult.connResults.add(ConnectionResult())
 
     for i, f in allFuts:
       let sr = await f
-      result.connResults[futConnIdx[i]].streamResults.add(sr)
+      runResult.connResults[futConnIdx[i]].streamResults.add(sr)
 
   let totalDur = (Moment.now() - start).nanoseconds
-  for cr in result.connResults.mitems:
+  for cr in runResult.connResults.mitems:
     cr.durationNs = totalDur
-  result.durationNs = totalDur
+  runResult.durationNs = totalDur
 
   for conn in conns:
     conn.close()
   for client in clients:
     await client.stop()
 
-  return result
+  return runResult
 
 # -- Mode: rampup (1 conn, 1 stream, measure throughput over time) --
 
@@ -321,7 +321,7 @@ const
 proc modeRampUp(
     serverAddr: TransportAddress, downloadSize: int, chunkSize: int
 ): Future[RunResult] {.async.} =
-  var result = RunResult(
+  var runResult = RunResult(
     mode: RampUp,
     connections: 1,
     streamsPerConn: 1,
@@ -417,24 +417,25 @@ proc modeRampUp(
 
   var connRes =
     ConnectionResult(streamResults: @[sr], durationNs: totalDuration.nanoseconds)
-  result.connResults.add(connRes)
-  result.durationNs = totalDuration.nanoseconds
+  runResult.connResults.add(connRes)
+  runResult.durationNs = totalDuration.nanoseconds
 
   conn.close()
   await client.stop()
-  return result
+  return runResult
 
 # -- Print results --
 
-proc printResults(result: RunResult) =
+proc printResults(runResult: RunResult) =
   echo ""
   echo "=== Benchmark Results ==="
-  echo "Mode: ", result.mode
-  echo "Connections: ", result.connections, ", Streams/conn: ", result.streamsPerConn
-  echo "Total duration: ", formatDuration(result.durationNs)
+  echo "Mode: ", runResult.mode
+  echo "Connections: ",
+    runResult.connections, ", Streams/conn: ", runResult.streamsPerConn
+  echo "Total duration: ", formatDuration(runResult.durationNs)
   echo ""
 
-  for ci, cr in result.connResults:
+  for ci, cr in runResult.connResults:
     echo "  Connection #", ci + 1, ":"
 
     for si, sr in cr.streamResults:

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -175,7 +175,7 @@ proc toJson*(r: RunResult): JsonNode =
         streamNode["time_to_p90_ns"] = %sr.timeToP90Ns
       streamArr.add(streamNode)
     connArr.add(%*{"streams": streamArr, "duration_ns": cr.durationNs})
-  result = %*{
+  var json = %*{
     "mode": $r.mode,
     "connections": r.connections,
     "streams_per_conn": r.streamsPerConn,
@@ -185,3 +185,4 @@ proc toJson*(r: RunResult): JsonNode =
     "duration_ns": r.durationNs,
     "connections_results": connArr,
   }
+  json

--- a/lsquic.nim
+++ b/lsquic.nim
@@ -2,8 +2,11 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import
-  ./lsquic/
-    [errors, client, server, connection, stream, lsquic, tlsconfig, certificateverifier]
+  ./lsquic/[
+    errors, endpoint, client, server, connection, stream, lsquic, tlsconfig,
+    certificateverifier,
+  ]
 
 export
-  errors, client, server, connection, stream, lsquic, tlsconfig, certificateverifier
+  errors, endpoint, client, server, connection, stream, lsquic, tlsconfig,
+  certificateverifier

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -1,5 +1,5 @@
 packageName = "lsquic"
-version = "0.4.3"
+version = "0.5.0"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"

--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -1,67 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import chronos, chronicles, results
-import ./[errors, connection, tlsconfig, datagram, connectionmanager]
-import ./context/[context, io, client]
+import chronos
+import ./[errors, connection, tlsconfig, endpoint]
 
 type QuicClient* = ref object of RootObj
-  connman: ConnectionManager
   tlsConfig: TLSConfig
-  ctx4: ClientContext
-  ctx6: ClientContext
-  udp4: DatagramTransport
-  udp6: DatagramTransport
+  endpoint4: QuicEndpoint
+  endpoint6: QuicEndpoint
 
 proc new*(t: typedesc[QuicClient], tlsConfig: TLSConfig): QuicClient {.raises: [].} =
-  QuicClient(tlsConfig: tlsConfig, connman: ConnectionManager.new())
+  QuicClient(tlsConfig: tlsConfig)
 
-proc createCtxUdp(
-    tlsConfig: TLSConfig, family: AddressFamily
-): (ClientContext, DatagramTransport) {.raises: [QuicError, TransportOsError].} =
-  let ctx = ClientContext.new(tlsConfig).valueOr:
-    raise newException(QuicError, error)
-
-  proc onReceive(
-      udp: DatagramTransport, remote: TransportAddress
-  ) {.async: (raises: []).} =
-    try:
-      let datagram = Datagram(data: udp.getMessage())
-      ctx.receive(datagram, udp.localAddress(), remote)
-    except TransportError as e:
-      error "Unexpected transport error", errorMsg = e.msg
-
-  let udp =
-    case family
-    of AddressFamily.IPv4:
-      newDatagramTransport(onReceive)
-    of AddressFamily.IPv6:
-      newDatagramTransport6(onReceive)
-    else:
-      raise newException(QuicError, "client supports only IPv4/IPv6 address")
-
-  ctx.fd = cint(udp.fd)
-
-  return (ctx, udp)
-
-proc getCtxUdp(
+proc getEndpoint(
     self: QuicClient, family: AddressFamily
-): (ClientContext, DatagramTransport) {.raises: [QuicError, TransportOsError].} =
+): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
   case family
   of AddressFamily.IPv4:
-    if self.udp4.isNil:
-      let (ctx, udp) = createCtxUdp(self.tlsConfig, family)
-      self.udp4 = udp
-      self.ctx4 = ctx
+    if self.endpoint4.isNil:
+      self.endpoint4 = QuicEndpoint.new(self.tlsConfig, family)
 
-    return (self.ctx4, self.udp4)
+    return self.endpoint4
   of AddressFamily.IPv6:
-    if self.udp6.isNil:
-      let (ctx, udp) = createCtxUdp(self.tlsConfig, family)
-      self.udp6 = udp
-      self.ctx6 = ctx
+    if self.endpoint6.isNil:
+      self.endpoint6 = QuicEndpoint.new(self.tlsConfig, family)
 
-    return (self.ctx6, self.udp6)
+    return self.endpoint6
   else:
     raise newException(QuicError, "client supports only IPv4/IPv6 address")
 
@@ -70,29 +34,12 @@ proc dial*(
 ): Future[Connection] {.
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
-  let (ctx, udp) = self.getCtxUdp(address.family)
-  let connection = newOutgoingConnection(ctx, udp.localAddress, address)
-  self.connman.addConnection(connection)
-  await connection.dial()
-  connection
+  await self.getEndpoint(address.family).dial(address)
 
 proc stop*(self: QuicClient) {.async: (raises: [CancelledError]).} =
-  await noCancel self.connman.stop()
-  # Politely wait before closing udp so connections closure go out
-  # TODO: this should be ~ 3 times the PTO.
-  # Find out if it's possible to react to shutting down the context and
-  # lsquic engine. Maybe there's a callback that one can hook to and safely
-  # stop the udp transport.
-  await noCancel sleepAsync(300.milliseconds)
-  if not self.ctx4.isNil:
-    self.ctx4.stop()
-  if not self.ctx6.isNil:
-    self.ctx6.stop()
-  if not self.udp4.isNil:
-    await noCancel self.udp4.closeWait()
-  if not self.ctx4.isNil:
-    self.ctx4.destroy()
-  if not self.udp6.isNil:
-    await noCancel self.udp6.closeWait()
-  if not self.ctx6.isNil:
-    self.ctx6.destroy()
+  if not self.endpoint4.isNil:
+    await noCancel self.endpoint4.stop()
+  if not self.endpoint6.isNil:
+    await noCancel self.endpoint6.stop()
+  self.endpoint4 = nil
+  self.endpoint6 = nil

--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -6,8 +6,8 @@ import ./[errors, connection, tlsconfig, endpoint]
 
 type QuicClient* = ref object of RootObj
   tlsConfig: TLSConfig
-  endpoint4: QuicEndpoint
-  endpoint6: QuicEndpoint
+  ip4Endpoint: QuicEndpoint
+  ip6Endpoint: QuicEndpoint
 
 proc new*(t: typedesc[QuicClient], tlsConfig: TLSConfig): QuicClient {.raises: [].} =
   QuicClient(tlsConfig: tlsConfig)
@@ -17,15 +17,15 @@ proc getEndpoint(
 ): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
   case family
   of AddressFamily.IPv4:
-    if self.endpoint4.isNil:
-      self.endpoint4 = QuicEndpoint.new(self.tlsConfig, family)
+    if self.ip4Endpoint.isNil:
+      self.ip4Endpoint = QuicEndpoint.new(self.tlsConfig, family)
 
-    return self.endpoint4
+    return self.ip4Endpoint
   of AddressFamily.IPv6:
-    if self.endpoint6.isNil:
-      self.endpoint6 = QuicEndpoint.new(self.tlsConfig, family)
+    if self.ip6Endpoint.isNil:
+      self.ip6Endpoint = QuicEndpoint.new(self.tlsConfig, family)
 
-    return self.endpoint6
+    return self.ip6Endpoint
   else:
     raise newException(QuicError, "client supports only IPv4/IPv6 address")
 
@@ -37,9 +37,11 @@ proc dial*(
   await self.getEndpoint(address.family).dial(address)
 
 proc stop*(self: QuicClient) {.async: (raises: [CancelledError]).} =
-  if not self.endpoint4.isNil:
-    await noCancel self.endpoint4.stop()
-  if not self.endpoint6.isNil:
-    await noCancel self.endpoint6.stop()
-  self.endpoint4 = nil
-  self.endpoint6 = nil
+  var stops: seq[Future[void]]
+  if not self.ip4Endpoint.isNil:
+    stops.add(noCancel self.ip4Endpoint.stop())
+  if not self.ip6Endpoint.isNil:
+    stops.add(noCancel self.ip6Endpoint.stop())
+  await allFutures(stops)
+  self.ip4Endpoint = nil
+  self.ip6Endpoint = nil

--- a/lsquic/connectionmanager.nim
+++ b/lsquic/connectionmanager.nim
@@ -23,7 +23,7 @@ proc stop*(connman: ConnectionManager) {.async: (raises: [CancelledError]).} =
   for conn in active:
     conn.abort()
 
-proc removeConnection(connman: ConnectionManager, conn: Connection) {.raises: [].} =
+proc removeConnection*(connman: ConnectionManager, conn: Connection) {.raises: [].} =
   for i in 0 ..< connman.connections.len:
     if connman.connections[i] == conn:
       let last = connman.connections.high

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -147,7 +147,7 @@ proc accept*(
 
     if raceFut == closedFut:
       await incomingFut.cancelAndWait()
-      raise newException(TransportError, "listener is stopped")
+      raise newException(TransportError, "endpoint is stopped")
 
     let quicConn = await incomingFut
     if quicConn.lsquicConn.isNil:

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import chronos, chronicles, results
+import ./[errors, connection, tlsconfig, datagram, connectionmanager]
+import ./context/[server, client, context, io]
+
+type
+  QuicEndpointCapability* = enum
+    CanListen
+    CanDial
+
+  QuicEndpointCapabilities* = set[QuicEndpointCapability]
+
+  QuicEndpoint* = ref object of RootObj
+    tlsConfig: TLSConfig
+    capabilities: QuicEndpointCapabilities
+    serverContext: ServerContext
+    clientContext: ClientContext
+    connman: ConnectionManager
+    udp: DatagramTransport
+    stopped: bool
+
+proc createServerContext(tlsConfig: TLSConfig): ServerContext {.raises: [QuicError].} =
+  ServerContext.new(tlsConfig).valueOr:
+    raise newException(QuicError, error)
+
+proc createClientContext(tlsConfig: TLSConfig): ClientContext {.raises: [QuicError].} =
+  ClientContext.new(tlsConfig).valueOr:
+    raise newException(QuicError, error)
+
+proc receiveDatagram(
+    endpoint: QuicEndpoint, data: seq[byte], local, remote: TransportAddress
+) {.raises: [].} =
+  if endpoint.isNil or endpoint.stopped:
+    return
+
+  if not endpoint.clientContext.isNil:
+    endpoint.clientContext.receive(Datagram(data: data), local, remote)
+  if not endpoint.serverContext.isNil:
+    endpoint.serverContext.receive(Datagram(data: data), local, remote)
+
+proc createUdp(
+    endpoint: QuicEndpoint, address: TransportAddress
+): DatagramTransport {.raises: [QuicError, TransportOsError].} =
+  proc onReceive(
+      udp: DatagramTransport, remote: TransportAddress
+  ) {.async: (raises: []).} =
+    try:
+      endpoint.receiveDatagram(udp.getMessage(), udp.localAddress(), remote)
+    except TransportError as e:
+      error "Unexpected transport error", errorMsg = e.msg
+
+  case address.family
+  of AddressFamily.IPv4:
+    newDatagramTransport(onReceive, local = address)
+  of AddressFamily.IPv6:
+    newDatagramTransport6(onReceive, local = address)
+  else:
+    raise newException(QuicError, "only IPv4/IPv6 address is supported")
+
+proc createUdp(
+    endpoint: QuicEndpoint, family: AddressFamily
+): DatagramTransport {.raises: [QuicError, TransportOsError].} =
+  proc onReceive(
+      udp: DatagramTransport, remote: TransportAddress
+  ) {.async: (raises: []).} =
+    try:
+      endpoint.receiveDatagram(udp.getMessage(), udp.localAddress(), remote)
+    except TransportError as e:
+      error "Unexpected transport error", errorMsg = e.msg
+
+  case family
+  of AddressFamily.IPv4:
+    newDatagramTransport(onReceive)
+  of AddressFamily.IPv6:
+    newDatagramTransport6(onReceive)
+  else:
+    raise newException(QuicError, "client supports only IPv4/IPv6 address")
+
+proc setContextFd(endpoint: QuicEndpoint) {.raises: [].} =
+  if not endpoint.serverContext.isNil:
+    endpoint.serverContext.fd = cint(endpoint.udp.fd)
+  if not endpoint.clientContext.isNil:
+    endpoint.clientContext.fd = cint(endpoint.udp.fd)
+
+proc new*(
+    _: type QuicEndpoint,
+    tlsConfig: TLSConfig,
+    address: TransportAddress,
+    capabilities: QuicEndpointCapabilities = {CanListen, CanDial},
+): QuicEndpoint {.raises: [QuicConfigError, QuicError, TransportOsError].} =
+  if CanListen in capabilities and tlsConfig.certificate.len == 0:
+    raise newException(QuicConfigError, "tlsConfig does not contain a certificate")
+
+  let serverContext =
+    if CanListen in capabilities:
+      createServerContext(tlsConfig)
+    else:
+      nil
+
+  result = QuicEndpoint(
+    tlsConfig: tlsConfig,
+    capabilities: capabilities,
+    serverContext: serverContext,
+    connman: ConnectionManager.new(),
+  )
+  result.udp = result.createUdp(address)
+  result.setContextFd()
+
+proc new*(
+    _: type QuicEndpoint, tlsConfig: TLSConfig, family: AddressFamily
+): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
+  result = QuicEndpoint(
+    tlsConfig: tlsConfig, capabilities: {CanDial}, connman: ConnectionManager.new()
+  )
+  result.udp = result.createUdp(family)
+
+proc ensureClientContext(
+    endpoint: QuicEndpoint
+): ClientContext {.raises: [QuicError].} =
+  if CanDial notin endpoint.capabilities:
+    raise newException(QuicError, "endpoint is not dial-capable")
+
+  if endpoint.clientContext.isNil:
+    endpoint.clientContext = createClientContext(endpoint.tlsConfig)
+    endpoint.clientContext.fd = cint(endpoint.udp.fd)
+
+  endpoint.clientContext
+
+proc waitForIncoming(
+    endpoint: QuicEndpoint
+): Future[QuicConnection] {.async: (raises: [CancelledError]).} =
+  await endpoint.serverContext.incoming.get()
+
+proc accept*(
+    endpoint: QuicEndpoint
+): Future[Connection] {.async: (raises: [CancelledError, TransportError]).} =
+  if endpoint.serverContext.isNil:
+    raise newException(TransportError, "endpoint is not listen-capable")
+
+  while true:
+    let
+      incomingFut = endpoint.waitForIncoming()
+      closedFut = endpoint.connman.closed
+      raceFut = await race(closedFut, incomingFut)
+
+    if raceFut == closedFut:
+      await incomingFut.cancelAndWait()
+      raise newException(TransportError, "listener is stopped")
+
+    let quicConn = await incomingFut
+    if quicConn.lsquicConn.isNil:
+      debug "Dropping already closed incoming connection"
+      continue
+
+    let conn = newIncomingConnection(endpoint.serverContext, quicConn)
+    endpoint.connman.addConnection(conn)
+    return conn
+
+proc dial*(
+    endpoint: QuicEndpoint, address: TransportAddress
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  let ctx = endpoint.ensureClientContext()
+  let connection = newOutgoingConnection(ctx, endpoint.udp.localAddress(), address)
+  endpoint.connman.addConnection(connection)
+  await connection.dial()
+  connection
+
+proc localAddress*(
+    endpoint: QuicEndpoint
+): TransportAddress {.raises: [TransportOsError].} =
+  endpoint.udp.localAddress()
+
+proc datagramTransport*(endpoint: QuicEndpoint): DatagramTransport {.raises: [].} =
+  endpoint.udp
+
+proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =
+  if endpoint.stopped:
+    return
+
+  endpoint.stopped = true
+  await noCancel endpoint.connman.stop()
+  # Politely wait before closing udp so connection close packets can be sent.
+  await noCancel sleepAsync(300.milliseconds)
+
+  if not endpoint.clientContext.isNil:
+    endpoint.clientContext.stop()
+  if not endpoint.serverContext.isNil:
+    endpoint.serverContext.stop()
+
+  await noCancel endpoint.udp.closeWait()
+
+  if not endpoint.clientContext.isNil:
+    endpoint.clientContext.destroy()
+    endpoint.clientContext = nil
+  if not endpoint.serverContext.isNil:
+    endpoint.serverContext.destroy()
+    endpoint.serverContext = nil

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -21,13 +21,23 @@ type
     udp: DatagramTransport
     stopped: bool
 
-proc createServerContext(tlsConfig: TLSConfig): ServerContext {.raises: [QuicError].} =
-  ServerContext.new(tlsConfig).valueOr:
-    raise newException(QuicError, error)
+const CloseWait: Duration = 300.milliseconds
 
-proc createClientContext(tlsConfig: TLSConfig): ClientContext {.raises: [QuicError].} =
-  ClientContext.new(tlsConfig).valueOr:
+proc createServerContext(
+    tlsConfig: TLSConfig, fd: cint
+): ServerContext {.raises: [QuicError].} =
+  var context = ServerContext.new(tlsConfig).valueOr:
     raise newException(QuicError, error)
+  context.fd = fd
+  context
+
+proc createClientContext(
+    tlsConfig: TLSConfig, fd: cint
+): ClientContext {.raises: [QuicError].} =
+  var context = ClientContext.new(tlsConfig).valueOr:
+    raise newException(QuicError, error)
+  context.fd = fd
+  context
 
 proc receiveDatagram(
     endpoint: QuicEndpoint, data: seq[byte], local, remote: TransportAddress
@@ -35,10 +45,19 @@ proc receiveDatagram(
   if endpoint.isNil or endpoint.stopped:
     return
 
+  # Endpoints can have both contexts; each engine needs to see the packet.
   if not endpoint.clientContext.isNil:
     endpoint.clientContext.receive(Datagram(data: data), local, remote)
   if not endpoint.serverContext.isNil:
     endpoint.serverContext.receive(Datagram(data: data), local, remote)
+
+proc receiveFromUdp(
+    endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress
+) {.raises: [].} =
+  try:
+    endpoint.receiveDatagram(udp.getMessage(), udp.localAddress(), remote)
+  except TransportError as e:
+    warn "Could not read received datagram", errorMsg = e.msg
 
 proc createUdp(
     endpoint: QuicEndpoint, address: TransportAddress
@@ -46,10 +65,7 @@ proc createUdp(
   proc onReceive(
       udp: DatagramTransport, remote: TransportAddress
   ) {.async: (raises: []).} =
-    try:
-      endpoint.receiveDatagram(udp.getMessage(), udp.localAddress(), remote)
-    except TransportError as e:
-      error "Unexpected transport error", errorMsg = e.msg
+    endpoint.receiveFromUdp(udp, remote)
 
   case address.family
   of AddressFamily.IPv4:
@@ -65,10 +81,7 @@ proc createUdp(
   proc onReceive(
       udp: DatagramTransport, remote: TransportAddress
   ) {.async: (raises: []).} =
-    try:
-      endpoint.receiveDatagram(udp.getMessage(), udp.localAddress(), remote)
-    except TransportError as e:
-      error "Unexpected transport error", errorMsg = e.msg
+    endpoint.receiveFromUdp(udp, remote)
 
   case family
   of AddressFamily.IPv4:
@@ -76,13 +89,7 @@ proc createUdp(
   of AddressFamily.IPv6:
     newDatagramTransport6(onReceive)
   else:
-    raise newException(QuicError, "client supports only IPv4/IPv6 address")
-
-proc setContextFd(endpoint: QuicEndpoint) {.raises: [].} =
-  if not endpoint.serverContext.isNil:
-    endpoint.serverContext.fd = cint(endpoint.udp.fd)
-  if not endpoint.clientContext.isNil:
-    endpoint.clientContext.fd = cint(endpoint.udp.fd)
+    raise newException(QuicError, "endpoint supports only IPv4/IPv6 address")
 
 proc new*(
     _: type QuicEndpoint,
@@ -93,28 +100,24 @@ proc new*(
   if CanListen in capabilities and tlsConfig.certificate.len == 0:
     raise newException(QuicConfigError, "tlsConfig does not contain a certificate")
 
-  let serverContext =
-    if CanListen in capabilities:
-      createServerContext(tlsConfig)
-    else:
-      nil
-
-  result = QuicEndpoint(
-    tlsConfig: tlsConfig,
-    capabilities: capabilities,
-    serverContext: serverContext,
-    connman: ConnectionManager.new(),
+  var endpoint = QuicEndpoint(
+    tlsConfig: tlsConfig, capabilities: capabilities, connman: ConnectionManager.new()
   )
-  result.udp = result.createUdp(address)
-  result.setContextFd()
+  endpoint.udp = endpoint.createUdp(address)
+
+  if CanListen in capabilities:
+    endpoint.serverContext = createServerContext(tlsConfig, cint(endpoint.udp.fd))
+
+  endpoint
 
 proc new*(
     _: type QuicEndpoint, tlsConfig: TLSConfig, family: AddressFamily
 ): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
-  result = QuicEndpoint(
+  var endpoint = QuicEndpoint(
     tlsConfig: tlsConfig, capabilities: {CanDial}, connman: ConnectionManager.new()
   )
-  result.udp = result.createUdp(family)
+  endpoint.udp = endpoint.createUdp(family)
+  endpoint
 
 proc ensureClientContext(
     endpoint: QuicEndpoint
@@ -123,8 +126,8 @@ proc ensureClientContext(
     raise newException(QuicError, "endpoint is not dial-capable")
 
   if endpoint.clientContext.isNil:
-    endpoint.clientContext = createClientContext(endpoint.tlsConfig)
-    endpoint.clientContext.fd = cint(endpoint.udp.fd)
+    endpoint.clientContext =
+      createClientContext(endpoint.tlsConfig, cint(endpoint.udp.fd))
 
   endpoint.clientContext
 
@@ -136,8 +139,11 @@ proc waitForIncoming(
 proc accept*(
     endpoint: QuicEndpoint
 ): Future[Connection] {.async: (raises: [CancelledError, TransportError]).} =
-  if endpoint.serverContext.isNil:
+  if CanListen notin endpoint.capabilities:
     raise newException(TransportError, "endpoint is not listen-capable")
+
+  if endpoint.stopped or endpoint.serverContext.isNil:
+    raise newException(TransportError, "endpoint is stopped")
 
   while true:
     let
@@ -166,7 +172,14 @@ proc dial*(
   let ctx = endpoint.ensureClientContext()
   let connection = newOutgoingConnection(ctx, endpoint.udp.localAddress(), address)
   endpoint.connman.addConnection(connection)
-  await connection.dial()
+  var connected = false
+  try:
+    await connection.dial()
+    connected = true
+  finally:
+    if not connected:
+      endpoint.connman.removeConnection(connection)
+
   connection
 
 proc localAddress*(
@@ -184,7 +197,7 @@ proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =
   endpoint.stopped = true
   await noCancel endpoint.connman.stop()
   # Politely wait before closing udp so connection close packets can be sent.
-  await noCancel sleepAsync(300.milliseconds)
+  await noCancel sleepAsync(CloseWait)
 
   if not endpoint.clientContext.isNil:
     endpoint.clientContext.stop()

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import chronos, chronicles, results
-import ./[errors, connection, tlsconfig, datagram, connectionmanager]
-import ./context/[server, context, io]
+import chronos, results
+import ./[errors, tlsconfig, endpoint]
 
 type QuicServer* = ref object of RootObj
   tlsConfig: TLSConfig
+
+type Listener* = QuicEndpoint
 
 proc new*(
     t: typedesc[QuicServer], tlsConfig: TLSConfig
@@ -16,83 +17,13 @@ proc new*(
 
   return QuicServer(tlsConfig: tlsConfig)
 
-type Listener* = ref object of RootObj
-  quicContext: ServerContext
-  connman: ConnectionManager
-  udp: DatagramTransport
-
 proc newListener*(
     tlsConfig: TLSConfig, address: TransportAddress
 ): Result[Listener, string] =
-  let quicContext = ?ServerContext.new(tlsConfig)
-
-  proc onReceive(
-      udp: DatagramTransport, remote: TransportAddress
-  ) {.async: (raises: []).} =
-    try:
-      let datagram = Datagram(data: udp.getMessage())
-      quicContext.receive(datagram, udp.localAddress(), remote)
-    except TransportError as e:
-      error "Unexpected transport error", errorMsg = e.msg
-
-  var udp: DatagramTransport
-  case address.family
-  of AddressFamily.IPv4:
-    udp = newDatagramTransport(onReceive, local = address)
-  of AddressFamily.IPv6:
-    udp = newDatagramTransport6(onReceive, local = address)
-  else:
-    return err("only IPv4/IPv6 address is supported")
-
-  let listener =
-    Listener(quicContext: quicContext, connman: ConnectionManager.new(), udp: udp)
-  quicContext.fd = cint(listener.udp.fd)
-
-  ok(listener)
-
-proc waitForIncoming(
-    listener: Listener
-): Future[QuicConnection] {.async: (raises: [CancelledError]).} =
-  await listener.quicContext.incoming.get()
-
-proc accept*(
-    listener: Listener
-): Future[Connection] {.async: (raises: [CancelledError, TransportError]).} =
-  while true:
-    let
-      incomingFut = listener.waitForIncoming()
-      closedFut = listener.connman.closed
-      raceFut = await race(closedFut, incomingFut)
-
-    if raceFut == closedFut:
-      await incomingFut.cancelAndWait()
-      raise newException(TransportError, "listener is stopped")
-
-    let quicConn = await incomingFut
-    if quicConn.lsquicConn.isNil:
-      debug "Dropping already closed incoming connection"
-      continue
-
-    let conn = newIncomingConnection(listener.quicContext, quicConn)
-    listener.connman.addConnection(conn)
-    return conn
-
-proc localAddress*(
-    listener: Listener
-): TransportAddress {.raises: [TransportOsError].} =
-  listener.udp.localAddress()
-
-proc stop*(listener: Listener) {.async: (raises: [CancelledError]).} =
-  await noCancel listener.connman.stop()
-  # Politely wait before closing udp so connections closure go out
-  # TODO: this should be ~ 3 times the PTO.
-  # Find out if it's possible to react to shutting down the context and
-  # lsquic engine. Maybe there's a callback that one can hook to and safely
-  # stop the udp transport.
-  await noCancel sleepAsync(300.milliseconds)
-  listener.quicContext.stop()
-  await noCancel listener.udp.closeWait()
-  listener.quicContext.destroy()
+  try:
+    ok(QuicEndpoint.new(tlsConfig, address, {CanListen, CanDial}))
+  except QuicConfigError, QuicError, TransportOsError:
+    err(getCurrentExceptionMsg())
 
 proc listen*(
     self: QuicServer, address: TransportAddress

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -2,12 +2,14 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import chronos, results
-import ./[errors, tlsconfig, endpoint]
+import ./[errors, connection, tlsconfig, endpoint]
 
-type QuicServer* = ref object of RootObj
-  tlsConfig: TLSConfig
+type
+  QuicServer* = ref object of RootObj
+    tlsConfig: TLSConfig
 
-type Listener* = QuicEndpoint
+  Listener* = ref object of RootObj
+    endpoint: QuicEndpoint
 
 proc new*(
     t: typedesc[QuicServer], tlsConfig: TLSConfig
@@ -21,7 +23,7 @@ proc newListener*(
     tlsConfig: TLSConfig, address: TransportAddress
 ): Result[Listener, string] =
   try:
-    ok(QuicEndpoint.new(tlsConfig, address, {CanListen, CanDial}))
+    ok(Listener(endpoint: QuicEndpoint.new(tlsConfig, address, {CanListen, CanDial})))
   except QuicConfigError, QuicError, TransportOsError:
     err(getCurrentExceptionMsg())
 
@@ -30,3 +32,23 @@ proc listen*(
 ): Listener {.raises: [QuicError, TransportOsError].} =
   newListener(self.tlsConfig, address).valueOr:
     raise newException(QuicError, error)
+
+proc accept*(
+    listener: Listener
+): Future[Connection] {.async: (raises: [CancelledError, TransportError]).} =
+  await listener.endpoint.accept()
+
+proc dial*(
+    listener: Listener, address: TransportAddress
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  await listener.endpoint.dial(address)
+
+proc localAddress*(
+    listener: Listener
+): TransportAddress {.raises: [TransportOsError].} =
+  listener.endpoint.localAddress()
+
+proc stop*(listener: Listener) {.async: (raises: [CancelledError]).} =
+  await listener.endpoint.stop()

--- a/tests/helpers/clientserver.nim
+++ b/tests/helpers/clientserver.nim
@@ -12,7 +12,7 @@ proc certificateCb(
 ): bool {.gcsafe.} =
   return derCertificates.len > 0
 
-proc makeTLSConfig*(): TLSConfig =
+proc makeTLSConfig*(): TLSConfig {.raises: [QuicConfigError].} =
   let customCertVerif: CertificateVerifier =
     CustomCertificateVerifier.init(certificateCb)
   TLSConfig.new(

--- a/tests/helpers/clientserver.nim
+++ b/tests/helpers/clientserver.nim
@@ -12,26 +12,31 @@ proc certificateCb(
 ): bool {.gcsafe.} =
   return derCertificates.len > 0
 
+proc makeTLSConfig*(): TLSConfig =
+  let customCertVerif: CertificateVerifier =
+    CustomCertificateVerifier.init(certificateCb)
+  TLSConfig.new(
+    testCertificate(),
+    testPrivateKey(),
+    @["test"].toHashSet(),
+    Opt.some(customCertVerif),
+  )
+
 proc makeClient*(): QuicClient {.
     raises: [QuicConfigError, QuicError, TransportOsError]
 .} =
-  let customCertVerif: CertificateVerifier =
-    CustomCertificateVerifier.init(certificateCb)
-  let clientTLSConfig = TLSConfig.new(
-    testCertificate(),
-    testPrivateKey(),
-    @["test"].toHashSet(),
-    Opt.some(customCertVerif),
-  )
-  return QuicClient.new(clientTLSConfig)
+  return QuicClient.new(makeTLSConfig())
 
 proc makeServer*(): QuicServer {.raises: [QuicConfigError].} =
-  let customCertVerif: CertificateVerifier =
-    CustomCertificateVerifier.init(certificateCb)
-  let serverTLSConfig = TLSConfig.new(
-    testCertificate(),
-    testPrivateKey(),
-    @["test"].toHashSet(),
-    Opt.some(customCertVerif),
-  )
-  return QuicServer.new(serverTLSConfig)
+  return QuicServer.new(makeTLSConfig())
+
+proc makeEndpoint*(
+    address: TransportAddress,
+    capabilities: QuicEndpointCapabilities = {CanListen, CanDial},
+): QuicEndpoint {.raises: [QuicConfigError, QuicError, TransportOsError].} =
+  QuicEndpoint.new(makeTLSConfig(), address, capabilities)
+
+proc makeDialEndpoint*(
+    family: AddressFamily
+): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
+  QuicEndpoint.new(makeTLSConfig(), family)

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -97,6 +97,65 @@ proc runConnectionTest(
 proc runConnectionTest(address: TransportAddress) {.async.} =
   await runConnectionTest(address, address)
 
+proc runEndpointAcceptTest(address: TransportAddress) {.async.} =
+  let client = makeClient()
+  let endpoint = makeEndpoint(address, {CanListen})
+  let boundAddress = endpoint.localAddress()
+  defer:
+    await allFutures(client.stop(), endpoint.stop())
+
+  let accepting = endpoint.accept()
+  let outgoingConn = await client.dial(boundAddress)
+  let incomingConn = await accepting
+
+  check:
+    outgoingConn.certificates().len == 1
+    incomingConn.certificates().len == 1
+    incomingConn.localAddress().port == boundAddress.port
+
+  outgoingConn.close()
+  incomingConn.close()
+  await sleepAsync(1.seconds)
+
+proc runEndpointSharedSocketDialTest(address: TransportAddress) {.async.} =
+  let endpoint = makeEndpoint(address)
+  let boundAddress = endpoint.localAddress()
+  defer:
+    await endpoint.stop()
+
+  let accepting = endpoint.accept()
+  let outgoingConn = await endpoint.dial(boundAddress)
+  let incomingConn = await accepting
+
+  check:
+    outgoingConn.localAddress().port == boundAddress.port
+    incomingConn.localAddress().port == boundAddress.port
+    incomingConn.remoteAddress().port == boundAddress.port
+
+  outgoingConn.close()
+  incomingConn.close()
+  await sleepAsync(1.seconds)
+
+proc runEndpointDialOnlyTest(address: TransportAddress) {.async.} =
+  let server = makeServer()
+  let listener = server.listen(address)
+  let boundAddress = listener.localAddress()
+  let endpoint = makeDialEndpoint(boundAddress.family)
+  defer:
+    await allFutures(listener.stop(), endpoint.stop())
+
+  let accepting = listener.accept()
+  let outgoingConn = await endpoint.dial(boundAddress)
+  let incomingConn = await accepting
+
+  check:
+    outgoingConn.remoteAddress().port == boundAddress.port
+    incomingConn.localAddress().port == boundAddress.port
+
+  outgoingConn.close()
+  incomingConn.close()
+  await sleepAsync(1.seconds)
+
 proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
   const streamCount = 16
 
@@ -155,3 +214,12 @@ suite "connection":
 
   asyncTest "multiple concurrent stream opens":
     await runConcurrentStreamOpenTest(initTAddress("127.0.0.1:12346"))
+
+  asyncTest "endpoint accepts inbound quic":
+    await runEndpointAcceptTest(initTAddress("127.0.0.1:0"))
+
+  asyncTest "endpoint dials from listener socket":
+    await runEndpointSharedSocketDialTest(initTAddress("127.0.0.1:0"))
+
+  asyncTest "dial-only endpoint works without listener":
+    await runEndpointDialOnlyTest(initTAddress("127.0.0.1:0"))

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -81,18 +81,15 @@ proc runConnectionTest(
     except CancelledError:
       raiseAssert "Canceled incoming behavior"
 
-  discard allFutures(outgoingBehaviour(), incomingBehaviour())
-
-  await sleepAsync(1.seconds)
+  await allFutures(outgoingBehaviour(), incomingBehaviour())
 
   outgoingConn.close()
   incomingConn.close()
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
 
   # Cannot create a stream once closed
   expect ConnectionClosedError:
     discard await outgoingConn.openStream()
-
-  await sleepAsync(1.seconds)
 
 proc runConnectionTest(address: TransportAddress) {.async.} =
   await runConnectionTest(address, address)
@@ -115,7 +112,7 @@ proc runEndpointAcceptTest(address: TransportAddress) {.async.} =
 
   outgoingConn.close()
   incomingConn.close()
-  await sleepAsync(1.seconds)
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
 
 proc runEndpointSharedSocketDialTest(address: TransportAddress) {.async.} =
   let endpoint = makeEndpoint(address)
@@ -134,7 +131,7 @@ proc runEndpointSharedSocketDialTest(address: TransportAddress) {.async.} =
 
   outgoingConn.close()
   incomingConn.close()
-  await sleepAsync(1.seconds)
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
 
 proc runEndpointDialOnlyTest(address: TransportAddress) {.async.} =
   let server = makeServer()
@@ -154,7 +151,7 @@ proc runEndpointDialOnlyTest(address: TransportAddress) {.async.} =
 
   outgoingConn.close()
   incomingConn.close()
-  await sleepAsync(1.seconds)
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
 
 proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
   const streamCount = 16

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -77,11 +77,12 @@ suite "lifecycle":
     check (await peers.incoming.closedFuture().withTimeout(2.seconds))
     check peers.incoming.isClosed
 
-  asyncTest "accept skips closed connection and client redials":
+  asyncTest "accept skips connections closed before wrapping":
     let server = makeServer()
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     let address = listener.localAddress()
-    let client = makeClient()
+    let staleClient = makeClient()
+    let goodClient = makeClient()
     var accepted: Future[Connection]
     var incomingStream: Future[Stream]
     defer:
@@ -89,14 +90,14 @@ suite "lifecycle":
         await accepted.cancelAndWait()
       if not incomingStream.isNil and not incomingStream.finished:
         await incomingStream.cancelAndWait()
-      await allFutures(client.stop(), listener.stop())
+      await allFutures(staleClient.stop(), goodClient.stop(), listener.stop())
 
-    let stale = await client.dial(address)
+    let stale = await staleClient.dial(address)
     stale.abort()
     check (await stale.closedFuture().withTimeout(2.seconds))
 
     accepted = listener.accept()
-    let outgoing = await client.dial(address)
+    let outgoing = await goodClient.dial(address)
     check (await accepted.withTimeout(2.seconds))
     let incoming = await accepted
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -77,12 +77,11 @@ suite "lifecycle":
     check (await peers.incoming.closedFuture().withTimeout(2.seconds))
     check peers.incoming.isClosed
 
-  asyncTest "accept skips connections closed before wrapping":
+  asyncTest "accept skips closed connection and client redials":
     let server = makeServer()
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     let address = listener.localAddress()
-    let staleClient = makeClient()
-    let goodClient = makeClient()
+    let client = makeClient()
     var accepted: Future[Connection]
     var incomingStream: Future[Stream]
     defer:
@@ -90,14 +89,14 @@ suite "lifecycle":
         await accepted.cancelAndWait()
       if not incomingStream.isNil and not incomingStream.finished:
         await incomingStream.cancelAndWait()
-      await allFutures(staleClient.stop(), goodClient.stop(), listener.stop())
+      await allFutures(client.stop(), listener.stop())
 
-    let stale = await staleClient.dial(address)
+    let stale = await client.dial(address)
     stale.abort()
     check (await stale.closedFuture().withTimeout(2.seconds))
 
     accepted = listener.accept()
-    let outgoing = await goodClient.dial(address)
+    let outgoing = await client.dial(address)
     check (await accepted.withTimeout(2.seconds))
     let incoming = await accepted
 

--- a/tests/test_stress.nim
+++ b/tests/test_stress.nim
@@ -28,10 +28,11 @@ const
       64 * 1024
 
 proc payload(id: int, size: int): seq[byte] =
-  result = newSeq[byte](size)
-  result[0] = byte(id)
+  var data = newSeq[byte](size)
+  data[0] = byte(id)
   for i in 1 ..< size:
-    result[i] = byte((id + i) mod 251)
+    data[i] = byte((id + i) mod 251)
+  data
 
 proc connectPeers(): Future[(QuicClient, Listener, Connection, Connection)] {.async.} =
   let client = makeClient()

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -13,8 +13,9 @@ import lsquic/lsquic_ffi
 import ./helpers/certificate
 
 proc singleAlpn(): HashSet[string] =
-  result = initHashSet[string]()
-  result.incl("test")
+  var alpn = initHashSet[string]()
+  alpn.incl("test")
+  alpn
 
 suite "tls config":
   test "certificate requires key":

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -16,8 +16,9 @@ type RejectVerifierRecorder = ref object
   rejectCount: int
 
 proc singleAlpn(name: string = "test"): HashSet[string] =
-  result = initHashSet[string]()
-  result.incl(name)
+  var alpn = initHashSet[string]()
+  alpn.incl(name)
+  alpn
 
 proc acceptingCertificateCb(
     serverName: string, derCertificates: seq[seq[byte]]


### PR DESCRIPTION
## Summary

Adds a reusable `QuicEndpoint` abstraction that can listen and dial over a shared UDP socket. `QuicServer` listeners now use this endpoint internally, and `QuicClient` reuses dial-only endpoints per address family.

This makes it possible to accept inbound QUIC connections and initiate outbound QUIC connections from the same bound socket (this is required for holepunching).

## Affected Areas

- [x] Transports
  - QUIC endpoint, client, server listener, and connection tests

## Impact on Library Users

Exports the new `QuicEndpoint` API and keeps the existing `QuicClient`, `QuicServer`, and `Listener` entry points available. Existing listener behavior is preserved while adding the ability to use a listen-capable endpoint for outbound dialing.

## Risk Assessment

The main risk is QUIC socket lifecycle behavior, since client and server contexts can now share one datagram transport. The PR adds coverage for inbound endpoint accept, shared-socket dialing, and dial-only endpoint use.
