### PR TITLE
fix: ensure lsquic engine processes shutdown regardless of being at EoF or not

### DIFF
--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -127,10 +127,10 @@ proc close*(stream: Stream) {.async: (raises: [StreamError, CancelledError]).} =
       if lsquic_stream_close(stream.quicStream) != 0:
         stream.abort()
         raise newException(StreamError, "could not close the stream")
-      stream.doProcess()
 
     stream.abortPendingWrites("stream closed")
     stream.closeWrite = true
+    stream.doProcess()
   else:
     raise newException(StreamError, "could not close the stream")
 


### PR DESCRIPTION
## Summary

Ensure stream shutdown is processed after the write side is marked closed and pending writes are aborted.

This makes `doProcess()` run for both EOF and non-EOF close paths, instead of only when the stream had already reached EOF.

## Affected Areas

- [x] Transports  
  Stream close/shutdown handling in `lsquic/stream.nim`.

## Impact on Library Users

No API changes. This adjusts the ordering of existing stream close behavior.

## Risk Assessment

Low risk, localized to stream close handling. The main behavior change is when close processing is triggered relative to write-side shutdown state updates.