### PR TITLE
fix: require certverifier in client context

### DIFF
--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -118,6 +118,9 @@ const Cubic = 1
 const Adaptive = 3
 
 proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
+  if tlsConfig.certVerifier.isNone:
+    return err("client TLSConfig requires a certificate verifier")
+
   var ctx = ClientContext()
   ctx.tlsConfig = tlsConfig
   ctx.running = true


### PR DESCRIPTION
## Summary

Require client-side `TLSConfig` values to include a certificate verifier before creating a `ClientContext`.

Without this guard, a client config with no verifier could reach SSL context setup without installing certificate verification. The new check fails fast with an explicit error instead of allowing that state.