### PR TITLE
chore(ffi): generate lsquic bindings with nodeclguards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,13 @@ jobs:
           - os: windows
             cpu: amd64
         nim:
-          - ref: version-2-0
+          - ref: v2.2.4
             memory_management: refc
-          - ref: version-2-2
+          - ref: v2.2.4
+            memory_management: orc
+          - ref: v2.2.10
             memory_management: refc
-          - ref: version-2-2
+          - ref: v2.2.10
             memory_management: orc
         include:
           - platform:

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
@@ -17,7 +19,7 @@ nimble install futhark@0.15.0
 
 # Futhark's Opir cache key does not include the contents of the imported
 # headers, so force it to rebuild when regenerating after an lsquic update.
-nim c -d:opirRebuild --maxLoopIterationsVM:100000000 generate_lsquic_ffi.nim
+nim c -d:nodeclguards -d:opirRebuild --maxLoopIterationsVM:100000000 generate_lsquic_ffi.nim
 
 cat "${root}/prelude.nim" > lsquic/lsquic_ffi.nim
 
@@ -26,9 +28,6 @@ echo >> lsquic/lsquic_ffi.nim # linebreak
 for file in "${toCompile[@]}"; do
     echo "{.compile: \"$file\".}" >> lsquic/lsquic_ffi.nim
 done
-
-# correct casing for SockAddr
-sed -i 's/Sockaddr/SockAddr/g' tmp_lsquic_ffi.nim
 
 cat tmp_lsquic_ffi.nim >> lsquic/lsquic_ffi.nim
 

--- a/generate_lsquic_ffi.nim
+++ b/generate_lsquic_ffi.nim
@@ -5,22 +5,68 @@ import futhark
 import std/json
 from os import parentDir, `/`
 
+import chronos/osdefs
 import boringssl
 
-const preludeTypes = ["struct_lsquic_cid", "lsquic_cid_t"]
+include lsquic/lsquic_ffi_types
 
-proc dropPreludeTypesAndGeneratedCEnumsImpl(opirOutput: JsonNode): JsonNode =
+# These are emitted from the C headers, but supplied by the shared types file.
+const manualPreludeSymbols =
+  ["MAX_CID_LEN", "GQUIC_CID_LEN", "struct_lsquic_cid", "lsquic_cid_t"]
+
+# Futhark would otherwise emit opaque placeholders for aliases to these types
+# when declaration guards are disabled.
+const predeclaredTypeNames = [
+  "lsquic_cid_t", "struct_ssl_st", "struct_ssl_ctx_st", "struct_ssl_session_st",
+  "struct_stack_st_X509",
+]
+
+# Opir nests type descriptions inside fields, parameters, and return values.
+# Rewriting aliases to bases makes Futhark reuse the Nim types already in scope.
+proc rewriteKnownTypeAliases(node: JsonNode, knownTypeNames: openArray[string]) =
+  case node.kind
+  of JObject:
+    if node{"kind"}.getStr("") == "alias":
+      let aliasName = node{"value"}.getStr("")
+      if aliasName in knownTypeNames:
+        node["kind"] = %"base"
+        return
+
+      # chronos already provides this type under Nim's SockAddr spelling.
+      if aliasName == "struct_sockaddr":
+        node["kind"] = %"base"
+        node["value"] = %"SockAddr"
+        return
+
+    for _, value in node.pairs:
+      rewriteKnownTypeAliases(value, knownTypeNames)
+  of JArray:
+    for value in node.items:
+      rewriteKnownTypeAliases(value, knownTypeNames)
+  else:
+    discard
+
+proc normalizeOpirImpl(opirOutput: JsonNode): JsonNode =
+  var knownTypeNames: seq[string]
+  for name in predeclaredTypeNames:
+    knownTypeNames.add name
+
+  for node in opirOutput.items:
+    if node{"kind"}.getStr("") == "enum" and node.hasKey("name") and
+        node["name"].kind == JString:
+      knownTypeNames.add node{"name"}.getStr("")
+
   var resp = newJArray()
-  for node in opirOutput:
+  for node in opirOutput.items:
+    if node{"name"}.getStr("") in manualPreludeSymbols:
+      continue
+
     # enums are generated manually to avoid issue described in
     # https://github.com/PMunch/futhark/issues/152
     if node{"kind"}.getStr("") == "enum":
       continue
 
-    # Futhark incorrectly maps the struct alignment on lsquic_cid_t to field alignment,
-    # so the prelude supplies the correct native layout instead.
-    if node{"name"}.getStr("") in preludeTypes:
-      continue
+    rewriteKnownTypeAliases(node, knownTypeNames)
 
     resp.add node
   resp
@@ -29,7 +75,6 @@ importc:
   outputPath currentSourcePath.parentDir / "tmp_lsquic_ffi.nim"
   path currentSourcePath.parentDir / "libs/lsquic/include"
   addopircallback proc(opirOutput: JsonNode): JsonNode {.closure.} =
-    dropPreludeTypesAndGeneratedCEnumsImpl(opirOutput)
+    normalizeOpirImpl(opirOutput)
   rename FILE, CFile # Rename `FILE` that STB uses to `CFile` which is the Nim equivalent
-  rename struct_sockaddr, SockAddr # Rename `struct_sockaddr` for chronos SockAddr
   "lsquic.h"

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -1,5 +1,5 @@
 packageName = "lsquic"
-version = "0.5.1"
+version = "0.5.2"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"

--- a/lsquic/lsquic_ffi.nim
+++ b/lsquic/lsquic_ffi.nim
@@ -8,91 +8,12 @@ when defined(windows):
 
 import std/[os, strutils]
 import chronos/osdefs
+{.push warning[UnusedImport]: off.}
 import zlib
+{.pop.}
 import boringssl
 
-type
-  ptrdiff_t* {.importc: "ptrdiff_t", header: "<stddef.h>".} = int
-  uint_fast8_t* {.importc: "uint_fast8_t", header: "<stdint.h>".} = uint8
-
-# enums are generated manually to avoid issue described in
-# https://github.com/PMunch/futhark/issues/152
-template borrowCEnumOps(T: typedesc) =
-  proc `==`*(a, b: T): bool {.borrow.}
-  proc `<`*(a, b: T): bool {.borrow.}
-  proc `<=`*(a, b: T): bool {.borrow.}
-  proc `or`*(a, b: T): T {.borrow.}
-  proc `and`*(a, b: T): T {.borrow.}
-  proc `xor`*(a, b: T): T {.borrow.}
-  proc `not`*(a: T): T {.borrow.}
-  proc `$`*(a: T): string {.borrow.}
-
-type
-  enum_lsquic_version* = distinct cuint
-  enum_lsquic_hsk_status* = distinct cuint
-  enum_lsquic_hsi_flag* = distinct cuint
-  enum_lsquic_logger_timestamp_style* = distinct cuint
-  enum_lsquic_crypto_ver* = distinct cuint
-  enum_lsquic_conn_param* = distinct cuint
-  enum_LSQUIC_CONN_STATUS* = distinct cuint
-
-borrowCEnumOps(enum_lsquic_version)
-borrowCEnumOps(enum_lsquic_hsk_status)
-borrowCEnumOps(enum_lsquic_hsi_flag)
-borrowCEnumOps(enum_lsquic_logger_timestamp_style)
-borrowCEnumOps(enum_lsquic_crypto_ver)
-borrowCEnumOps(enum_lsquic_conn_param)
-borrowCEnumOps(enum_LSQUIC_CONN_STATUS)
-
-const
-  MAX_CID_LEN* = 20
-  GQUIC_CID_LEN* = 8
-
-  LSQVER_043* = enum_lsquic_version(0)
-  LSQVER_046* = enum_lsquic_version(1)
-  LSQVER_050* = enum_lsquic_version(2)
-  LSQVER_ID27* = enum_lsquic_version(3)
-  LSQVER_ID29* = enum_lsquic_version(4)
-  LSQVER_I001* = enum_lsquic_version(5)
-  LSQVER_I002* = enum_lsquic_version(6)
-  LSQVER_RESVED* = enum_lsquic_version(7)
-  N_LSQVER* = enum_lsquic_version(8)
-  LSQVER_VERNEG* = enum_lsquic_version(9)
-
-  LSQ_HSK_FAIL* = enum_lsquic_hsk_status(0)
-  LSQ_HSK_OK* = enum_lsquic_hsk_status(1)
-  LSQ_HSK_RESUMED_OK* = enum_lsquic_hsk_status(2)
-  LSQ_HSK_RESUMED_FAIL* = enum_lsquic_hsk_status(3)
-
-  LSQUIC_HSI_HTTP1X* = enum_lsquic_hsi_flag(2)
-  LSQUIC_HSI_HASH_NAME* = enum_lsquic_hsi_flag(4)
-  LSQUIC_HSI_HASH_NAMEVAL* = enum_lsquic_hsi_flag(8)
-
-  LLTS_NONE* = enum_lsquic_logger_timestamp_style(0)
-  LLTS_HHMMSSMS* = enum_lsquic_logger_timestamp_style(1)
-  LLTS_YYYYMMDD_HHMMSSMS* = enum_lsquic_logger_timestamp_style(2)
-  LLTS_CHROMELIKE* = enum_lsquic_logger_timestamp_style(3)
-  LLTS_HHMMSSUS* = enum_lsquic_logger_timestamp_style(4)
-  LLTS_YYYYMMDD_HHMMSSUS* = enum_lsquic_logger_timestamp_style(5)
-  N_LLTS* = enum_lsquic_logger_timestamp_style(6)
-
-  LSQ_CRY_QUIC* = enum_lsquic_crypto_ver(0)
-  LSQ_CRY_TLSv13* = enum_lsquic_crypto_ver(1)
-
-  LSQCP_MAX_PACING_RATE* = enum_lsquic_conn_param(1)
-  LSQCP_ENABLE_BW_SAMPLER* = enum_lsquic_conn_param(2)
-
-  LSCONN_ST_HSK_IN_PROGRESS* = enum_LSQUIC_CONN_STATUS(0)
-  LSCONN_ST_CONNECTED* = enum_LSQUIC_CONN_STATUS(1)
-  LSCONN_ST_HSK_FAILURE* = enum_LSQUIC_CONN_STATUS(2)
-  LSCONN_ST_GOING_AWAY* = enum_LSQUIC_CONN_STATUS(3)
-  LSCONN_ST_TIMED_OUT* = enum_LSQUIC_CONN_STATUS(4)
-  LSCONN_ST_RESET* = enum_LSQUIC_CONN_STATUS(5)
-  LSCONN_ST_USER_ABORTED* = enum_LSQUIC_CONN_STATUS(6)
-  LSCONN_ST_ERROR* = enum_LSQUIC_CONN_STATUS(7)
-  LSCONN_ST_CLOSED* = enum_LSQUIC_CONN_STATUS(8)
-  LSCONN_ST_PEER_GOING_AWAY* = enum_LSQUIC_CONN_STATUS(9)
-  LSCONN_ST_VERNEG_FAILURE* = enum_LSQUIC_CONN_STATUS(10)
+include lsquic/lsquic_ffi_types
 
 # use rsplit as a workaround for cross compilation path separator issue
 const root = currentSourcePath.rsplit({DirSep, AltSep}, 2)[0]
@@ -111,16 +32,6 @@ when defined(windows):
 {.passc: "-I" & lsqpack.}
 {.passc: "-I" & lshpack.}
 {.passc: "-I" & xxhash.}
-
-type
-  struct_lsquic_cid* {.
-    importc: "struct lsquic_cid", header: "lsquic_types.h", bycopy, completeStruct
-  .} = object
-    buf* {.importc: "buf".}: array[MAX_CID_LEN, uint8]
-    len* {.importc: "len".}: uint_fast8_t
-    padding: array[3, uint8]
-
-  lsquic_cid_t* = struct_lsquic_cid
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
 const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\"<lsquic_xxhash.h>\""
@@ -211,233 +122,74 @@ const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\"<lsquic_xxhash.h>\""
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_varint.c".}
 {.compile: "../libs/lsquic/src/liblsquic/lsquic_version.c".}
 
-{.warning[UnusedImport]: off.}
-{.hint[XDeclaredButNotUsed]: off.}
-from macros import hint, warning, newLit, getSize
-
-from os import parentDir
-
-when not declared(ownSizeOf):
-  macro ownSizeof(x: typed): untyped =
-    newLit(x.getSize)
-
-when not declared(struct_ssl_st):
-  type struct_ssl_st* = object
-else:
-  static:
-    hint("Declaration of " & "struct_ssl_st" & " already exists, not redeclaring")
-when not declared(struct_lsquic_stream):
-  type struct_lsquic_stream* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_stream" & " already exists, not redeclaring"
-    )
-when not declared(enum_lsquic_version):
-  type enum_lsquic_version* = object
-else:
-  static:
-    hint("Declaration of " & "enum_lsquic_version" & " already exists, not redeclaring")
-when not declared(struct_lsquic_conn):
-  type struct_lsquic_conn* = object
-else:
-  static:
-    hint("Declaration of " & "struct_lsquic_conn" & " already exists, not redeclaring")
-when not declared(enum_lsquic_hsi_flag):
-  type enum_lsquic_hsi_flag* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "enum_lsquic_hsi_flag" & " already exists, not redeclaring"
-    )
-when not declared(enum_LSQUIC_CONN_STATUS):
-  type enum_LSQUIC_CONN_STATUS* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "enum_LSQUIC_CONN_STATUS" & " already exists, not redeclaring"
-    )
-when not declared(buf):
-  type buf* = object
-else:
-  static:
-    hint("Declaration of " & "buf" & " already exists, not redeclaring")
-when not declared(enum_lsquic_conn_param):
-  type enum_lsquic_conn_param* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "enum_lsquic_conn_param" & " already exists, not redeclaring"
-    )
-when not declared(struct_lsxpack_header):
-  type struct_lsxpack_header* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsxpack_header" & " already exists, not redeclaring"
-    )
-when not declared(struct_stack_st_X509):
-  type struct_stack_st_X509* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_stack_st_X509" & " already exists, not redeclaring"
-    )
-when not declared(enum_lsquic_crypto_ver):
-  type enum_lsquic_crypto_ver* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "enum_lsquic_crypto_ver" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_CFCW_SERVER):
-  type LSQUIC_DF_CFCW_SERVER* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_CFCW_SERVER" & " already exists, not redeclaring"
-    )
-when not declared(enum_lsquic_hsk_status):
-  type enum_lsquic_hsk_status* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "enum_lsquic_hsk_status" & " already exists, not redeclaring"
-    )
-when not declared(SockAddr):
-  type SockAddr* = object
-else:
-  static:
-    hint("Declaration of " & "SockAddr" & " already exists, not redeclaring")
-when not declared(struct_lsquic_stream_ctx):
-  type struct_lsquic_stream_ctx* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_stream_ctx" & " already exists, not redeclaring"
-    )
-when not declared(enum_lsquic_logger_timestamp_style):
-  type enum_lsquic_logger_timestamp_style* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "enum_lsquic_logger_timestamp_style" &
-        " already exists, not redeclaring"
-    )
-when not declared(struct_ssl_session_st):
-  type struct_ssl_session_st* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_ssl_session_st" & " already exists, not redeclaring"
-    )
-when not declared(struct_lsquic_conn_ctx):
-  type struct_lsquic_conn_ctx* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_conn_ctx" & " already exists, not redeclaring"
-    )
-when not declared(struct_ssl_ctx_st):
-  type struct_ssl_ctx_st* = object
-else:
-  static:
-    hint("Declaration of " & "struct_ssl_ctx_st" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_SFCW_SERVER):
-  type LSQUIC_DF_SFCW_SERVER* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SFCW_SERVER" & " already exists, not redeclaring"
-    )
-when not declared(struct_lsquic_engine):
-  type struct_lsquic_engine* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_engine" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SFCW_CLIENT):
-  type LSQUIC_DF_SFCW_CLIENT* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SFCW_CLIENT" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_CFCW_CLIENT):
-  type LSQUIC_DF_CFCW_CLIENT* = object
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_CFCW_CLIENT" & " already exists, not redeclaring"
-    )
+type struct_lsquic_stream* = object
+type struct_lsquic_conn* = object
+type buf* = object
+type struct_lsxpack_header* = object
+type LSQUIC_DF_CFCW_SERVER* = object
+type struct_lsquic_stream_ctx* = object
+type struct_lsquic_conn_ctx* = object
+type LSQUIC_DF_SFCW_SERVER* = object
+type struct_lsquic_engine* = object
+type LSQUIC_DF_SFCW_CLIENT* = object
+type LSQUIC_DF_CFCW_CLIENT* = object
 type
-  uint_fast8_t_570425836 = uint8 ## Generated based on /usr/include/stdint.h:60:24
-  lsquic_stream_id_t_570425840 = uint64
+  lsquic_stream_id_t* = uint64
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:40:18
-  lsquic_engine_t_570425842 = struct_lsquic_engine
+  lsquic_engine_t* = struct_lsquic_engine
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:43:30
-  lsquic_conn_t_570425844 = struct_lsquic_conn
+  lsquic_conn_t* = struct_lsquic_conn
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:46:28
-  lsquic_conn_ctx_t_570425846 = struct_lsquic_conn_ctx
+  lsquic_conn_ctx_t* = struct_lsquic_conn_ctx
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:49:32
-  lsquic_stream_t_570425848 = struct_lsquic_stream
+  lsquic_stream_t* = struct_lsquic_stream
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:52:30
-  lsquic_stream_ctx_t_570425850 = struct_lsquic_stream_ctx
+  lsquic_stream_ctx_t* = struct_lsquic_stream_ctx
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:55:34
-  lsquic_http_headers_t_570425852 = struct_lsquic_http_headers_570425855
+  lsquic_http_headers_t* = struct_lsquic_http_headers
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:58:36
-  struct_lsquic_http_headers_570425854 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_http_headers* {.pure, inheritable, bycopy.} = object
     count*: cint
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1743:8
     headers*: ptr struct_lsxpack_header
 
-  struct_lsquic_stream_if_570425856 {.pure, inheritable, bycopy.} = object
-    on_new_conn*: proc(
-      a0: pointer, a1: ptr lsquic_conn_t_570425845
-    ): ptr lsquic_conn_ctx_t_570425847 {.cdecl.}
+  struct_lsquic_stream_if* {.pure, inheritable, bycopy.} = object
+    on_new_conn*:
+      proc(a0: pointer, a1: ptr lsquic_conn_t): ptr lsquic_conn_ctx_t {.cdecl.}
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:163:8
-    on_goaway_received*: proc(a0: ptr lsquic_conn_t_570425845): void {.cdecl.}
-    on_conn_closed*: proc(a0: ptr lsquic_conn_t_570425845): void {.cdecl.}
-    on_new_stream*: proc(
-      a0: pointer, a1: ptr lsquic_stream_t_570425849
-    ): ptr lsquic_stream_ctx_t_570425851 {.cdecl.}
-    on_read*: proc(
-      a0: ptr lsquic_stream_t_570425849, a1: ptr lsquic_stream_ctx_t_570425851
-    ): void {.cdecl.}
-    on_write*: proc(
-      a0: ptr lsquic_stream_t_570425849, a1: ptr lsquic_stream_ctx_t_570425851
-    ): void {.cdecl.}
-    on_close*: proc(
-      a0: ptr lsquic_stream_t_570425849, a1: ptr lsquic_stream_ctx_t_570425851
-    ): void {.cdecl.}
-    on_dg_write*: proc(
-      a0: ptr lsquic_conn_t_570425845, a1: pointer, a2: csize_t
-    ): ssize_t_570425859 {.cdecl.}
-    on_datagram*:
-      proc(a0: ptr lsquic_conn_t_570425845, a1: pointer, a2: csize_t): void {.cdecl.}
+    on_goaway_received*: proc(a0: ptr lsquic_conn_t): void {.cdecl.}
+    on_conn_closed*: proc(a0: ptr lsquic_conn_t): void {.cdecl.}
+    on_new_stream*:
+      proc(a0: pointer, a1: ptr lsquic_stream_t): ptr lsquic_stream_ctx_t {.cdecl.}
+    on_read*: proc(a0: ptr lsquic_stream_t, a1: ptr lsquic_stream_ctx_t): void {.cdecl.}
+    on_write*:
+      proc(a0: ptr lsquic_stream_t, a1: ptr lsquic_stream_ctx_t): void {.cdecl.}
+    on_close*:
+      proc(a0: ptr lsquic_stream_t, a1: ptr lsquic_stream_ctx_t): void {.cdecl.}
+    on_dg_write*:
+      proc(a0: ptr lsquic_conn_t, a1: pointer, a2: csize_t): ssize_t {.cdecl.}
+    on_datagram*: proc(a0: ptr lsquic_conn_t, a1: pointer, a2: csize_t): void {.cdecl.}
     on_hsk_done*:
-      proc(a0: ptr lsquic_conn_t_570425845, a1: enum_lsquic_hsk_status): void {.cdecl.}
+      proc(a0: ptr lsquic_conn_t, a1: enum_lsquic_hsk_status): void {.cdecl.}
     on_new_token*:
-      proc(a0: ptr lsquic_conn_t_570425845, a1: ptr uint8, a2: csize_t): void {.cdecl.}
+      proc(a0: ptr lsquic_conn_t, a1: ptr uint8, a2: csize_t): void {.cdecl.}
     on_sess_resume_info*:
-      proc(a0: ptr lsquic_conn_t_570425845, a1: ptr uint8, a2: csize_t): void {.cdecl.}
+      proc(a0: ptr lsquic_conn_t, a1: ptr uint8, a2: csize_t): void {.cdecl.}
     on_reset*: proc(
-      a0: ptr lsquic_stream_t_570425849, a1: ptr lsquic_stream_ctx_t_570425851, a2: cint
+      a0: ptr lsquic_stream_t, a1: ptr lsquic_stream_ctx_t, a2: cint
     ): void {.cdecl.}
     on_conncloseframe_received*: proc(
-      a0: ptr lsquic_conn_t_570425845, a1: cint, a2: uint64, a3: cstring, a4: cint
+      a0: ptr lsquic_conn_t, a1: cint, a2: uint64, a3: cstring, a4: cint
     ): void {.cdecl.}
-    on_hset_in*: proc(
-      a0: ptr lsquic_stream_t_570425849, a1: ptr lsquic_stream_ctx_t_570425851
-    ): void {.cdecl.}
+    on_hset_in*:
+      proc(a0: ptr lsquic_stream_t, a1: ptr lsquic_stream_ctx_t): void {.cdecl.}
 
-  ssize_t_570425858 = compiler_ssize_t_570425901
+  ssize_t* = compiler_ssize_t
     ## Generated based on /usr/include/x86_64-linux-gnu/sys/types.h:108:19
-  lsquic_lookup_cert_f_570425860 =
+  lsquic_lookup_cert_f* =
     proc(a0: pointer, a1: ptr SockAddr, a2: cstring): ptr struct_ssl_ctx_st {.cdecl.}
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:260:31
-  struct_lsquic_engine_settings_570425862 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_engine_settings* {.pure, inheritable, bycopy.} = object
     es_versions*: cuint
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:487:8
     es_cfcw*: cuint
@@ -517,28 +269,27 @@ type
     es_send_verneg*: cint
     es_preferred_address*: array[24'i64, uint8]
 
-  struct_lsquic_out_spec_570425864 {.pure, inheritable, bycopy.} = object
-    iov*: ptr struct_iovec_570425867
+  struct_lsquic_out_spec* {.pure, inheritable, bycopy.} = object
+    iov*: ptr struct_iovec
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1214:8
     iovlen*: csize_t
     local_sa*: ptr SockAddr
     dest_sa*: ptr SockAddr
     peer_ctx*: pointer
-    conn_ctx*: ptr lsquic_conn_ctx_t_570425847
+    conn_ctx*: ptr lsquic_conn_ctx_t
     ecn*: cint
 
-  struct_iovec_570425866 {.pure, inheritable, bycopy.} = object
+  struct_iovec* {.pure, inheritable, bycopy.} = object
     iov_base*: pointer
       ## Generated based on /usr/include/x86_64-linux-gnu/bits/types/struct_iovec.h:26:8
     iov_len*: csize_t
 
-  lsquic_packets_out_f_570425868 = proc(
-    a0: pointer, a1: ptr struct_lsquic_out_spec_570425865, a2: cuint
-  ): cint {.cdecl.}
+  lsquic_packets_out_f* =
+    proc(a0: pointer, a1: ptr struct_lsquic_out_spec, a2: cuint): cint {.cdecl.}
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1238:15
-  struct_lsquic_shared_hash_if_570425870 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_shared_hash_if* {.pure, inheritable, bycopy.} = object
     shi_insert*: proc(
-      a0: pointer, a1: pointer, a2: cuint, a3: pointer, a4: cuint, a5: time_t_570425873
+      a0: pointer, a1: pointer, a2: cuint, a3: pointer, a4: cuint, a5: time_t
     ): cint {.cdecl.}
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1248:8
     shi_delete*: proc(a0: pointer, a1: pointer, a2: cuint): cint {.cdecl.}
@@ -546,27 +297,23 @@ type
       a0: pointer, a1: pointer, a2: cuint, a3: ptr pointer, a4: ptr cuint
     ): cint {.cdecl.}
 
-  time_t_570425872 = compiler_time_t_570425903
+  time_t* = compiler_time_t
     ## Generated based on /usr/include/x86_64-linux-gnu/bits/types/time_t.h:10:18
-  struct_lsquic_packout_mem_if_570425874 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_packout_mem_if* {.pure, inheritable, bycopy.} = object
     pmi_allocate*: proc(
-      a0: pointer,
-      a1: pointer,
-      a2: ptr lsquic_conn_ctx_t_570425847,
-      a3: cushort,
-      a4: cschar,
+      a0: pointer, a1: pointer, a2: ptr lsquic_conn_ctx_t, a3: cushort, a4: cschar
     ): pointer {.cdecl.}
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1286:8
     pmi_release*:
       proc(a0: pointer, a1: pointer, a2: pointer, a3: cschar): void {.cdecl.}
     pmi_return*: proc(a0: pointer, a1: pointer, a2: pointer, a3: cschar): void {.cdecl.}
 
-  lsquic_cids_update_f_570425876 =
+  lsquic_cids_update_f* =
     proc(a0: pointer, a1: ptr pointer, a2: ptr lsquic_cid_t, a3: cuint): void {.cdecl.}
     ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1307:16
-  struct_lsquic_hset_if_570425878 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_hset_if* {.pure, inheritable, bycopy.} = object
     hsi_create_header_set*:
-      proc(a0: pointer, a1: ptr lsquic_stream_t_570425849, a2: cint): pointer {.cdecl.}
+      proc(a0: pointer, a1: ptr lsquic_stream_t, a2: cint): pointer {.cdecl.}
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1325:8
     hsi_prepare_decode*: proc(
       a0: pointer, a1: ptr struct_lsxpack_header, a2: csize_t
@@ -576,52 +323,51 @@ type
     hsi_discard_header_set*: proc(a0: pointer): void {.cdecl.}
     hsi_flags*: enum_lsquic_hsi_flag
 
-  struct_lsquic_engine_api_570425880 {.pure, inheritable, bycopy.} = object
-    ea_settings*: ptr struct_lsquic_engine_settings_570425863
+  struct_lsquic_engine_api* {.pure, inheritable, bycopy.} = object
+    ea_settings*: ptr struct_lsquic_engine_settings
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1398:8
-    ea_stream_if*: ptr struct_lsquic_stream_if_570425857
+    ea_stream_if*: ptr struct_lsquic_stream_if
     ea_stream_if_ctx*: pointer
-    ea_packets_out*: lsquic_packets_out_f_570425869
+    ea_packets_out*: lsquic_packets_out_f
     ea_packets_out_ctx*: pointer
-    ea_lookup_cert*: lsquic_lookup_cert_f_570425861
+    ea_lookup_cert*: lsquic_lookup_cert_f
     ea_cert_lu_ctx*: pointer
     ea_get_ssl_ctx*:
       proc(a0: pointer, a1: ptr SockAddr): ptr struct_ssl_ctx_st {.cdecl.}
-    ea_shi*: ptr struct_lsquic_shared_hash_if_570425871
+    ea_shi*: ptr struct_lsquic_shared_hash_if
     ea_shi_ctx*: pointer
-    ea_pmi*: ptr struct_lsquic_packout_mem_if_570425875
+    ea_pmi*: ptr struct_lsquic_packout_mem_if
     ea_pmi_ctx*: pointer
-    ea_new_scids*: lsquic_cids_update_f_570425877
-    ea_live_scids*: lsquic_cids_update_f_570425877
-    ea_old_scids*: lsquic_cids_update_f_570425877
+    ea_new_scids*: lsquic_cids_update_f
+    ea_live_scids*: lsquic_cids_update_f
+    ea_old_scids*: lsquic_cids_update_f
     ea_cids_update_ctx*: pointer
     ea_verify_cert*: proc(a0: pointer, a1: ptr struct_stack_st_X509): cint {.cdecl.}
     ea_verify_ctx*: pointer
-    ea_hsi_if*: ptr struct_lsquic_hset_if_570425879
+    ea_hsi_if*: ptr struct_lsquic_hset_if
     ea_hsi_ctx*: pointer
     ea_stats_fh*: pointer
     ea_alpn*: cstring
-    ea_generate_scid*: proc(
-      a0: pointer, a1: ptr lsquic_conn_t_570425845, a2: ptr uint8, a3: cuint
-    ): void {.cdecl.}
+    ea_generate_scid*:
+      proc(a0: pointer, a1: ptr lsquic_conn_t, a2: ptr uint8, a3: cuint): void {.cdecl.}
     ea_gen_scid_ctx*: pointer
 
-  struct_lsquic_reader_570425882 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_reader* {.pure, inheritable, bycopy.} = object
     lsqr_read*: proc(a0: pointer, a1: pointer, a2: csize_t): csize_t {.cdecl.}
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1702:8
     lsqr_size*: proc(a0: pointer): csize_t {.cdecl.}
     lsqr_ctx*: pointer
 
-  struct_lsquic_ext_http_prio_570425884 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_ext_http_prio* {.pure, inheritable, bycopy.} = object
     urgency*: uint8
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1900:8
     incremental*: cschar
 
-  struct_lsquic_logger_if_570425886 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_logger_if* {.pure, inheritable, bycopy.} = object
     log_buf*: proc(a0: pointer, a1: cstring, a2: csize_t): cint {.cdecl.}
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1973:8
 
-  struct_lsquic_conn_info_570425895 {.pure, inheritable, bycopy.} = object
+  struct_lsquic_conn_info* {.pure, inheritable, bycopy.} = object
     lci_cwnd*: uint32
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:2197:8
     lci_pmtu*: uint32
@@ -638,2385 +384,874 @@ type
     lci_max_pacing_rate*: uint64
     lci_pacing_rate*: uint64
 
-  compiler_ssize_t_570425900 = clong
+  compiler_ssize_t* = clong
     ## Generated based on /usr/include/x86_64-linux-gnu/bits/types.h:194:27
-  compiler_time_t_570425902 = clong
+  compiler_time_t* = clong
     ## Generated based on /usr/include/x86_64-linux-gnu/bits/types.h:160:26
-  struct_lsquic_reader_570425883 = (
-    when declared(struct_lsquic_reader):
-      when ownSizeof(struct_lsquic_reader) != ownSizeof(struct_lsquic_reader_570425882):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_reader" &
-              " exists but with different size"
-          )
-      struct_lsquic_reader
-    else:
-      struct_lsquic_reader_570425882
-  )
-  lsquic_lookup_cert_f_570425861 = (
-    when declared(lsquic_lookup_cert_f):
-      when ownSizeof(lsquic_lookup_cert_f) != ownSizeof(lsquic_lookup_cert_f_570425860):
-        static:
-          warning(
-            "Declaration of " & "lsquic_lookup_cert_f" &
-              " exists but with different size"
-          )
-      lsquic_lookup_cert_f
-    else:
-      lsquic_lookup_cert_f_570425860
-  )
-  struct_lsquic_engine_api_570425881 = (
-    when declared(struct_lsquic_engine_api):
-      when ownSizeof(struct_lsquic_engine_api) !=
-          ownSizeof(struct_lsquic_engine_api_570425880):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_engine_api" &
-              " exists but with different size"
-          )
-      struct_lsquic_engine_api
-    else:
-      struct_lsquic_engine_api_570425880
-  )
-  compiler_ssize_t_570425901 = (
-    when declared(compiler_ssize_t):
-      when ownSizeof(compiler_ssize_t) != ownSizeof(compiler_ssize_t_570425900):
-        static:
-          warning(
-            "Declaration of " & "compiler_ssize_t" & " exists but with different size"
-          )
-      compiler_ssize_t
-    else:
-      compiler_ssize_t_570425900
-  )
-  struct_lsquic_shared_hash_if_570425871 = (
-    when declared(struct_lsquic_shared_hash_if):
-      when ownSizeof(struct_lsquic_shared_hash_if) !=
-          ownSizeof(struct_lsquic_shared_hash_if_570425870):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_shared_hash_if" &
-              " exists but with different size"
-          )
-      struct_lsquic_shared_hash_if
-    else:
-      struct_lsquic_shared_hash_if_570425870
-  )
-  lsquic_stream_t_570425849 = (
-    when declared(lsquic_stream_t):
-      when ownSizeof(lsquic_stream_t) != ownSizeof(lsquic_stream_t_570425848):
-        static:
-          warning(
-            "Declaration of " & "lsquic_stream_t" & " exists but with different size"
-          )
-      lsquic_stream_t
-    else:
-      lsquic_stream_t_570425848
-  )
-  struct_lsquic_ext_http_prio_570425885 = (
-    when declared(struct_lsquic_ext_http_prio):
-      when ownSizeof(struct_lsquic_ext_http_prio) !=
-          ownSizeof(struct_lsquic_ext_http_prio_570425884):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_ext_http_prio" &
-              " exists but with different size"
-          )
-      struct_lsquic_ext_http_prio
-    else:
-      struct_lsquic_ext_http_prio_570425884
-  )
-  struct_lsquic_conn_info_570425896 = (
-    when declared(struct_lsquic_conn_info):
-      when ownSizeof(struct_lsquic_conn_info) !=
-          ownSizeof(struct_lsquic_conn_info_570425895):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_conn_info" &
-              " exists but with different size"
-          )
-      struct_lsquic_conn_info
-    else:
-      struct_lsquic_conn_info_570425895
-  )
-  lsquic_stream_id_t_570425841 = (
-    when declared(lsquic_stream_id_t):
-      when ownSizeof(lsquic_stream_id_t) != ownSizeof(lsquic_stream_id_t_570425840):
-        static:
-          warning(
-            "Declaration of " & "lsquic_stream_id_t" & " exists but with different size"
-          )
-      lsquic_stream_id_t
-    else:
-      lsquic_stream_id_t_570425840
-  )
-  struct_lsquic_logger_if_570425887 = (
-    when declared(struct_lsquic_logger_if):
-      when ownSizeof(struct_lsquic_logger_if) !=
-          ownSizeof(struct_lsquic_logger_if_570425886):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_logger_if" &
-              " exists but with different size"
-          )
-      struct_lsquic_logger_if
-    else:
-      struct_lsquic_logger_if_570425886
-  )
-  struct_lsquic_packout_mem_if_570425875 = (
-    when declared(struct_lsquic_packout_mem_if):
-      when ownSizeof(struct_lsquic_packout_mem_if) !=
-          ownSizeof(struct_lsquic_packout_mem_if_570425874):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_packout_mem_if" &
-              " exists but with different size"
-          )
-      struct_lsquic_packout_mem_if
-    else:
-      struct_lsquic_packout_mem_if_570425874
-  )
-  lsquic_conn_t_570425845 = (
-    when declared(lsquic_conn_t):
-      when ownSizeof(lsquic_conn_t) != ownSizeof(lsquic_conn_t_570425844):
-        static:
-          warning(
-            "Declaration of " & "lsquic_conn_t" & " exists but with different size"
-          )
-      lsquic_conn_t
-    else:
-      lsquic_conn_t_570425844
-  )
-  struct_lsquic_http_headers_570425855 = (
-    when declared(struct_lsquic_http_headers):
-      when ownSizeof(struct_lsquic_http_headers) !=
-          ownSizeof(struct_lsquic_http_headers_570425854):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_http_headers" &
-              " exists but with different size"
-          )
-      struct_lsquic_http_headers
-    else:
-      struct_lsquic_http_headers_570425854
-  )
-  ssize_t_570425859 = (
-    when declared(ssize_t):
-      when ownSizeof(ssize_t) != ownSizeof(ssize_t_570425858):
-        static:
-          warning("Declaration of " & "ssize_t" & " exists but with different size")
-      ssize_t
-    else:
-      ssize_t_570425858
-  )
-  struct_lsquic_engine_settings_570425863 = (
-    when declared(struct_lsquic_engine_settings):
-      when ownSizeof(struct_lsquic_engine_settings) !=
-          ownSizeof(struct_lsquic_engine_settings_570425862):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_engine_settings" &
-              " exists but with different size"
-          )
-      struct_lsquic_engine_settings
-    else:
-      struct_lsquic_engine_settings_570425862
-  )
-  lsquic_cids_update_f_570425877 = (
-    when declared(lsquic_cids_update_f):
-      when ownSizeof(lsquic_cids_update_f) != ownSizeof(lsquic_cids_update_f_570425876):
-        static:
-          warning(
-            "Declaration of " & "lsquic_cids_update_f" &
-              " exists but with different size"
-          )
-      lsquic_cids_update_f
-    else:
-      lsquic_cids_update_f_570425876
-  )
-  compiler_time_t_570425903 = (
-    when declared(compiler_time_t):
-      when ownSizeof(compiler_time_t) != ownSizeof(compiler_time_t_570425902):
-        static:
-          warning(
-            "Declaration of " & "compiler_time_t" & " exists but with different size"
-          )
-      compiler_time_t
-    else:
-      compiler_time_t_570425902
-  )
-  lsquic_conn_ctx_t_570425847 = (
-    when declared(lsquic_conn_ctx_t):
-      when ownSizeof(lsquic_conn_ctx_t) != ownSizeof(lsquic_conn_ctx_t_570425846):
-        static:
-          warning(
-            "Declaration of " & "lsquic_conn_ctx_t" & " exists but with different size"
-          )
-      lsquic_conn_ctx_t
-    else:
-      lsquic_conn_ctx_t_570425846
-  )
-  struct_lsquic_stream_if_570425857 = (
-    when declared(struct_lsquic_stream_if):
-      when ownSizeof(struct_lsquic_stream_if) !=
-          ownSizeof(struct_lsquic_stream_if_570425856):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_stream_if" &
-              " exists but with different size"
-          )
-      struct_lsquic_stream_if
-    else:
-      struct_lsquic_stream_if_570425856
-  )
-  struct_lsquic_hset_if_570425879 = (
-    when declared(struct_lsquic_hset_if):
-      when ownSizeof(struct_lsquic_hset_if) != ownSizeof(
-        struct_lsquic_hset_if_570425878
-      ):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_hset_if" &
-              " exists but with different size"
-          )
-      struct_lsquic_hset_if
-    else:
-      struct_lsquic_hset_if_570425878
-  )
-  struct_iovec_570425867 = (
-    when declared(struct_iovec):
-      when ownSizeof(struct_iovec) != ownSizeof(struct_iovec_570425866):
-        static:
-          warning(
-            "Declaration of " & "struct_iovec" & " exists but with different size"
-          )
-      struct_iovec
-    else:
-      struct_iovec_570425866
-  )
-  lsquic_stream_ctx_t_570425851 = (
-    when declared(lsquic_stream_ctx_t):
-      when ownSizeof(lsquic_stream_ctx_t) != ownSizeof(lsquic_stream_ctx_t_570425850):
-        static:
-          warning(
-            "Declaration of " & "lsquic_stream_ctx_t" & " exists but with different size"
-          )
-      lsquic_stream_ctx_t
-    else:
-      lsquic_stream_ctx_t_570425850
-  )
-  uint_fast8_t_570425837 = (
-    when declared(uint_fast8_t):
-      when ownSizeof(uint_fast8_t) != ownSizeof(uint_fast8_t_570425836):
-        static:
-          warning(
-            "Declaration of " & "uint_fast8_t" & " exists but with different size"
-          )
-      uint_fast8_t
-    else:
-      uint_fast8_t_570425836
-  )
-  struct_lsquic_out_spec_570425865 = (
-    when declared(struct_lsquic_out_spec):
-      when ownSizeof(struct_lsquic_out_spec) !=
-          ownSizeof(struct_lsquic_out_spec_570425864):
-        static:
-          warning(
-            "Declaration of " & "struct_lsquic_out_spec" &
-              " exists but with different size"
-          )
-      struct_lsquic_out_spec
-    else:
-      struct_lsquic_out_spec_570425864
-  )
-  lsquic_engine_t_570425843 = (
-    when declared(lsquic_engine_t):
-      when ownSizeof(lsquic_engine_t) != ownSizeof(lsquic_engine_t_570425842):
-        static:
-          warning(
-            "Declaration of " & "lsquic_engine_t" & " exists but with different size"
-          )
-      lsquic_engine_t
-    else:
-      lsquic_engine_t_570425842
-  )
-  time_t_570425873 = (
-    when declared(time_t):
-      when ownSizeof(time_t) != ownSizeof(time_t_570425872):
-        static:
-          warning("Declaration of " & "time_t" & " exists but with different size")
-      time_t
-    else:
-      time_t_570425872
-  )
-  lsquic_http_headers_t_570425853 = (
-    when declared(lsquic_http_headers_t):
-      when ownSizeof(lsquic_http_headers_t) != ownSizeof(
-        lsquic_http_headers_t_570425852
-      ):
-        static:
-          warning(
-            "Declaration of " & "lsquic_http_headers_t" &
-              " exists but with different size"
-          )
-      lsquic_http_headers_t
-    else:
-      lsquic_http_headers_t_570425852
-  )
-  lsquic_packets_out_f_570425869 = (
-    when declared(lsquic_packets_out_f):
-      when ownSizeof(lsquic_packets_out_f) != ownSizeof(lsquic_packets_out_f_570425868):
-        static:
-          warning(
-            "Declaration of " & "lsquic_packets_out_f" &
-              " exists but with different size"
-          )
-      lsquic_packets_out_f
-    else:
-      lsquic_packets_out_f_570425868
-  )
 
-when not declared(struct_lsquic_reader):
-  type struct_lsquic_reader* = struct_lsquic_reader_570425882
+when buf is typedesc:
+  type idbuf* = buf
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:30:9
+
 else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_reader" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_lookup_cert_f):
-  type lsquic_lookup_cert_f* = lsquic_lookup_cert_f_570425860
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_lookup_cert_f" & " already exists, not redeclaring"
-    )
-when not declared(struct_lsquic_engine_api):
-  type struct_lsquic_engine_api* = struct_lsquic_engine_api_570425880
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_engine_api" & " already exists, not redeclaring"
-    )
-when not declared(compiler_ssize_t):
-  type compiler_ssize_t* = compiler_ssize_t_570425900
-else:
-  static:
-    hint("Declaration of " & "compiler_ssize_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_shared_hash_if):
-  type struct_lsquic_shared_hash_if* = struct_lsquic_shared_hash_if_570425870
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_shared_hash_if" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_t):
-  type lsquic_stream_t* = lsquic_stream_t_570425848
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_ext_http_prio):
-  type struct_lsquic_ext_http_prio* = struct_lsquic_ext_http_prio_570425884
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_ext_http_prio" &
-        " already exists, not redeclaring"
-    )
-when not declared(struct_lsquic_conn_info):
-  type struct_lsquic_conn_info* = struct_lsquic_conn_info_570425895
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_conn_info" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_id_t):
-  type lsquic_stream_id_t* = lsquic_stream_id_t_570425840
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_id_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_logger_if):
-  type struct_lsquic_logger_if* = struct_lsquic_logger_if_570425886
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_logger_if" & " already exists, not redeclaring"
-    )
-when not declared(struct_lsquic_packout_mem_if):
-  type struct_lsquic_packout_mem_if* = struct_lsquic_packout_mem_if_570425874
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_packout_mem_if" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_t):
-  type lsquic_conn_t* = lsquic_conn_t_570425844
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_http_headers):
-  type struct_lsquic_http_headers* = struct_lsquic_http_headers_570425854
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_http_headers" &
-        " already exists, not redeclaring"
-    )
-when not declared(ssize_t):
-  type ssize_t* = ssize_t_570425858
-else:
-  static:
-    hint("Declaration of " & "ssize_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_engine_settings):
-  type struct_lsquic_engine_settings* = struct_lsquic_engine_settings_570425862
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_engine_settings" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_cids_update_f):
-  type lsquic_cids_update_f* = lsquic_cids_update_f_570425876
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_cids_update_f" & " already exists, not redeclaring"
-    )
-when not declared(compiler_time_t):
-  type compiler_time_t* = compiler_time_t_570425902
-else:
-  static:
-    hint("Declaration of " & "compiler_time_t" & " already exists, not redeclaring")
-when not declared(lsquic_conn_ctx_t):
-  type lsquic_conn_ctx_t* = lsquic_conn_ctx_t_570425846
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_ctx_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_stream_if):
-  type struct_lsquic_stream_if* = struct_lsquic_stream_if_570425856
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_stream_if" & " already exists, not redeclaring"
-    )
-when not declared(struct_lsquic_hset_if):
-  type struct_lsquic_hset_if* = struct_lsquic_hset_if_570425878
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_hset_if" & " already exists, not redeclaring"
-    )
-when not declared(struct_iovec):
-  type struct_iovec* = struct_iovec_570425866
-else:
-  static:
-    hint("Declaration of " & "struct_iovec" & " already exists, not redeclaring")
-when not declared(lsquic_stream_ctx_t):
-  type lsquic_stream_ctx_t* = lsquic_stream_ctx_t_570425850
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_ctx_t" & " already exists, not redeclaring")
-when not declared(uint_fast8_t):
-  type uint_fast8_t* = uint_fast8_t_570425836
-else:
-  static:
-    hint("Declaration of " & "uint_fast8_t" & " already exists, not redeclaring")
-when not declared(struct_lsquic_out_spec):
-  type struct_lsquic_out_spec* = struct_lsquic_out_spec_570425864
-else:
-  static:
-    hint(
-      "Declaration of " & "struct_lsquic_out_spec" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_t):
-  type lsquic_engine_t* = lsquic_engine_t_570425842
-else:
-  static:
-    hint("Declaration of " & "lsquic_engine_t" & " already exists, not redeclaring")
-when not declared(time_t):
-  type time_t* = time_t_570425872
-else:
-  static:
-    hint("Declaration of " & "time_t" & " already exists, not redeclaring")
-when not declared(lsquic_http_headers_t):
-  type lsquic_http_headers_t* = lsquic_http_headers_t_570425852
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_http_headers_t" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_packets_out_f):
-  type lsquic_packets_out_f* = lsquic_packets_out_f_570425868
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_packets_out_f" & " already exists, not redeclaring"
-    )
-when not declared(MAX_CID_LEN):
-  when 20 is static:
-    const MAX_CID_LEN* = 20
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:13:9
-  else:
-    let MAX_CID_LEN* = 20
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:13:9
-else:
-  static:
-    hint("Declaration of " & "MAX_CID_LEN" & " already exists, not redeclaring")
-when not declared(GQUIC_CID_LEN):
-  when 8 is static:
-    const GQUIC_CID_LEN* = 8
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:14:9
-  else:
-    let GQUIC_CID_LEN* = 8
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:14:9
-else:
-  static:
-    hint("Declaration of " & "GQUIC_CID_LEN" & " already exists, not redeclaring")
-when not declared(idbuf):
-  when buf is typedesc:
-    type idbuf* = buf
+  when buf is static:
+    const idbuf* = buf
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:30:9
+  else:
+    let idbuf* = buf
+      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:30:9
+when 4 is static:
+  const LSQUIC_MAJOR_VERSION* = 4
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:28:9
+else:
+  let LSQUIC_MAJOR_VERSION* = 4
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:28:9
+when 7 is static:
+  const LSQUIC_MINOR_VERSION* = 7
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:29:9
+else:
+  let LSQUIC_MINOR_VERSION* = 7
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:29:9
+when 0 is static:
+  const LSQUIC_PATCH_VERSION* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:30:9
+else:
+  let LSQUIC_PATCH_VERSION* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:30:9
+when 100 is static:
+  const LSQUIC_DF_MAX_STREAMS_IN* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:285:9
+else:
+  let LSQUIC_DF_MAX_STREAMS_IN* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:285:9
+when LSQUIC_DF_CFCW_SERVER is typedesc:
+  type LSQUIC_DF_INIT_MAX_DATA_SERVER* = LSQUIC_DF_CFCW_SERVER
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:288:9
 
-  else:
-    when buf is static:
-      const idbuf* = buf
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:30:9
-    else:
-      let idbuf* = buf
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic_types.h:30:9
 else:
-  static:
-    hint("Declaration of " & "idbuf" & " already exists, not redeclaring")
-when not declared(LSQUIC_MAJOR_VERSION):
-  when 4 is static:
-    const LSQUIC_MAJOR_VERSION* = 4
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:28:9
-  else:
-    let LSQUIC_MAJOR_VERSION* = 4
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:28:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_MAJOR_VERSION" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_MINOR_VERSION):
-  when 7 is static:
-    const LSQUIC_MINOR_VERSION* = 7
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:29:9
-  else:
-    let LSQUIC_MINOR_VERSION* = 7
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:29:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_MINOR_VERSION" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_PATCH_VERSION):
-  when 0 is static:
-    const LSQUIC_PATCH_VERSION* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:30:9
-  else:
-    let LSQUIC_PATCH_VERSION* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:30:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_PATCH_VERSION" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MAX_STREAMS_IN):
-  when 100 is static:
-    const LSQUIC_DF_MAX_STREAMS_IN* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:285:9
-  else:
-    let LSQUIC_DF_MAX_STREAMS_IN* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:285:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MAX_STREAMS_IN" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_DATA_SERVER):
-  when LSQUIC_DF_CFCW_SERVER is typedesc:
-    type LSQUIC_DF_INIT_MAX_DATA_SERVER* = LSQUIC_DF_CFCW_SERVER
+  when LSQUIC_DF_CFCW_SERVER is static:
+    const LSQUIC_DF_INIT_MAX_DATA_SERVER* = LSQUIC_DF_CFCW_SERVER
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:288:9
-
   else:
-    when LSQUIC_DF_CFCW_SERVER is static:
-      const LSQUIC_DF_INIT_MAX_DATA_SERVER* = LSQUIC_DF_CFCW_SERVER
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:288:9
-    else:
-      let LSQUIC_DF_INIT_MAX_DATA_SERVER* = LSQUIC_DF_CFCW_SERVER
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:288:9
+    let LSQUIC_DF_INIT_MAX_DATA_SERVER* = LSQUIC_DF_CFCW_SERVER
+      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:288:9
+when LSQUIC_DF_CFCW_CLIENT is typedesc:
+  type LSQUIC_DF_INIT_MAX_DATA_CLIENT* = LSQUIC_DF_CFCW_CLIENT
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:289:9
+
 else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_DATA_SERVER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_DATA_CLIENT):
-  when LSQUIC_DF_CFCW_CLIENT is typedesc:
-    type LSQUIC_DF_INIT_MAX_DATA_CLIENT* = LSQUIC_DF_CFCW_CLIENT
+  when LSQUIC_DF_CFCW_CLIENT is static:
+    const LSQUIC_DF_INIT_MAX_DATA_CLIENT* = LSQUIC_DF_CFCW_CLIENT
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:289:9
-
   else:
-    when LSQUIC_DF_CFCW_CLIENT is static:
-      const LSQUIC_DF_INIT_MAX_DATA_CLIENT* = LSQUIC_DF_CFCW_CLIENT
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:289:9
-    else:
-      let LSQUIC_DF_INIT_MAX_DATA_CLIENT* = LSQUIC_DF_CFCW_CLIENT
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:289:9
+    let LSQUIC_DF_INIT_MAX_DATA_CLIENT* = LSQUIC_DF_CFCW_CLIENT
+      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:289:9
+when LSQUIC_DF_SFCW_SERVER is typedesc:
+  type LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER* = LSQUIC_DF_SFCW_SERVER
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:290:9
+
 else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_DATA_CLIENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER):
-  when LSQUIC_DF_SFCW_SERVER is typedesc:
-    type LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER* = LSQUIC_DF_SFCW_SERVER
+  when LSQUIC_DF_SFCW_SERVER is static:
+    const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER* = LSQUIC_DF_SFCW_SERVER
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:290:9
+  else:
+    let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER* = LSQUIC_DF_SFCW_SERVER
+      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:290:9
+when 0 is static:
+  const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_SERVER* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:291:9
+else:
+  let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_SERVER* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:291:9
+when 0 is static:
+  const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_CLIENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:292:9
+else:
+  let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_CLIENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:292:9
+when LSQUIC_DF_SFCW_CLIENT is typedesc:
+  type LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT* = LSQUIC_DF_SFCW_CLIENT
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:293:9
 
-  else:
-    when LSQUIC_DF_SFCW_SERVER is static:
-      const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER* = LSQUIC_DF_SFCW_SERVER
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:290:9
-    else:
-      let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER* = LSQUIC_DF_SFCW_SERVER
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:290:9
 else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_SERVER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_SERVER):
-  when 0 is static:
-    const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_SERVER* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:291:9
-  else:
-    let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_SERVER* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:291:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_SERVER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_CLIENT):
-  when 0 is static:
-    const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_CLIENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:292:9
-  else:
-    let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_CLIENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:292:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_REMOTE_CLIENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT):
-  when LSQUIC_DF_SFCW_CLIENT is typedesc:
-    type LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT* = LSQUIC_DF_SFCW_CLIENT
+  when LSQUIC_DF_SFCW_CLIENT is static:
+    const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT* = LSQUIC_DF_SFCW_CLIENT
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:293:9
-
   else:
-    when LSQUIC_DF_SFCW_CLIENT is static:
-      const LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT* = LSQUIC_DF_SFCW_CLIENT
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:293:9
-    else:
-      let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT* = LSQUIC_DF_SFCW_CLIENT
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:293:9
+    let LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT* = LSQUIC_DF_SFCW_CLIENT
+      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:293:9
+when LSQUIC_DF_MAX_STREAMS_IN is typedesc:
+  type LSQUIC_DF_INIT_MAX_STREAMS_BIDI* = LSQUIC_DF_MAX_STREAMS_IN
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:294:9
+
 else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAM_DATA_BIDI_LOCAL_CLIENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAMS_BIDI):
-  when LSQUIC_DF_MAX_STREAMS_IN is typedesc:
-    type LSQUIC_DF_INIT_MAX_STREAMS_BIDI* = LSQUIC_DF_MAX_STREAMS_IN
+  when LSQUIC_DF_MAX_STREAMS_IN is static:
+    const LSQUIC_DF_INIT_MAX_STREAMS_BIDI* = LSQUIC_DF_MAX_STREAMS_IN
       ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:294:9
-
-  else:
-    when LSQUIC_DF_MAX_STREAMS_IN is static:
-      const LSQUIC_DF_INIT_MAX_STREAMS_BIDI* = LSQUIC_DF_MAX_STREAMS_IN
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:294:9
-    else:
-      let LSQUIC_DF_INIT_MAX_STREAMS_BIDI* = LSQUIC_DF_MAX_STREAMS_IN
-        ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:294:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAMS_BIDI" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAMS_UNI_CLIENT):
-  when 100 is static:
-    const LSQUIC_DF_INIT_MAX_STREAMS_UNI_CLIENT* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:295:9
-  else:
-    let LSQUIC_DF_INIT_MAX_STREAMS_UNI_CLIENT* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:295:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAMS_UNI_CLIENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_INIT_MAX_STREAMS_UNI_SERVER):
-  when 3 is static:
-    const LSQUIC_DF_INIT_MAX_STREAMS_UNI_SERVER* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:296:9
-  else:
-    let LSQUIC_DF_INIT_MAX_STREAMS_UNI_SERVER* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:296:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_INIT_MAX_STREAMS_UNI_SERVER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_IDLE_TIMEOUT):
-  when 30 is static:
-    const LSQUIC_DF_IDLE_TIMEOUT* = 30
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:304:9
-  else:
-    let LSQUIC_DF_IDLE_TIMEOUT* = 30
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:304:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_IDLE_TIMEOUT" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PING_PERIOD):
-  when 15 is static:
-    const LSQUIC_DF_PING_PERIOD* = 15
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:309:9
-  else:
-    let LSQUIC_DF_PING_PERIOD* = 15
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:309:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PING_PERIOD" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SILENT_CLOSE):
-  when 1 is static:
-    const LSQUIC_DF_SILENT_CLOSE* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:317:9
-  else:
-    let LSQUIC_DF_SILENT_CLOSE* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:317:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SILENT_CLOSE" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MAX_HEADER_LIST_SIZE):
-  when 0 is static:
-    const LSQUIC_DF_MAX_HEADER_LIST_SIZE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:323:9
-  else:
-    let LSQUIC_DF_MAX_HEADER_LIST_SIZE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:323:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MAX_HEADER_LIST_SIZE" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_UA):
-  when "LSQUIC" is static:
-    const LSQUIC_DF_UA* = "LSQUIC"
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:326:9
-  else:
-    let LSQUIC_DF_UA* = "LSQUIC"
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:326:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_UA" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_STTL):
-  when 86400 is static:
-    const LSQUIC_DF_STTL* = 86400
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:328:9
-  else:
-    let LSQUIC_DF_STTL* = 86400
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:328:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_STTL" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_SUPPORT_SREJ_SERVER):
-  when 1 is static:
-    const LSQUIC_DF_SUPPORT_SREJ_SERVER* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:331:9
-  else:
-    let LSQUIC_DF_SUPPORT_SREJ_SERVER* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:331:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SUPPORT_SREJ_SERVER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SUPPORT_SREJ_CLIENT):
-  when 0 is static:
-    const LSQUIC_DF_SUPPORT_SREJ_CLIENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:332:9
-  else:
-    let LSQUIC_DF_SUPPORT_SREJ_CLIENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:332:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SUPPORT_SREJ_CLIENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SUPPORT_NSTP):
-  when 0 is static:
-    const LSQUIC_DF_SUPPORT_NSTP* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:335:9
-  else:
-    let LSQUIC_DF_SUPPORT_NSTP* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:335:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SUPPORT_NSTP" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SUPPORT_PUSH):
-  when 0 is static:
-    const LSQUIC_DF_SUPPORT_PUSH* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:337:9
-  else:
-    let LSQUIC_DF_SUPPORT_PUSH* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:337:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SUPPORT_PUSH" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SUPPORT_TCID0):
-  when 1 is static:
-    const LSQUIC_DF_SUPPORT_TCID0* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:338:9
-  else:
-    let LSQUIC_DF_SUPPORT_TCID0* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:338:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SUPPORT_TCID0" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_HONOR_PRST):
-  when 0 is static:
-    const LSQUIC_DF_HONOR_PRST* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:340:9
-  else:
-    let LSQUIC_DF_HONOR_PRST* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:340:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_HONOR_PRST" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SEND_PRST):
-  when 0 is static:
-    const LSQUIC_DF_SEND_PRST* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:346:9
-  else:
-    let LSQUIC_DF_SEND_PRST* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:346:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_SEND_PRST" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_SEND_VERNEG):
-  when 1 is static:
-    const LSQUIC_DF_SEND_VERNEG* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:352:9
-  else:
-    let LSQUIC_DF_SEND_VERNEG* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:352:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SEND_VERNEG" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PROGRESS_CHECK):
-  when 1000 is static:
-    const LSQUIC_DF_PROGRESS_CHECK* = 1000
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:355:9
-  else:
-    let LSQUIC_DF_PROGRESS_CHECK* = 1000
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:355:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PROGRESS_CHECK" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_RW_ONCE):
-  when 0 is static:
-    const LSQUIC_DF_RW_ONCE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:358:9
-  else:
-    let LSQUIC_DF_RW_ONCE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:358:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_RW_ONCE" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_PROC_TIME_THRESH):
-  when 0 is static:
-    const LSQUIC_DF_PROC_TIME_THRESH* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:361:9
-  else:
-    let LSQUIC_DF_PROC_TIME_THRESH* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:361:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PROC_TIME_THRESH" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PACE_PACKETS):
-  when 1 is static:
-    const LSQUIC_DF_PACE_PACKETS* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:364:9
-  else:
-    let LSQUIC_DF_PACE_PACKETS* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:364:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PACE_PACKETS" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_CLOCK_GRANULARITY):
-  when 1000 is static:
-    const LSQUIC_DF_CLOCK_GRANULARITY* = 1000
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:367:9
-  else:
-    let LSQUIC_DF_CLOCK_GRANULARITY* = 1000
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:367:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_CLOCK_GRANULARITY" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_SCID_LEN):
-  when 8 is static:
-    const LSQUIC_DF_SCID_LEN* = 8
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:370:9
-  else:
-    let LSQUIC_DF_SCID_LEN* = 8
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:370:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_SCID_LEN" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_SCID_ISS_RATE):
-  when 60 is static:
-    const LSQUIC_DF_SCID_ISS_RATE* = 60
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:373:9
-  else:
-    let LSQUIC_DF_SCID_ISS_RATE* = 60
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:373:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_SCID_ISS_RATE" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_QPACK_DEC_MAX_BLOCKED):
-  when 100 is static:
-    const LSQUIC_DF_QPACK_DEC_MAX_BLOCKED* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:375:9
-  else:
-    let LSQUIC_DF_QPACK_DEC_MAX_BLOCKED* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:375:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_QPACK_DEC_MAX_BLOCKED" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_QPACK_DEC_MAX_SIZE):
-  when 4096 is static:
-    const LSQUIC_DF_QPACK_DEC_MAX_SIZE* = 4096
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:376:9
-  else:
-    let LSQUIC_DF_QPACK_DEC_MAX_SIZE* = 4096
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:376:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_QPACK_DEC_MAX_SIZE" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_QPACK_ENC_MAX_BLOCKED):
-  when 100 is static:
-    const LSQUIC_DF_QPACK_ENC_MAX_BLOCKED* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:377:9
-  else:
-    let LSQUIC_DF_QPACK_ENC_MAX_BLOCKED* = 100
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:377:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_QPACK_ENC_MAX_BLOCKED" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_QPACK_ENC_MAX_SIZE):
-  when 4096 is static:
-    const LSQUIC_DF_QPACK_ENC_MAX_SIZE* = 4096
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:378:9
-  else:
-    let LSQUIC_DF_QPACK_ENC_MAX_SIZE* = 4096
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:378:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_QPACK_ENC_MAX_SIZE" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_QPACK_EXPERIMENT):
-  when 0 is static:
-    const LSQUIC_DF_QPACK_EXPERIMENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:381:9
-  else:
-    let LSQUIC_DF_QPACK_EXPERIMENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:381:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_QPACK_EXPERIMENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_ECN):
-  when 0 is static:
-    const LSQUIC_DF_ECN* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:384:9
-  else:
-    let LSQUIC_DF_ECN* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:384:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_ECN" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_ALLOW_MIGRATION):
-  when 1 is static:
-    const LSQUIC_DF_ALLOW_MIGRATION* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:387:9
-  else:
-    let LSQUIC_DF_ALLOW_MIGRATION* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:387:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_ALLOW_MIGRATION" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_RETRY_TOKEN_DURATION):
-  when 10 is static:
-    const LSQUIC_DF_RETRY_TOKEN_DURATION* = 10
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:390:9
-  else:
-    let LSQUIC_DF_RETRY_TOKEN_DURATION* = 10
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:390:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_RETRY_TOKEN_DURATION" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_QL_BITS):
-  when 2 is static:
-    const LSQUIC_DF_QL_BITS* = 2
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:393:9
   else:
-    let LSQUIC_DF_QL_BITS* = 2
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:393:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_QL_BITS" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_SPIN):
-  when 1 is static:
-    const LSQUIC_DF_SPIN* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:396:9
-  else:
-    let LSQUIC_DF_SPIN* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:396:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_SPIN" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_DELAYED_ACKS):
-  when 1 is static:
-    const LSQUIC_DF_DELAYED_ACKS* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:399:9
-  else:
-    let LSQUIC_DF_DELAYED_ACKS* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:399:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_DELAYED_ACKS" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_PERIODICITY):
-  when 3 is static:
-    const LSQUIC_DF_PTPC_PERIODICITY* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:405:9
-  else:
-    let LSQUIC_DF_PTPC_PERIODICITY* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:405:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_PERIODICITY" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_MAX_PACKTOL):
-  when 150 is static:
-    const LSQUIC_DF_PTPC_MAX_PACKTOL* = 150
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:406:9
-  else:
-    let LSQUIC_DF_PTPC_MAX_PACKTOL* = 150
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:406:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_MAX_PACKTOL" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_DYN_TARGET):
-  when 1 is static:
-    const LSQUIC_DF_PTPC_DYN_TARGET* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:407:9
-  else:
-    let LSQUIC_DF_PTPC_DYN_TARGET* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:407:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_DYN_TARGET" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_TARGET):
-  when 1.0 is static:
-    const LSQUIC_DF_PTPC_TARGET* = 1.0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:408:9
-  else:
-    let LSQUIC_DF_PTPC_TARGET* = 1.0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:408:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_TARGET" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_PROP_GAIN):
-  when 0.8 is static:
-    const LSQUIC_DF_PTPC_PROP_GAIN* = 0.8
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:409:9
-  else:
-    let LSQUIC_DF_PTPC_PROP_GAIN* = 0.8
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:409:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_PROP_GAIN" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_INT_GAIN):
-  when 0.35 is static:
-    const LSQUIC_DF_PTPC_INT_GAIN* = 0.35
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:410:9
-  else:
-    let LSQUIC_DF_PTPC_INT_GAIN* = 0.35
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:410:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_INT_GAIN" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_ERR_THRESH):
-  when 0.05 is static:
-    const LSQUIC_DF_PTPC_ERR_THRESH* = 0.05
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:411:9
-  else:
-    let LSQUIC_DF_PTPC_ERR_THRESH* = 0.05
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:411:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_ERR_THRESH" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_PTPC_ERR_DIVISOR):
-  when 0.05 is static:
-    const LSQUIC_DF_PTPC_ERR_DIVISOR* = 0.05
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:412:9
-  else:
-    let LSQUIC_DF_PTPC_ERR_DIVISOR* = 0.05
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:412:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_PTPC_ERR_DIVISOR" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_TIMESTAMPS):
-  when 1 is static:
-    const LSQUIC_DF_TIMESTAMPS* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:415:9
-  else:
-    let LSQUIC_DF_TIMESTAMPS* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:415:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_TIMESTAMPS" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_AMP_FACTOR):
-  when 3 is static:
-    const LSQUIC_DF_AMP_FACTOR* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:418:9
-  else:
-    let LSQUIC_DF_AMP_FACTOR* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:418:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_AMP_FACTOR" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_CC_ALGO):
-  when 3 is static:
-    const LSQUIC_DF_CC_ALGO* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:421:9
-  else:
-    let LSQUIC_DF_CC_ALGO* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:421:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_CC_ALGO" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_CC_RTT_THRESH):
-  when 1500 is static:
-    const LSQUIC_DF_CC_RTT_THRESH* = 1500
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:424:9
-  else:
-    let LSQUIC_DF_CC_RTT_THRESH* = 1500
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:424:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_CC_RTT_THRESH" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_ENABLE_BW_SAMPLER):
-  when 0 is static:
-    const LSQUIC_DF_ENABLE_BW_SAMPLER* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:427:9
-  else:
-    let LSQUIC_DF_ENABLE_BW_SAMPLER* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:427:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_ENABLE_BW_SAMPLER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_DATAGRAMS):
-  when 0 is static:
-    const LSQUIC_DF_DATAGRAMS* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:430:9
-  else:
-    let LSQUIC_DF_DATAGRAMS* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:430:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_DATAGRAMS" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_OPTIMISTIC_NAT):
-  when 1 is static:
-    const LSQUIC_DF_OPTIMISTIC_NAT* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:433:9
-  else:
-    let LSQUIC_DF_OPTIMISTIC_NAT* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:433:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_OPTIMISTIC_NAT" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_EXT_HTTP_PRIO):
-  when 1 is static:
-    const LSQUIC_DF_EXT_HTTP_PRIO* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:436:9
-  else:
-    let LSQUIC_DF_EXT_HTTP_PRIO* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:436:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_EXT_HTTP_PRIO" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX):
-  when 0 is static:
-    const LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:439:9
-  else:
-    let LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:439:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_GREASE_QUIC_BIT):
-  when 1 is static:
-    const LSQUIC_DF_GREASE_QUIC_BIT* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:445:9
-  else:
-    let LSQUIC_DF_GREASE_QUIC_BIT* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:445:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_GREASE_QUIC_BIT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_DPLPMTUD):
-  when 1 is static:
-    const LSQUIC_DF_DPLPMTUD* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:448:9
-  else:
-    let LSQUIC_DF_DPLPMTUD* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:448:9
-else:
-  static:
-    hint("Declaration of " & "LSQUIC_DF_DPLPMTUD" & " already exists, not redeclaring")
-when not declared(LSQUIC_DF_BASE_PLPMTU):
-  when 0 is static:
-    const LSQUIC_DF_BASE_PLPMTU* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:451:9
-  else:
-    let LSQUIC_DF_BASE_PLPMTU* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:451:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_BASE_PLPMTU" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MAX_PLPMTU):
-  when 0 is static:
-    const LSQUIC_DF_MAX_PLPMTU* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:454:9
-  else:
-    let LSQUIC_DF_MAX_PLPMTU* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:454:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MAX_PLPMTU" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER):
-  when 60 is static:
-    const LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER* = 60
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:457:9
-  else:
-    let LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER* = 60
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:457:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_NOPROGRESS_TIMEOUT_CLIENT):
-  when 0 is static:
-    const LSQUIC_DF_NOPROGRESS_TIMEOUT_CLIENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:460:9
-  else:
-    let LSQUIC_DF_NOPROGRESS_TIMEOUT_CLIENT* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:460:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_NOPROGRESS_TIMEOUT_CLIENT" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MTU_PROBE_TIMER):
-  when 1000 is static:
-    const LSQUIC_DF_MTU_PROBE_TIMER* = 1000
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:463:9
-  else:
-    let LSQUIC_DF_MTU_PROBE_TIMER* = 1000
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:463:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MTU_PROBE_TIMER" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_DELAY_ONCLOSE):
-  when 0 is static:
-    const LSQUIC_DF_DELAY_ONCLOSE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:466:9
-  else:
-    let LSQUIC_DF_DELAY_ONCLOSE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:466:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_DELAY_ONCLOSE" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MAX_BATCH_SIZE):
-  when 0 is static:
-    const LSQUIC_DF_MAX_BATCH_SIZE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:472:9
-  else:
-    let LSQUIC_DF_MAX_BATCH_SIZE* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:472:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MAX_BATCH_SIZE" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS):
-  when 32 is static:
-    const LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS* = 32
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:475:9
-  else:
-    let LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS* = 32
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:475:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DF_CHECK_TP_SANITY):
-  when 1 is static:
-    const LSQUIC_DF_CHECK_TP_SANITY* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:478:9
-  else:
-    let LSQUIC_DF_CHECK_TP_SANITY* = 1
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:478:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DF_CHECK_TP_SANITY" &
-        " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_MAX_HTTP_URGENCY):
-  when 7 is static:
-    const LSQUIC_MAX_HTTP_URGENCY* = 7
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1896:9
-  else:
-    let LSQUIC_MAX_HTTP_URGENCY* = 7
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1896:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_MAX_HTTP_URGENCY" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DEF_HTTP_URGENCY):
-  when 3 is static:
-    const LSQUIC_DEF_HTTP_URGENCY* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1897:9
-  else:
-    let LSQUIC_DEF_HTTP_URGENCY* = 3
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1897:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DEF_HTTP_URGENCY" & " already exists, not redeclaring"
-    )
-when not declared(LSQUIC_DEF_HTTP_INCREMENTAL):
-  when 0 is static:
-    const LSQUIC_DEF_HTTP_INCREMENTAL* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1898:9
-  else:
-    let LSQUIC_DEF_HTTP_INCREMENTAL* = 0
-      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1898:9
-else:
-  static:
-    hint(
-      "Declaration of " & "LSQUIC_DEF_HTTP_INCREMENTAL" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_init_settings):
-  proc lsquic_engine_init_settings*(
-    a0: ptr struct_lsquic_engine_settings_570425863, lsquic_engine_flags: cuint
-  ): void {.cdecl, importc: "lsquic_engine_init_settings".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_init_settings" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_check_settings):
-  proc lsquic_engine_check_settings*(
-    settings: ptr struct_lsquic_engine_settings_570425863,
-    lsquic_engine_flags: cuint,
-    err_buf: cstring,
-    err_buf_sz: csize_t,
-  ): cint {.cdecl, importc: "lsquic_engine_check_settings".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_check_settings" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_get_conns_count):
-  proc lsquic_engine_get_conns_count*(
-    engine: ptr lsquic_engine_t_570425843
-  ): cuint {.cdecl, importc: "lsquic_engine_get_conns_count".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_get_conns_count" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_new):
-  proc lsquic_engine_new*(
-    lsquic_engine_flags: cuint, api: ptr struct_lsquic_engine_api_570425881
-  ): ptr lsquic_engine_t_570425843 {.cdecl, importc: "lsquic_engine_new".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_engine_new" & " already exists, not redeclaring")
-when not declared(lsquic_engine_connect):
-  proc lsquic_engine_connect*(
-    a0: ptr lsquic_engine_t_570425843,
-    a1: enum_lsquic_version,
-    local_sa: ptr SockAddr,
-    peer_sa: ptr SockAddr,
-    peer_ctx: pointer,
-    conn_ctx: ptr lsquic_conn_ctx_t_570425847,
-    hostname: cstring,
-    base_plpmtu: cushort,
-    sess_resume: ptr uint8,
-    sess_resume_len: csize_t,
-    token: ptr uint8,
-    token_sz: csize_t,
-  ): ptr lsquic_conn_t_570425845 {.cdecl, importc: "lsquic_engine_connect".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_connect" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_packet_in):
-  proc lsquic_engine_packet_in*(
-    a0: ptr lsquic_engine_t_570425843,
-    packet_in_data: ptr uint8,
-    packet_in_size: csize_t,
-    sa_local: ptr SockAddr,
-    sa_peer: ptr SockAddr,
-    peer_ctx: pointer,
-    ecn: cint,
-  ): cint {.cdecl, importc: "lsquic_engine_packet_in".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_packet_in" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_process_conns):
-  proc lsquic_engine_process_conns*(
-    engine: ptr lsquic_engine_t_570425843
-  ): void {.cdecl, importc: "lsquic_engine_process_conns".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_process_conns" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_has_unsent_packets):
-  proc lsquic_engine_has_unsent_packets*(
-    engine: ptr lsquic_engine_t_570425843
-  ): cint {.cdecl, importc: "lsquic_engine_has_unsent_packets".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_has_unsent_packets" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_send_unsent_packets):
-  proc lsquic_engine_send_unsent_packets*(
-    engine: ptr lsquic_engine_t_570425843
-  ): void {.cdecl, importc: "lsquic_engine_send_unsent_packets".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_send_unsent_packets" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_destroy):
-  proc lsquic_engine_destroy*(
-    a0: ptr lsquic_engine_t_570425843
-  ): void {.cdecl, importc: "lsquic_engine_destroy".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_destroy" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_n_avail_streams):
-  proc lsquic_conn_n_avail_streams*(
-    a0: ptr lsquic_conn_t_570425845
-  ): cuint {.cdecl, importc: "lsquic_conn_n_avail_streams".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_n_avail_streams" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_make_stream):
-  proc lsquic_conn_make_stream*(
-    a0: ptr lsquic_conn_t_570425845
-  ): void {.cdecl, importc: "lsquic_conn_make_stream".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_make_stream" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_n_pending_streams):
-  proc lsquic_conn_n_pending_streams*(
-    a0: ptr lsquic_conn_t_570425845
-  ): cuint {.cdecl, importc: "lsquic_conn_n_pending_streams".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_n_pending_streams" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_cancel_pending_streams):
-  proc lsquic_conn_cancel_pending_streams*(
-    a0: ptr lsquic_conn_t_570425845, n: cuint
-  ): cuint {.cdecl, importc: "lsquic_conn_cancel_pending_streams".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_cancel_pending_streams" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_going_away):
-  proc lsquic_conn_going_away*(
-    a0: ptr lsquic_conn_t_570425845
-  ): void {.cdecl, importc: "lsquic_conn_going_away".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_going_away" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_close):
-  proc lsquic_conn_close*(
-    a0: ptr lsquic_conn_t_570425845
-  ): void {.cdecl, importc: "lsquic_conn_close".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_close" & " already exists, not redeclaring")
-when not declared(lsquic_stream_wantread):
-  proc lsquic_stream_wantread*(
-    s: ptr lsquic_stream_t_570425849, is_want: cint
-  ): cint {.cdecl, importc: "lsquic_stream_wantread".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_wantread" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_read):
-  proc lsquic_stream_read*(
-    s: ptr lsquic_stream_t_570425849, buf: pointer, len: csize_t
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_read".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_read" & " already exists, not redeclaring")
-when not declared(lsquic_stream_readv):
-  proc lsquic_stream_readv*(
-    s: ptr lsquic_stream_t_570425849, vec: ptr struct_iovec_570425867, iovcnt: cint
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_readv".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_readv" & " already exists, not redeclaring")
-when not declared(lsquic_stream_readf):
-  proc lsquic_stream_readf*(
-    s: ptr lsquic_stream_t_570425849,
-    readf: proc(a0: pointer, a1: ptr uint8, a2: csize_t, a3: cint): csize_t {.cdecl.},
-    ctx: pointer,
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_readf".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_readf" & " already exists, not redeclaring")
-when not declared(lsquic_stream_wantwrite):
-  proc lsquic_stream_wantwrite*(
-    s: ptr lsquic_stream_t_570425849, is_want: cint
-  ): cint {.cdecl, importc: "lsquic_stream_wantwrite".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_wantwrite" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_write):
-  proc lsquic_stream_write*(
-    s: ptr lsquic_stream_t_570425849, buf: pointer, len: csize_t
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_write".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_write" & " already exists, not redeclaring")
-when not declared(lsquic_stream_writev):
-  proc lsquic_stream_writev*(
-    s: ptr lsquic_stream_t_570425849, vec: ptr struct_iovec_570425867, count: cint
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_writev".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_writev" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_pwritev):
-  proc lsquic_stream_pwritev*(
-    s: ptr lsquic_stream_t_570425849,
-    preadv: proc(
-      a0: pointer, a1: ptr struct_iovec_570425867, a2: cint
-    ): ssize_t_570425859 {.cdecl.},
-    user_data: pointer,
-    n_to_write: csize_t,
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_pwritev".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_pwritev" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_writef):
-  proc lsquic_stream_writef*(
-    a0: ptr lsquic_stream_t_570425849, a1: ptr struct_lsquic_reader_570425883
-  ): ssize_t_570425859 {.cdecl, importc: "lsquic_stream_writef".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_writef" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_flush):
-  proc lsquic_stream_flush*(
-    s: ptr lsquic_stream_t_570425849
-  ): cint {.cdecl, importc: "lsquic_stream_flush".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_flush" & " already exists, not redeclaring")
-when not declared(lsquic_stream_send_headers):
-  proc lsquic_stream_send_headers*(
-    s: ptr lsquic_stream_t_570425849,
-    headers: ptr lsquic_http_headers_t_570425853,
-    eos: cint,
-  ): cint {.cdecl, importc: "lsquic_stream_send_headers".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_send_headers" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_get_hset):
-  proc lsquic_stream_get_hset*(
-    a0: ptr lsquic_stream_t_570425849
-  ): pointer {.cdecl, importc: "lsquic_stream_get_hset".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_get_hset" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_push_stream):
-  proc lsquic_conn_push_stream*(
-    c: ptr lsquic_conn_t_570425845,
-    hdr_set: pointer,
-    s: ptr lsquic_stream_t_570425849,
-    headers: ptr lsquic_http_headers_t_570425853,
-  ): cint {.cdecl, importc: "lsquic_conn_push_stream".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_push_stream" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_is_push_enabled):
-  proc lsquic_conn_is_push_enabled*(
-    a0: ptr lsquic_conn_t_570425845
-  ): cint {.cdecl, importc: "lsquic_conn_is_push_enabled".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_is_push_enabled" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_shutdown):
-  proc lsquic_stream_shutdown*(
-    s: ptr lsquic_stream_t_570425849, how: cint
-  ): cint {.cdecl, importc: "lsquic_stream_shutdown".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_shutdown" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_close):
-  proc lsquic_stream_close*(
-    s: ptr lsquic_stream_t_570425849
-  ): cint {.cdecl, importc: "lsquic_stream_close".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_close" & " already exists, not redeclaring")
-when not declared(lsquic_stream_has_unacked_data):
-  proc lsquic_stream_has_unacked_data*(
-    s: ptr lsquic_stream_t_570425849
-  ): cint {.cdecl, importc: "lsquic_stream_has_unacked_data".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_has_unacked_data" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_server_cert_chain):
-  proc lsquic_conn_get_server_cert_chain*(
-    a0: ptr lsquic_conn_t_570425845
-  ): ptr struct_stack_st_X509 {.cdecl, importc: "lsquic_conn_get_server_cert_chain".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_server_cert_chain" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_full_cert_chain):
-  proc lsquic_conn_get_full_cert_chain*(
-    a0: ptr lsquic_conn_t_570425845
-  ): ptr struct_stack_st_X509 {.cdecl, importc: "lsquic_conn_get_full_cert_chain".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_full_cert_chain" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_id):
-  proc lsquic_stream_id*(
-    s: ptr lsquic_stream_t_570425849
-  ): lsquic_stream_id_t_570425841 {.cdecl, importc: "lsquic_stream_id".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_id" & " already exists, not redeclaring")
-when not declared(lsquic_stream_get_ctx):
-  proc lsquic_stream_get_ctx*(
-    s: ptr lsquic_stream_t_570425849
-  ): ptr lsquic_stream_ctx_t_570425851 {.cdecl, importc: "lsquic_stream_get_ctx".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_get_ctx" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_set_ctx):
-  proc lsquic_stream_set_ctx*(
-    stream: ptr lsquic_stream_t_570425849, ctx: ptr lsquic_stream_ctx_t_570425851
-  ): void {.cdecl, importc: "lsquic_stream_set_ctx".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_set_ctx" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_is_pushed):
-  proc lsquic_stream_is_pushed*(
-    s: ptr lsquic_stream_t_570425849
-  ): cint {.cdecl, importc: "lsquic_stream_is_pushed".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_is_pushed" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_is_rejected):
-  proc lsquic_stream_is_rejected*(
-    s: ptr lsquic_stream_t_570425849
-  ): cint {.cdecl, importc: "lsquic_stream_is_rejected".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_is_rejected" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_refuse_push):
-  proc lsquic_stream_refuse_push*(
-    s: ptr lsquic_stream_t_570425849
-  ): cint {.cdecl, importc: "lsquic_stream_refuse_push".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_refuse_push" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_push_info):
-  proc lsquic_stream_push_info*(
-    a0: ptr lsquic_stream_t_570425849,
-    ref_stream_id: ptr lsquic_stream_id_t_570425841,
-    hdr_set: ptr pointer,
-  ): cint {.cdecl, importc: "lsquic_stream_push_info".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_push_info" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_priority):
-  proc lsquic_stream_priority*(
-    s: ptr lsquic_stream_t_570425849
-  ): cuint {.cdecl, importc: "lsquic_stream_priority".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_priority" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_set_priority):
-  proc lsquic_stream_set_priority*(
-    s: ptr lsquic_stream_t_570425849, priority: cuint
-  ): cint {.cdecl, importc: "lsquic_stream_set_priority".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_set_priority" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_get_http_prio):
-  proc lsquic_stream_get_http_prio*(
-    a0: ptr lsquic_stream_t_570425849, a1: ptr struct_lsquic_ext_http_prio_570425885
-  ): cint {.cdecl, importc: "lsquic_stream_get_http_prio".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_get_http_prio" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_set_http_prio):
-  proc lsquic_stream_set_http_prio*(
-    a0: ptr lsquic_stream_t_570425849, a1: ptr struct_lsquic_ext_http_prio_570425885
-  ): cint {.cdecl, importc: "lsquic_stream_set_http_prio".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_stream_set_http_prio" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_stream_conn):
-  proc lsquic_stream_conn*(
-    s: ptr lsquic_stream_t_570425849
-  ): ptr lsquic_conn_t_570425845 {.cdecl, importc: "lsquic_stream_conn".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_stream_conn" & " already exists, not redeclaring")
-when not declared(lsquic_conn_id):
-  proc lsquic_conn_id*(
-    c: ptr lsquic_conn_t_570425845
-  ): ptr lsquic_cid_t {.cdecl, importc: "lsquic_conn_id".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_id" & " already exists, not redeclaring")
-when not declared(lsquic_conn_get_engine):
-  proc lsquic_conn_get_engine*(
-    c: ptr lsquic_conn_t_570425845
-  ): ptr lsquic_engine_t_570425843 {.cdecl, importc: "lsquic_conn_get_engine".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_engine" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_sockaddr):
-  proc lsquic_conn_get_sockaddr*(
-    c: ptr lsquic_conn_t_570425845, local: ptr ptr SockAddr, peer: ptr ptr SockAddr
-  ): cint {.cdecl, importc: "lsquic_conn_get_sockaddr".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_sockaddr" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_want_datagram_write):
-  proc lsquic_conn_want_datagram_write*(
-    a0: ptr lsquic_conn_t_570425845, is_want: cint
-  ): cint {.cdecl, importc: "lsquic_conn_want_datagram_write".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_want_datagram_write" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_min_datagram_size):
-  proc lsquic_conn_get_min_datagram_size*(
-    a0: ptr lsquic_conn_t_570425845
-  ): csize_t {.cdecl, importc: "lsquic_conn_get_min_datagram_size".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_min_datagram_size" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_set_min_datagram_size):
-  proc lsquic_conn_set_min_datagram_size*(
-    a0: ptr lsquic_conn_t_570425845, sz: csize_t
-  ): cint {.cdecl, importc: "lsquic_conn_set_min_datagram_size".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_set_min_datagram_size" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_logger_init):
-  proc lsquic_logger_init*(
-    a0: ptr struct_lsquic_logger_if_570425887,
-    logger_ctx: pointer,
-    a2: enum_lsquic_logger_timestamp_style,
-  ): void {.cdecl, importc: "lsquic_logger_init".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_logger_init" & " already exists, not redeclaring")
-when not declared(lsquic_set_log_level):
-  proc lsquic_set_log_level*(
-    log_level: cstring
-  ): cint {.cdecl, importc: "lsquic_set_log_level".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_set_log_level" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_logger_lopt):
-  proc lsquic_logger_lopt*(
-    optarg: cstring
-  ): cint {.cdecl, importc: "lsquic_logger_lopt".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_logger_lopt" & " already exists, not redeclaring")
-when not declared(lsquic_engine_quic_versions):
-  proc lsquic_engine_quic_versions*(
-    a0: ptr lsquic_engine_t_570425843
-  ): cuint {.cdecl, importc: "lsquic_engine_quic_versions".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_quic_versions" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_global_init):
-  proc lsquic_global_init*(flags: cint): cint {.cdecl, importc: "lsquic_global_init".}
-else:
-  static:
-    hint("Declaration of " & "lsquic_global_init" & " already exists, not redeclaring")
-when not declared(lsquic_global_cleanup):
-  proc lsquic_global_cleanup*(): void {.cdecl, importc: "lsquic_global_cleanup".}
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_global_cleanup" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_quic_version):
-  proc lsquic_conn_quic_version*(
-    c: ptr lsquic_conn_t_570425845
-  ): enum_lsquic_version {.cdecl, importc: "lsquic_conn_quic_version".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_quic_version" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_crypto_keysize):
-  proc lsquic_conn_crypto_keysize*(
-    c: ptr lsquic_conn_t_570425845
-  ): cint {.cdecl, importc: "lsquic_conn_crypto_keysize".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_crypto_keysize" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_crypto_alg_keysize):
-  proc lsquic_conn_crypto_alg_keysize*(
-    c: ptr lsquic_conn_t_570425845
-  ): cint {.cdecl, importc: "lsquic_conn_crypto_alg_keysize".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_crypto_alg_keysize" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_crypto_ver):
-  proc lsquic_conn_crypto_ver*(
-    c: ptr lsquic_conn_t_570425845
-  ): enum_lsquic_crypto_ver {.cdecl, importc: "lsquic_conn_crypto_ver".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_crypto_ver" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_crypto_cipher):
-  proc lsquic_conn_crypto_cipher*(
-    c: ptr lsquic_conn_t_570425845
-  ): cstring {.cdecl, importc: "lsquic_conn_crypto_cipher".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_crypto_cipher" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_str2ver):
-  proc lsquic_str2ver*(
-    str: cstring, len: csize_t
-  ): enum_lsquic_version {.cdecl, importc: "lsquic_str2ver".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_str2ver" & " already exists, not redeclaring")
-when not declared(lsquic_alpn2ver):
-  proc lsquic_alpn2ver*(
-    alpn: cstring, len: csize_t
-  ): enum_lsquic_version {.cdecl, importc: "lsquic_alpn2ver".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_alpn2ver" & " already exists, not redeclaring")
-when not declared(lsquic_engine_cooldown):
-  proc lsquic_engine_cooldown*(
-    a0: ptr lsquic_engine_t_570425843
-  ): void {.cdecl, importc: "lsquic_engine_cooldown".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_cooldown" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_ctx):
-  proc lsquic_conn_get_ctx*(
-    a0: ptr lsquic_conn_t_570425845
-  ): ptr lsquic_conn_ctx_t_570425847 {.cdecl, importc: "lsquic_conn_get_ctx".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_get_ctx" & " already exists, not redeclaring")
-when not declared(lsquic_conn_set_ctx):
-  proc lsquic_conn_set_ctx*(
-    a0: ptr lsquic_conn_t_570425845, a1: ptr lsquic_conn_ctx_t_570425847
-  ): void {.cdecl, importc: "lsquic_conn_set_ctx".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_set_ctx" & " already exists, not redeclaring")
-when not declared(lsquic_conn_get_peer_ctx):
-  proc lsquic_conn_get_peer_ctx*(
-    a0: ptr lsquic_conn_t_570425845, local_sa: ptr SockAddr
-  ): pointer {.cdecl, importc: "lsquic_conn_get_peer_ctx".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_peer_ctx" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_sni):
-  proc lsquic_conn_get_sni*(
-    a0: ptr lsquic_conn_t_570425845
-  ): cstring {.cdecl, importc: "lsquic_conn_get_sni".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_get_sni" & " already exists, not redeclaring")
-when not declared(lsquic_conn_abort):
-  proc lsquic_conn_abort*(
-    a0: ptr lsquic_conn_t_570425845
-  ): void {.cdecl, importc: "lsquic_conn_abort".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_abort" & " already exists, not redeclaring")
-when not declared(lsquic_conn_get_info):
-  proc lsquic_conn_get_info*(
-    conn: ptr lsquic_conn_t_570425845, info: ptr struct_lsquic_conn_info_570425896
-  ): cint {.cdecl, importc: "lsquic_conn_get_info".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_info" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_set_param):
-  proc lsquic_conn_set_param*(
-    conn: ptr lsquic_conn_t_570425845,
-    param: enum_lsquic_conn_param,
-    value: pointer,
-    value_len: csize_t,
-  ): cint {.cdecl, importc: "lsquic_conn_set_param".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_set_param" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_get_param):
-  proc lsquic_conn_get_param*(
-    conn: ptr lsquic_conn_t_570425845,
-    param: enum_lsquic_conn_param,
-    value: pointer,
-    value_len: ptr csize_t,
-  ): cint {.cdecl, importc: "lsquic_conn_get_param".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_conn_get_param" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_get_alt_svc_versions):
-  proc lsquic_get_alt_svc_versions*(
-    versions: cuint
-  ): cstring {.cdecl, importc: "lsquic_get_alt_svc_versions".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_get_alt_svc_versions" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_get_h3_alpns):
-  proc lsquic_get_h3_alpns*(
-    versions: cuint
-  ): ptr cstring {.cdecl, importc: "lsquic_get_h3_alpns".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_get_h3_alpns" & " already exists, not redeclaring")
-when not declared(lsquic_is_valid_hs_packet):
-  proc lsquic_is_valid_hs_packet*(
-    a0: ptr lsquic_engine_t_570425843, a1: ptr uint8, a2: csize_t
-  ): cint {.cdecl, importc: "lsquic_is_valid_hs_packet".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_is_valid_hs_packet" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_cid_from_packet):
-  proc lsquic_cid_from_packet*(
-    a0: ptr uint8, bufsz: csize_t, cid: ptr lsquic_cid_t
-  ): cint {.cdecl, importc: "lsquic_cid_from_packet".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_cid_from_packet" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_dcid_from_packet):
-  proc lsquic_dcid_from_packet*(
-    a0: ptr uint8, bufsz: csize_t, server_cid_len: cuint, cid_len: ptr uint8
-  ): cint {.cdecl, importc: "lsquic_dcid_from_packet".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_dcid_from_packet" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_earliest_adv_tick):
-  proc lsquic_engine_earliest_adv_tick*(
-    engine: ptr lsquic_engine_t_570425843, diff: ptr cint
-  ): cint {.cdecl, importc: "lsquic_engine_earliest_adv_tick".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_earliest_adv_tick" &
-        " already exists, not redeclaring"
-    )
-when not declared(lsquic_engine_count_attq):
-  proc lsquic_engine_count_attq*(
-    engine: ptr lsquic_engine_t_570425843, from_now: cint
-  ): cuint {.cdecl, importc: "lsquic_engine_count_attq".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_engine_count_attq" & " already exists, not redeclaring"
-    )
-when not declared(lsquic_conn_status):
-  proc lsquic_conn_status*(
-    a0: ptr lsquic_conn_t_570425845, errbuf: cstring, bufsz: csize_t
-  ): enum_LSQUIC_CONN_STATUS {.cdecl, importc: "lsquic_conn_status".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_conn_status" & " already exists, not redeclaring")
-when not declared(lsquic_ver2str):
-  var lsquic_ver2str* {.importc: "lsquic_ver2str".}: array[8'i64, cstring]
-else:
-  static:
-    hint("Declaration of " & "lsquic_ver2str" & " already exists, not redeclaring")
-when not declared(lsquic_ssl_to_conn):
-  proc lsquic_ssl_to_conn*(
-    a0: ptr struct_ssl_st
-  ): ptr lsquic_conn_t_570425845 {.cdecl, importc: "lsquic_ssl_to_conn".}
-
-else:
-  static:
-    hint("Declaration of " & "lsquic_ssl_to_conn" & " already exists, not redeclaring")
-when not declared(lsquic_ssl_sess_to_resume_info):
-  proc lsquic_ssl_sess_to_resume_info*(
-    a0: ptr struct_ssl_st,
-    a1: ptr struct_ssl_session_st,
-    buf: ptr ptr uint8,
-    buf_sz: ptr csize_t,
-  ): cint {.cdecl, importc: "lsquic_ssl_sess_to_resume_info".}
-
-else:
-  static:
-    hint(
-      "Declaration of " & "lsquic_ssl_sess_to_resume_info" &
-        " already exists, not redeclaring"
-    )
+    let LSQUIC_DF_INIT_MAX_STREAMS_BIDI* = LSQUIC_DF_MAX_STREAMS_IN
+      ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:294:9
+when 100 is static:
+  const LSQUIC_DF_INIT_MAX_STREAMS_UNI_CLIENT* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:295:9
+else:
+  let LSQUIC_DF_INIT_MAX_STREAMS_UNI_CLIENT* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:295:9
+when 3 is static:
+  const LSQUIC_DF_INIT_MAX_STREAMS_UNI_SERVER* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:296:9
+else:
+  let LSQUIC_DF_INIT_MAX_STREAMS_UNI_SERVER* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:296:9
+when 30 is static:
+  const LSQUIC_DF_IDLE_TIMEOUT* = 30
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:304:9
+else:
+  let LSQUIC_DF_IDLE_TIMEOUT* = 30
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:304:9
+when 15 is static:
+  const LSQUIC_DF_PING_PERIOD* = 15
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:309:9
+else:
+  let LSQUIC_DF_PING_PERIOD* = 15
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:309:9
+when 1 is static:
+  const LSQUIC_DF_SILENT_CLOSE* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:317:9
+else:
+  let LSQUIC_DF_SILENT_CLOSE* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:317:9
+when 0 is static:
+  const LSQUIC_DF_MAX_HEADER_LIST_SIZE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:323:9
+else:
+  let LSQUIC_DF_MAX_HEADER_LIST_SIZE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:323:9
+when "LSQUIC" is static:
+  const LSQUIC_DF_UA* = "LSQUIC"
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:326:9
+else:
+  let LSQUIC_DF_UA* = "LSQUIC"
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:326:9
+when 86400 is static:
+  const LSQUIC_DF_STTL* = 86400
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:328:9
+else:
+  let LSQUIC_DF_STTL* = 86400
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:328:9
+when 1 is static:
+  const LSQUIC_DF_SUPPORT_SREJ_SERVER* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:331:9
+else:
+  let LSQUIC_DF_SUPPORT_SREJ_SERVER* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:331:9
+when 0 is static:
+  const LSQUIC_DF_SUPPORT_SREJ_CLIENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:332:9
+else:
+  let LSQUIC_DF_SUPPORT_SREJ_CLIENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:332:9
+when 0 is static:
+  const LSQUIC_DF_SUPPORT_NSTP* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:335:9
+else:
+  let LSQUIC_DF_SUPPORT_NSTP* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:335:9
+when 0 is static:
+  const LSQUIC_DF_SUPPORT_PUSH* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:337:9
+else:
+  let LSQUIC_DF_SUPPORT_PUSH* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:337:9
+when 1 is static:
+  const LSQUIC_DF_SUPPORT_TCID0* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:338:9
+else:
+  let LSQUIC_DF_SUPPORT_TCID0* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:338:9
+when 0 is static:
+  const LSQUIC_DF_HONOR_PRST* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:340:9
+else:
+  let LSQUIC_DF_HONOR_PRST* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:340:9
+when 0 is static:
+  const LSQUIC_DF_SEND_PRST* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:346:9
+else:
+  let LSQUIC_DF_SEND_PRST* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:346:9
+when 1 is static:
+  const LSQUIC_DF_SEND_VERNEG* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:352:9
+else:
+  let LSQUIC_DF_SEND_VERNEG* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:352:9
+when 1000 is static:
+  const LSQUIC_DF_PROGRESS_CHECK* = 1000
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:355:9
+else:
+  let LSQUIC_DF_PROGRESS_CHECK* = 1000
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:355:9
+when 0 is static:
+  const LSQUIC_DF_RW_ONCE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:358:9
+else:
+  let LSQUIC_DF_RW_ONCE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:358:9
+when 0 is static:
+  const LSQUIC_DF_PROC_TIME_THRESH* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:361:9
+else:
+  let LSQUIC_DF_PROC_TIME_THRESH* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:361:9
+when 1 is static:
+  const LSQUIC_DF_PACE_PACKETS* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:364:9
+else:
+  let LSQUIC_DF_PACE_PACKETS* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:364:9
+when 1000 is static:
+  const LSQUIC_DF_CLOCK_GRANULARITY* = 1000
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:367:9
+else:
+  let LSQUIC_DF_CLOCK_GRANULARITY* = 1000
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:367:9
+when 8 is static:
+  const LSQUIC_DF_SCID_LEN* = 8
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:370:9
+else:
+  let LSQUIC_DF_SCID_LEN* = 8
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:370:9
+when 60 is static:
+  const LSQUIC_DF_SCID_ISS_RATE* = 60
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:373:9
+else:
+  let LSQUIC_DF_SCID_ISS_RATE* = 60
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:373:9
+when 100 is static:
+  const LSQUIC_DF_QPACK_DEC_MAX_BLOCKED* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:375:9
+else:
+  let LSQUIC_DF_QPACK_DEC_MAX_BLOCKED* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:375:9
+when 4096 is static:
+  const LSQUIC_DF_QPACK_DEC_MAX_SIZE* = 4096
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:376:9
+else:
+  let LSQUIC_DF_QPACK_DEC_MAX_SIZE* = 4096
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:376:9
+when 100 is static:
+  const LSQUIC_DF_QPACK_ENC_MAX_BLOCKED* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:377:9
+else:
+  let LSQUIC_DF_QPACK_ENC_MAX_BLOCKED* = 100
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:377:9
+when 4096 is static:
+  const LSQUIC_DF_QPACK_ENC_MAX_SIZE* = 4096
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:378:9
+else:
+  let LSQUIC_DF_QPACK_ENC_MAX_SIZE* = 4096
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:378:9
+when 0 is static:
+  const LSQUIC_DF_QPACK_EXPERIMENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:381:9
+else:
+  let LSQUIC_DF_QPACK_EXPERIMENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:381:9
+when 0 is static:
+  const LSQUIC_DF_ECN* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:384:9
+else:
+  let LSQUIC_DF_ECN* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:384:9
+when 1 is static:
+  const LSQUIC_DF_ALLOW_MIGRATION* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:387:9
+else:
+  let LSQUIC_DF_ALLOW_MIGRATION* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:387:9
+when 10 is static:
+  const LSQUIC_DF_RETRY_TOKEN_DURATION* = 10
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:390:9
+else:
+  let LSQUIC_DF_RETRY_TOKEN_DURATION* = 10
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:390:9
+when 2 is static:
+  const LSQUIC_DF_QL_BITS* = 2
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:393:9
+else:
+  let LSQUIC_DF_QL_BITS* = 2
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:393:9
+when 1 is static:
+  const LSQUIC_DF_SPIN* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:396:9
+else:
+  let LSQUIC_DF_SPIN* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:396:9
+when 1 is static:
+  const LSQUIC_DF_DELAYED_ACKS* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:399:9
+else:
+  let LSQUIC_DF_DELAYED_ACKS* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:399:9
+when 3 is static:
+  const LSQUIC_DF_PTPC_PERIODICITY* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:405:9
+else:
+  let LSQUIC_DF_PTPC_PERIODICITY* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:405:9
+when 150 is static:
+  const LSQUIC_DF_PTPC_MAX_PACKTOL* = 150
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:406:9
+else:
+  let LSQUIC_DF_PTPC_MAX_PACKTOL* = 150
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:406:9
+when 1 is static:
+  const LSQUIC_DF_PTPC_DYN_TARGET* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:407:9
+else:
+  let LSQUIC_DF_PTPC_DYN_TARGET* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:407:9
+when 1.0 is static:
+  const LSQUIC_DF_PTPC_TARGET* = 1.0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:408:9
+else:
+  let LSQUIC_DF_PTPC_TARGET* = 1.0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:408:9
+when 0.8 is static:
+  const LSQUIC_DF_PTPC_PROP_GAIN* = 0.8
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:409:9
+else:
+  let LSQUIC_DF_PTPC_PROP_GAIN* = 0.8
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:409:9
+when 0.35 is static:
+  const LSQUIC_DF_PTPC_INT_GAIN* = 0.35
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:410:9
+else:
+  let LSQUIC_DF_PTPC_INT_GAIN* = 0.35
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:410:9
+when 0.05 is static:
+  const LSQUIC_DF_PTPC_ERR_THRESH* = 0.05
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:411:9
+else:
+  let LSQUIC_DF_PTPC_ERR_THRESH* = 0.05
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:411:9
+when 0.05 is static:
+  const LSQUIC_DF_PTPC_ERR_DIVISOR* = 0.05
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:412:9
+else:
+  let LSQUIC_DF_PTPC_ERR_DIVISOR* = 0.05
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:412:9
+when 1 is static:
+  const LSQUIC_DF_TIMESTAMPS* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:415:9
+else:
+  let LSQUIC_DF_TIMESTAMPS* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:415:9
+when 3 is static:
+  const LSQUIC_DF_AMP_FACTOR* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:418:9
+else:
+  let LSQUIC_DF_AMP_FACTOR* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:418:9
+when 3 is static:
+  const LSQUIC_DF_CC_ALGO* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:421:9
+else:
+  let LSQUIC_DF_CC_ALGO* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:421:9
+when 1500 is static:
+  const LSQUIC_DF_CC_RTT_THRESH* = 1500
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:424:9
+else:
+  let LSQUIC_DF_CC_RTT_THRESH* = 1500
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:424:9
+when 0 is static:
+  const LSQUIC_DF_ENABLE_BW_SAMPLER* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:427:9
+else:
+  let LSQUIC_DF_ENABLE_BW_SAMPLER* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:427:9
+when 0 is static:
+  const LSQUIC_DF_DATAGRAMS* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:430:9
+else:
+  let LSQUIC_DF_DATAGRAMS* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:430:9
+when 1 is static:
+  const LSQUIC_DF_OPTIMISTIC_NAT* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:433:9
+else:
+  let LSQUIC_DF_OPTIMISTIC_NAT* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:433:9
+when 1 is static:
+  const LSQUIC_DF_EXT_HTTP_PRIO* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:436:9
+else:
+  let LSQUIC_DF_EXT_HTTP_PRIO* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:436:9
+when 0 is static:
+  const LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:439:9
+else:
+  let LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:439:9
+when 1 is static:
+  const LSQUIC_DF_GREASE_QUIC_BIT* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:445:9
+else:
+  let LSQUIC_DF_GREASE_QUIC_BIT* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:445:9
+when 1 is static:
+  const LSQUIC_DF_DPLPMTUD* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:448:9
+else:
+  let LSQUIC_DF_DPLPMTUD* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:448:9
+when 0 is static:
+  const LSQUIC_DF_BASE_PLPMTU* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:451:9
+else:
+  let LSQUIC_DF_BASE_PLPMTU* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:451:9
+when 0 is static:
+  const LSQUIC_DF_MAX_PLPMTU* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:454:9
+else:
+  let LSQUIC_DF_MAX_PLPMTU* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:454:9
+when 60 is static:
+  const LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER* = 60
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:457:9
+else:
+  let LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER* = 60
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:457:9
+when 0 is static:
+  const LSQUIC_DF_NOPROGRESS_TIMEOUT_CLIENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:460:9
+else:
+  let LSQUIC_DF_NOPROGRESS_TIMEOUT_CLIENT* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:460:9
+when 1000 is static:
+  const LSQUIC_DF_MTU_PROBE_TIMER* = 1000
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:463:9
+else:
+  let LSQUIC_DF_MTU_PROBE_TIMER* = 1000
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:463:9
+when 0 is static:
+  const LSQUIC_DF_DELAY_ONCLOSE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:466:9
+else:
+  let LSQUIC_DF_DELAY_ONCLOSE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:466:9
+when 0 is static:
+  const LSQUIC_DF_MAX_BATCH_SIZE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:472:9
+else:
+  let LSQUIC_DF_MAX_BATCH_SIZE* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:472:9
+when 32 is static:
+  const LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS* = 32
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:475:9
+else:
+  let LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS* = 32
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:475:9
+when 1 is static:
+  const LSQUIC_DF_CHECK_TP_SANITY* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:478:9
+else:
+  let LSQUIC_DF_CHECK_TP_SANITY* = 1
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:478:9
+when 7 is static:
+  const LSQUIC_MAX_HTTP_URGENCY* = 7
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1896:9
+else:
+  let LSQUIC_MAX_HTTP_URGENCY* = 7
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1896:9
+when 3 is static:
+  const LSQUIC_DEF_HTTP_URGENCY* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1897:9
+else:
+  let LSQUIC_DEF_HTTP_URGENCY* = 3
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1897:9
+when 0 is static:
+  const LSQUIC_DEF_HTTP_INCREMENTAL* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1898:9
+else:
+  let LSQUIC_DEF_HTTP_INCREMENTAL* = 0
+    ## Generated based on /home/r/vacp2p/nim-lsquic/libs/lsquic/include/lsquic.h:1898:9
+proc lsquic_engine_init_settings*(
+  a0: ptr struct_lsquic_engine_settings, lsquic_engine_flags: cuint
+): void {.cdecl, importc: "lsquic_engine_init_settings".}
+
+proc lsquic_engine_check_settings*(
+  settings: ptr struct_lsquic_engine_settings,
+  lsquic_engine_flags: cuint,
+  err_buf: cstring,
+  err_buf_sz: csize_t,
+): cint {.cdecl, importc: "lsquic_engine_check_settings".}
+
+proc lsquic_engine_get_conns_count*(
+  engine: ptr lsquic_engine_t
+): cuint {.cdecl, importc: "lsquic_engine_get_conns_count".}
+
+proc lsquic_engine_new*(
+  lsquic_engine_flags: cuint, api: ptr struct_lsquic_engine_api
+): ptr lsquic_engine_t {.cdecl, importc: "lsquic_engine_new".}
+
+proc lsquic_engine_connect*(
+  a0: ptr lsquic_engine_t,
+  a1: enum_lsquic_version,
+  local_sa: ptr SockAddr,
+  peer_sa: ptr SockAddr,
+  peer_ctx: pointer,
+  conn_ctx: ptr lsquic_conn_ctx_t,
+  hostname: cstring,
+  base_plpmtu: cushort,
+  sess_resume: ptr uint8,
+  sess_resume_len: csize_t,
+  token: ptr uint8,
+  token_sz: csize_t,
+): ptr lsquic_conn_t {.cdecl, importc: "lsquic_engine_connect".}
+
+proc lsquic_engine_packet_in*(
+  a0: ptr lsquic_engine_t,
+  packet_in_data: ptr uint8,
+  packet_in_size: csize_t,
+  sa_local: ptr SockAddr,
+  sa_peer: ptr SockAddr,
+  peer_ctx: pointer,
+  ecn: cint,
+): cint {.cdecl, importc: "lsquic_engine_packet_in".}
+
+proc lsquic_engine_process_conns*(
+  engine: ptr lsquic_engine_t
+): void {.cdecl, importc: "lsquic_engine_process_conns".}
+
+proc lsquic_engine_has_unsent_packets*(
+  engine: ptr lsquic_engine_t
+): cint {.cdecl, importc: "lsquic_engine_has_unsent_packets".}
+
+proc lsquic_engine_send_unsent_packets*(
+  engine: ptr lsquic_engine_t
+): void {.cdecl, importc: "lsquic_engine_send_unsent_packets".}
+
+proc lsquic_engine_destroy*(
+  a0: ptr lsquic_engine_t
+): void {.cdecl, importc: "lsquic_engine_destroy".}
+
+proc lsquic_conn_n_avail_streams*(
+  a0: ptr lsquic_conn_t
+): cuint {.cdecl, importc: "lsquic_conn_n_avail_streams".}
+
+proc lsquic_conn_make_stream*(
+  a0: ptr lsquic_conn_t
+): void {.cdecl, importc: "lsquic_conn_make_stream".}
+
+proc lsquic_conn_n_pending_streams*(
+  a0: ptr lsquic_conn_t
+): cuint {.cdecl, importc: "lsquic_conn_n_pending_streams".}
+
+proc lsquic_conn_cancel_pending_streams*(
+  a0: ptr lsquic_conn_t, n: cuint
+): cuint {.cdecl, importc: "lsquic_conn_cancel_pending_streams".}
+
+proc lsquic_conn_going_away*(
+  a0: ptr lsquic_conn_t
+): void {.cdecl, importc: "lsquic_conn_going_away".}
+
+proc lsquic_conn_close*(
+  a0: ptr lsquic_conn_t
+): void {.cdecl, importc: "lsquic_conn_close".}
+
+proc lsquic_stream_wantread*(
+  s: ptr lsquic_stream_t, is_want: cint
+): cint {.cdecl, importc: "lsquic_stream_wantread".}
+
+proc lsquic_stream_read*(
+  s: ptr lsquic_stream_t, buf: pointer, len: csize_t
+): ssize_t {.cdecl, importc: "lsquic_stream_read".}
+
+proc lsquic_stream_readv*(
+  s: ptr lsquic_stream_t, vec: ptr struct_iovec, iovcnt: cint
+): ssize_t {.cdecl, importc: "lsquic_stream_readv".}
+
+proc lsquic_stream_readf*(
+  s: ptr lsquic_stream_t,
+  readf: proc(a0: pointer, a1: ptr uint8, a2: csize_t, a3: cint): csize_t {.cdecl.},
+  ctx: pointer,
+): ssize_t {.cdecl, importc: "lsquic_stream_readf".}
+
+proc lsquic_stream_wantwrite*(
+  s: ptr lsquic_stream_t, is_want: cint
+): cint {.cdecl, importc: "lsquic_stream_wantwrite".}
+
+proc lsquic_stream_write*(
+  s: ptr lsquic_stream_t, buf: pointer, len: csize_t
+): ssize_t {.cdecl, importc: "lsquic_stream_write".}
+
+proc lsquic_stream_writev*(
+  s: ptr lsquic_stream_t, vec: ptr struct_iovec, count: cint
+): ssize_t {.cdecl, importc: "lsquic_stream_writev".}
+
+proc lsquic_stream_pwritev*(
+  s: ptr lsquic_stream_t,
+  preadv: proc(a0: pointer, a1: ptr struct_iovec, a2: cint): ssize_t {.cdecl.},
+  user_data: pointer,
+  n_to_write: csize_t,
+): ssize_t {.cdecl, importc: "lsquic_stream_pwritev".}
+
+proc lsquic_stream_writef*(
+  a0: ptr lsquic_stream_t, a1: ptr struct_lsquic_reader
+): ssize_t {.cdecl, importc: "lsquic_stream_writef".}
+
+proc lsquic_stream_flush*(
+  s: ptr lsquic_stream_t
+): cint {.cdecl, importc: "lsquic_stream_flush".}
+
+proc lsquic_stream_send_headers*(
+  s: ptr lsquic_stream_t, headers: ptr lsquic_http_headers_t, eos: cint
+): cint {.cdecl, importc: "lsquic_stream_send_headers".}
+
+proc lsquic_stream_get_hset*(
+  a0: ptr lsquic_stream_t
+): pointer {.cdecl, importc: "lsquic_stream_get_hset".}
+
+proc lsquic_conn_push_stream*(
+  c: ptr lsquic_conn_t,
+  hdr_set: pointer,
+  s: ptr lsquic_stream_t,
+  headers: ptr lsquic_http_headers_t,
+): cint {.cdecl, importc: "lsquic_conn_push_stream".}
+
+proc lsquic_conn_is_push_enabled*(
+  a0: ptr lsquic_conn_t
+): cint {.cdecl, importc: "lsquic_conn_is_push_enabled".}
+
+proc lsquic_stream_shutdown*(
+  s: ptr lsquic_stream_t, how: cint
+): cint {.cdecl, importc: "lsquic_stream_shutdown".}
+
+proc lsquic_stream_close*(
+  s: ptr lsquic_stream_t
+): cint {.cdecl, importc: "lsquic_stream_close".}
+
+proc lsquic_stream_has_unacked_data*(
+  s: ptr lsquic_stream_t
+): cint {.cdecl, importc: "lsquic_stream_has_unacked_data".}
+
+proc lsquic_conn_get_server_cert_chain*(
+  a0: ptr lsquic_conn_t
+): ptr struct_stack_st_X509 {.cdecl, importc: "lsquic_conn_get_server_cert_chain".}
+
+proc lsquic_conn_get_full_cert_chain*(
+  a0: ptr lsquic_conn_t
+): ptr struct_stack_st_X509 {.cdecl, importc: "lsquic_conn_get_full_cert_chain".}
+
+proc lsquic_stream_id*(
+  s: ptr lsquic_stream_t
+): lsquic_stream_id_t {.cdecl, importc: "lsquic_stream_id".}
+
+proc lsquic_stream_get_ctx*(
+  s: ptr lsquic_stream_t
+): ptr lsquic_stream_ctx_t {.cdecl, importc: "lsquic_stream_get_ctx".}
+
+proc lsquic_stream_set_ctx*(
+  stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t
+): void {.cdecl, importc: "lsquic_stream_set_ctx".}
+
+proc lsquic_stream_is_pushed*(
+  s: ptr lsquic_stream_t
+): cint {.cdecl, importc: "lsquic_stream_is_pushed".}
+
+proc lsquic_stream_is_rejected*(
+  s: ptr lsquic_stream_t
+): cint {.cdecl, importc: "lsquic_stream_is_rejected".}
+
+proc lsquic_stream_refuse_push*(
+  s: ptr lsquic_stream_t
+): cint {.cdecl, importc: "lsquic_stream_refuse_push".}
+
+proc lsquic_stream_push_info*(
+  a0: ptr lsquic_stream_t, ref_stream_id: ptr lsquic_stream_id_t, hdr_set: ptr pointer
+): cint {.cdecl, importc: "lsquic_stream_push_info".}
+
+proc lsquic_stream_priority*(
+  s: ptr lsquic_stream_t
+): cuint {.cdecl, importc: "lsquic_stream_priority".}
+
+proc lsquic_stream_set_priority*(
+  s: ptr lsquic_stream_t, priority: cuint
+): cint {.cdecl, importc: "lsquic_stream_set_priority".}
+
+proc lsquic_stream_get_http_prio*(
+  a0: ptr lsquic_stream_t, a1: ptr struct_lsquic_ext_http_prio
+): cint {.cdecl, importc: "lsquic_stream_get_http_prio".}
+
+proc lsquic_stream_set_http_prio*(
+  a0: ptr lsquic_stream_t, a1: ptr struct_lsquic_ext_http_prio
+): cint {.cdecl, importc: "lsquic_stream_set_http_prio".}
+
+proc lsquic_stream_conn*(
+  s: ptr lsquic_stream_t
+): ptr lsquic_conn_t {.cdecl, importc: "lsquic_stream_conn".}
+
+proc lsquic_conn_id*(
+  c: ptr lsquic_conn_t
+): ptr lsquic_cid_t {.cdecl, importc: "lsquic_conn_id".}
+
+proc lsquic_conn_get_engine*(
+  c: ptr lsquic_conn_t
+): ptr lsquic_engine_t {.cdecl, importc: "lsquic_conn_get_engine".}
+
+proc lsquic_conn_get_sockaddr*(
+  c: ptr lsquic_conn_t, local: ptr ptr SockAddr, peer: ptr ptr SockAddr
+): cint {.cdecl, importc: "lsquic_conn_get_sockaddr".}
+
+proc lsquic_conn_want_datagram_write*(
+  a0: ptr lsquic_conn_t, is_want: cint
+): cint {.cdecl, importc: "lsquic_conn_want_datagram_write".}
+
+proc lsquic_conn_get_min_datagram_size*(
+  a0: ptr lsquic_conn_t
+): csize_t {.cdecl, importc: "lsquic_conn_get_min_datagram_size".}
+
+proc lsquic_conn_set_min_datagram_size*(
+  a0: ptr lsquic_conn_t, sz: csize_t
+): cint {.cdecl, importc: "lsquic_conn_set_min_datagram_size".}
+
+proc lsquic_logger_init*(
+  a0: ptr struct_lsquic_logger_if,
+  logger_ctx: pointer,
+  a2: enum_lsquic_logger_timestamp_style,
+): void {.cdecl, importc: "lsquic_logger_init".}
+
+proc lsquic_set_log_level*(
+  log_level: cstring
+): cint {.cdecl, importc: "lsquic_set_log_level".}
+
+proc lsquic_logger_lopt*(optarg: cstring): cint {.cdecl, importc: "lsquic_logger_lopt".}
+proc lsquic_engine_quic_versions*(
+  a0: ptr lsquic_engine_t
+): cuint {.cdecl, importc: "lsquic_engine_quic_versions".}
+
+proc lsquic_global_init*(flags: cint): cint {.cdecl, importc: "lsquic_global_init".}
+proc lsquic_global_cleanup*(): void {.cdecl, importc: "lsquic_global_cleanup".}
+proc lsquic_conn_quic_version*(
+  c: ptr lsquic_conn_t
+): enum_lsquic_version {.cdecl, importc: "lsquic_conn_quic_version".}
+
+proc lsquic_conn_crypto_keysize*(
+  c: ptr lsquic_conn_t
+): cint {.cdecl, importc: "lsquic_conn_crypto_keysize".}
+
+proc lsquic_conn_crypto_alg_keysize*(
+  c: ptr lsquic_conn_t
+): cint {.cdecl, importc: "lsquic_conn_crypto_alg_keysize".}
+
+proc lsquic_conn_crypto_ver*(
+  c: ptr lsquic_conn_t
+): enum_lsquic_crypto_ver {.cdecl, importc: "lsquic_conn_crypto_ver".}
+
+proc lsquic_conn_crypto_cipher*(
+  c: ptr lsquic_conn_t
+): cstring {.cdecl, importc: "lsquic_conn_crypto_cipher".}
+
+proc lsquic_str2ver*(
+  str: cstring, len: csize_t
+): enum_lsquic_version {.cdecl, importc: "lsquic_str2ver".}
+
+proc lsquic_alpn2ver*(
+  alpn: cstring, len: csize_t
+): enum_lsquic_version {.cdecl, importc: "lsquic_alpn2ver".}
+
+proc lsquic_engine_cooldown*(
+  a0: ptr lsquic_engine_t
+): void {.cdecl, importc: "lsquic_engine_cooldown".}
+
+proc lsquic_conn_get_ctx*(
+  a0: ptr lsquic_conn_t
+): ptr lsquic_conn_ctx_t {.cdecl, importc: "lsquic_conn_get_ctx".}
+
+proc lsquic_conn_set_ctx*(
+  a0: ptr lsquic_conn_t, a1: ptr lsquic_conn_ctx_t
+): void {.cdecl, importc: "lsquic_conn_set_ctx".}
+
+proc lsquic_conn_get_peer_ctx*(
+  a0: ptr lsquic_conn_t, local_sa: ptr SockAddr
+): pointer {.cdecl, importc: "lsquic_conn_get_peer_ctx".}
+
+proc lsquic_conn_get_sni*(
+  a0: ptr lsquic_conn_t
+): cstring {.cdecl, importc: "lsquic_conn_get_sni".}
+
+proc lsquic_conn_abort*(
+  a0: ptr lsquic_conn_t
+): void {.cdecl, importc: "lsquic_conn_abort".}
+
+proc lsquic_conn_get_info*(
+  conn: ptr lsquic_conn_t, info: ptr struct_lsquic_conn_info
+): cint {.cdecl, importc: "lsquic_conn_get_info".}
+
+proc lsquic_conn_set_param*(
+  conn: ptr lsquic_conn_t,
+  param: enum_lsquic_conn_param,
+  value: pointer,
+  value_len: csize_t,
+): cint {.cdecl, importc: "lsquic_conn_set_param".}
+
+proc lsquic_conn_get_param*(
+  conn: ptr lsquic_conn_t,
+  param: enum_lsquic_conn_param,
+  value: pointer,
+  value_len: ptr csize_t,
+): cint {.cdecl, importc: "lsquic_conn_get_param".}
+
+proc lsquic_get_alt_svc_versions*(
+  versions: cuint
+): cstring {.cdecl, importc: "lsquic_get_alt_svc_versions".}
+
+proc lsquic_get_h3_alpns*(
+  versions: cuint
+): ptr cstring {.cdecl, importc: "lsquic_get_h3_alpns".}
+
+proc lsquic_is_valid_hs_packet*(
+  a0: ptr lsquic_engine_t, a1: ptr uint8, a2: csize_t
+): cint {.cdecl, importc: "lsquic_is_valid_hs_packet".}
+
+proc lsquic_cid_from_packet*(
+  a0: ptr uint8, bufsz: csize_t, cid: ptr lsquic_cid_t
+): cint {.cdecl, importc: "lsquic_cid_from_packet".}
+
+proc lsquic_dcid_from_packet*(
+  a0: ptr uint8, bufsz: csize_t, server_cid_len: cuint, cid_len: ptr uint8
+): cint {.cdecl, importc: "lsquic_dcid_from_packet".}
+
+proc lsquic_engine_earliest_adv_tick*(
+  engine: ptr lsquic_engine_t, diff: ptr cint
+): cint {.cdecl, importc: "lsquic_engine_earliest_adv_tick".}
+
+proc lsquic_engine_count_attq*(
+  engine: ptr lsquic_engine_t, from_now: cint
+): cuint {.cdecl, importc: "lsquic_engine_count_attq".}
+
+proc lsquic_conn_status*(
+  a0: ptr lsquic_conn_t, errbuf: cstring, bufsz: csize_t
+): enum_LSQUIC_CONN_STATUS {.cdecl, importc: "lsquic_conn_status".}
+
+var lsquic_ver2str* {.importc: "lsquic_ver2str".}: array[8'i64, cstring]
+proc lsquic_ssl_to_conn*(
+  a0: ptr struct_ssl_st
+): ptr lsquic_conn_t {.cdecl, importc: "lsquic_ssl_to_conn".}
+
+proc lsquic_ssl_sess_to_resume_info*(
+  a0: ptr struct_ssl_st,
+  a1: ptr struct_ssl_session_st,
+  buf: ptr ptr uint8,
+  buf_sz: ptr csize_t,
+): cint {.cdecl, importc: "lsquic_ssl_sess_to_resume_info".}
+
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 

--- a/lsquic/lsquic_ffi_types.nim
+++ b/lsquic/lsquic_ffi_types.nim
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+type
+  ptrdiff_t* {.importc: "ptrdiff_t", header: "<stddef.h>".} = int
+  uint_fast8_t* {.importc: "uint_fast8_t", header: "<stdint.h>".} = uint8
+
+# enums are generated manually to avoid issue described in
+# https://github.com/PMunch/futhark/issues/152
+template borrowCEnumOps(T: typedesc) =
+  proc `==`*(a, b: T): bool {.borrow.}
+  proc `<`*(a, b: T): bool {.borrow.}
+  proc `<=`*(a, b: T): bool {.borrow.}
+  proc `or`*(a, b: T): T {.borrow.}
+  proc `and`*(a, b: T): T {.borrow.}
+  proc `xor`*(a, b: T): T {.borrow.}
+  proc `not`*(a: T): T {.borrow.}
+  proc `$`*(a: T): string {.borrow.}
+
+type
+  enum_lsquic_version* = distinct cuint
+  enum_lsquic_hsk_status* = distinct cuint
+  enum_lsquic_hsi_flag* = distinct cuint
+  enum_lsquic_logger_timestamp_style* = distinct cuint
+  enum_lsquic_crypto_ver* = distinct cuint
+  enum_lsquic_conn_param* = distinct cuint
+  enum_LSQUIC_CONN_STATUS* = distinct cuint
+
+borrowCEnumOps(enum_lsquic_version)
+borrowCEnumOps(enum_lsquic_hsk_status)
+borrowCEnumOps(enum_lsquic_hsi_flag)
+borrowCEnumOps(enum_lsquic_logger_timestamp_style)
+borrowCEnumOps(enum_lsquic_crypto_ver)
+borrowCEnumOps(enum_lsquic_conn_param)
+borrowCEnumOps(enum_LSQUIC_CONN_STATUS)
+
+const
+  MAX_CID_LEN* = 20
+  GQUIC_CID_LEN* = 8
+
+  LSQVER_043* = enum_lsquic_version(0)
+  LSQVER_046* = enum_lsquic_version(1)
+  LSQVER_050* = enum_lsquic_version(2)
+  LSQVER_ID27* = enum_lsquic_version(3)
+  LSQVER_ID29* = enum_lsquic_version(4)
+  LSQVER_I001* = enum_lsquic_version(5)
+  LSQVER_I002* = enum_lsquic_version(6)
+  LSQVER_RESVED* = enum_lsquic_version(7)
+  N_LSQVER* = enum_lsquic_version(8)
+  LSQVER_VERNEG* = enum_lsquic_version(9)
+
+  LSQ_HSK_FAIL* = enum_lsquic_hsk_status(0)
+  LSQ_HSK_OK* = enum_lsquic_hsk_status(1)
+  LSQ_HSK_RESUMED_OK* = enum_lsquic_hsk_status(2)
+  LSQ_HSK_RESUMED_FAIL* = enum_lsquic_hsk_status(3)
+
+  LSQUIC_HSI_HTTP1X* = enum_lsquic_hsi_flag(2)
+  LSQUIC_HSI_HASH_NAME* = enum_lsquic_hsi_flag(4)
+  LSQUIC_HSI_HASH_NAMEVAL* = enum_lsquic_hsi_flag(8)
+
+  LLTS_NONE* = enum_lsquic_logger_timestamp_style(0)
+  LLTS_HHMMSSMS* = enum_lsquic_logger_timestamp_style(1)
+  LLTS_YYYYMMDD_HHMMSSMS* = enum_lsquic_logger_timestamp_style(2)
+  LLTS_CHROMELIKE* = enum_lsquic_logger_timestamp_style(3)
+  LLTS_HHMMSSUS* = enum_lsquic_logger_timestamp_style(4)
+  LLTS_YYYYMMDD_HHMMSSUS* = enum_lsquic_logger_timestamp_style(5)
+  N_LLTS* = enum_lsquic_logger_timestamp_style(6)
+
+  LSQ_CRY_QUIC* = enum_lsquic_crypto_ver(0)
+  LSQ_CRY_TLSv13* = enum_lsquic_crypto_ver(1)
+
+  LSQCP_MAX_PACING_RATE* = enum_lsquic_conn_param(1)
+  LSQCP_ENABLE_BW_SAMPLER* = enum_lsquic_conn_param(2)
+
+  LSCONN_ST_HSK_IN_PROGRESS* = enum_LSQUIC_CONN_STATUS(0)
+  LSCONN_ST_CONNECTED* = enum_LSQUIC_CONN_STATUS(1)
+  LSCONN_ST_HSK_FAILURE* = enum_LSQUIC_CONN_STATUS(2)
+  LSCONN_ST_GOING_AWAY* = enum_LSQUIC_CONN_STATUS(3)
+  LSCONN_ST_TIMED_OUT* = enum_LSQUIC_CONN_STATUS(4)
+  LSCONN_ST_RESET* = enum_LSQUIC_CONN_STATUS(5)
+  LSCONN_ST_USER_ABORTED* = enum_LSQUIC_CONN_STATUS(6)
+  LSCONN_ST_ERROR* = enum_LSQUIC_CONN_STATUS(7)
+  LSCONN_ST_CLOSED* = enum_LSQUIC_CONN_STATUS(8)
+  LSCONN_ST_PEER_GOING_AWAY* = enum_LSQUIC_CONN_STATUS(9)
+  LSCONN_ST_VERNEG_FAILURE* = enum_LSQUIC_CONN_STATUS(10)
+
+type
+  struct_lsquic_cid* {.
+    importc: "struct lsquic_cid", header: "lsquic_types.h", bycopy, completeStruct
+  .} = object
+    buf* {.importc: "buf".}: array[MAX_CID_LEN, uint8]
+    len* {.importc: "len".}: uint_fast8_t
+    padding: array[3, uint8]
+
+  lsquic_cid_t* = struct_lsquic_cid

--- a/prelude.nim
+++ b/prelude.nim
@@ -8,91 +8,12 @@ when defined(windows):
 
 import std/[os, strutils]
 import chronos/osdefs
+{.push warning[UnusedImport]: off.}
 import zlib
+{.pop.}
 import boringssl
 
-type
-  ptrdiff_t* {.importc: "ptrdiff_t", header: "<stddef.h>".} = int
-  uint_fast8_t* {.importc: "uint_fast8_t", header: "<stdint.h>".} = uint8
-
-# enums are generated manually to avoid issue described in
-# https://github.com/PMunch/futhark/issues/152
-template borrowCEnumOps(T: typedesc) =
-  proc `==`*(a, b: T): bool {.borrow.}
-  proc `<`*(a, b: T): bool {.borrow.}
-  proc `<=`*(a, b: T): bool {.borrow.}
-  proc `or`*(a, b: T): T {.borrow.}
-  proc `and`*(a, b: T): T {.borrow.}
-  proc `xor`*(a, b: T): T {.borrow.}
-  proc `not`*(a: T): T {.borrow.}
-  proc `$`*(a: T): string {.borrow.}
-
-type
-  enum_lsquic_version* = distinct cuint
-  enum_lsquic_hsk_status* = distinct cuint
-  enum_lsquic_hsi_flag* = distinct cuint
-  enum_lsquic_logger_timestamp_style* = distinct cuint
-  enum_lsquic_crypto_ver* = distinct cuint
-  enum_lsquic_conn_param* = distinct cuint
-  enum_LSQUIC_CONN_STATUS* = distinct cuint
-
-borrowCEnumOps(enum_lsquic_version)
-borrowCEnumOps(enum_lsquic_hsk_status)
-borrowCEnumOps(enum_lsquic_hsi_flag)
-borrowCEnumOps(enum_lsquic_logger_timestamp_style)
-borrowCEnumOps(enum_lsquic_crypto_ver)
-borrowCEnumOps(enum_lsquic_conn_param)
-borrowCEnumOps(enum_LSQUIC_CONN_STATUS)
-
-const
-  MAX_CID_LEN* = 20
-  GQUIC_CID_LEN* = 8
-
-  LSQVER_043* = enum_lsquic_version(0)
-  LSQVER_046* = enum_lsquic_version(1)
-  LSQVER_050* = enum_lsquic_version(2)
-  LSQVER_ID27* = enum_lsquic_version(3)
-  LSQVER_ID29* = enum_lsquic_version(4)
-  LSQVER_I001* = enum_lsquic_version(5)
-  LSQVER_I002* = enum_lsquic_version(6)
-  LSQVER_RESVED* = enum_lsquic_version(7)
-  N_LSQVER* = enum_lsquic_version(8)
-  LSQVER_VERNEG* = enum_lsquic_version(9)
-
-  LSQ_HSK_FAIL* = enum_lsquic_hsk_status(0)
-  LSQ_HSK_OK* = enum_lsquic_hsk_status(1)
-  LSQ_HSK_RESUMED_OK* = enum_lsquic_hsk_status(2)
-  LSQ_HSK_RESUMED_FAIL* = enum_lsquic_hsk_status(3)
-
-  LSQUIC_HSI_HTTP1X* = enum_lsquic_hsi_flag(2)
-  LSQUIC_HSI_HASH_NAME* = enum_lsquic_hsi_flag(4)
-  LSQUIC_HSI_HASH_NAMEVAL* = enum_lsquic_hsi_flag(8)
-
-  LLTS_NONE* = enum_lsquic_logger_timestamp_style(0)
-  LLTS_HHMMSSMS* = enum_lsquic_logger_timestamp_style(1)
-  LLTS_YYYYMMDD_HHMMSSMS* = enum_lsquic_logger_timestamp_style(2)
-  LLTS_CHROMELIKE* = enum_lsquic_logger_timestamp_style(3)
-  LLTS_HHMMSSUS* = enum_lsquic_logger_timestamp_style(4)
-  LLTS_YYYYMMDD_HHMMSSUS* = enum_lsquic_logger_timestamp_style(5)
-  N_LLTS* = enum_lsquic_logger_timestamp_style(6)
-
-  LSQ_CRY_QUIC* = enum_lsquic_crypto_ver(0)
-  LSQ_CRY_TLSv13* = enum_lsquic_crypto_ver(1)
-
-  LSQCP_MAX_PACING_RATE* = enum_lsquic_conn_param(1)
-  LSQCP_ENABLE_BW_SAMPLER* = enum_lsquic_conn_param(2)
-
-  LSCONN_ST_HSK_IN_PROGRESS* = enum_LSQUIC_CONN_STATUS(0)
-  LSCONN_ST_CONNECTED* = enum_LSQUIC_CONN_STATUS(1)
-  LSCONN_ST_HSK_FAILURE* = enum_LSQUIC_CONN_STATUS(2)
-  LSCONN_ST_GOING_AWAY* = enum_LSQUIC_CONN_STATUS(3)
-  LSCONN_ST_TIMED_OUT* = enum_LSQUIC_CONN_STATUS(4)
-  LSCONN_ST_RESET* = enum_LSQUIC_CONN_STATUS(5)
-  LSCONN_ST_USER_ABORTED* = enum_LSQUIC_CONN_STATUS(6)
-  LSCONN_ST_ERROR* = enum_LSQUIC_CONN_STATUS(7)
-  LSCONN_ST_CLOSED* = enum_LSQUIC_CONN_STATUS(8)
-  LSCONN_ST_PEER_GOING_AWAY* = enum_LSQUIC_CONN_STATUS(9)
-  LSCONN_ST_VERNEG_FAILURE* = enum_LSQUIC_CONN_STATUS(10)
+include lsquic/lsquic_ffi_types
 
 # use rsplit as a workaround for cross compilation path separator issue
 const root = currentSourcePath.rsplit({DirSep, AltSep}, 2)[0]
@@ -111,16 +32,6 @@ when defined(windows):
 {.passc: "-I" & lsqpack.}
 {.passc: "-I" & lshpack.}
 {.passc: "-I" & xxhash.}
-
-type
-  struct_lsquic_cid* {.
-    importc: "struct lsquic_cid", header: "lsquic_types.h", bycopy, completeStruct
-  .} = object
-    buf* {.importc: "buf".}: array[MAX_CID_LEN, uint8]
-    len* {.importc: "len".}: uint_fast8_t
-    padding: array[3, uint8]
-
-  lsquic_cid_t* = struct_lsquic_cid
 
 const HAVE_BORINGSSL = "-DHAVE_BORINGSSL"
 const XXH_HEADER_NAME = "-DXXH_HEADER_NAME=\"<lsquic_xxhash.h>\""


### PR DESCRIPTION
## Summary

Regenerates the lsquic FFI bindings with `-d:nodeclguards` for increased readability. Also updates CI targets so they match nim-libp2p (Using nim2.0 would trigger errors with these changes)

The manual enum and CID definitions are moved into `lsquic/lsquic_ffi_types.nim` so both the generator and final prelude compile against the same definitions. The generator filters symbols supplied by that shared file and rewrites aliases that should resolve to already-known Nim types, including manual enums, BoringSSL structs, and `SockAddr`.

## Affected Areas

- [x] Build / Tooling
  - Updates the Futhark generation flags and removes generated-file `SockAddr` post-processing from `build.sh`.
- [x] Other
  - Adds shared FFI type definitions included by both `prelude.nim` and `generate_lsquic_ffi.nim`.
  - Regenerates `lsquic/lsquic_ffi.nim` without Futhark declaration guards.

## References

- https://github.com/PMunch/futhark#compatibility-features-and-readability
