### PR TITLE
fix: leaks

### DIFF
--- a/lsquic/certificates.nim
+++ b/lsquic/certificates.nim
@@ -37,5 +37,19 @@ proc getCertChain*(chain: ptr struct_stack_st_X509): seq[seq[byte]] =
 
   return output
 
+proc freeCertChain*(chain: ptr struct_stack_st_X509) {.raises: [].} =
+  ## Frees chains returned by lsquic_conn_get_*_cert_chain.
+  if chain.isNil:
+    return
+
+  let stack = cast[ptr OPENSSL_STACK](chain)
+  let x509num = OPENSSL_sk_num(stack)
+  for i in 0 ..< x509num:
+    let cert = cast[ptr X509](OPENSSL_sk_value(stack, csize_t(i)))
+    if not cert.isNil:
+      X509_free(cert)
+
+  OPENSSL_sk_free(stack)
+
 proc getFullCertChain*(ssl: ptr SSL): seq[seq[byte]] =
   SSL_get_peer_full_cert_chain(ssl).getCertChain()

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -37,7 +37,7 @@ proc onHandshakeDone(
   else:
     let x509chain = lsquic_conn_get_full_cert_chain(quicClientConn.lsquicConn)
     let certChain = x509chain.getCertChain()
-    OPENSSL_sk_free(cast[ptr OPENSSL_STACK](x509chain))
+    x509chain.freeCertChain()
     quicClientConn.certChain = certChain
 
     quicClientConn.connectedFut.complete()
@@ -60,7 +60,9 @@ proc onConnClosed(conn: ptr lsquic_conn_t) {.cdecl.} =
       )
     quicClientConn.cancelPending()
     quicClientConn.onClose()
+    quicClientConn.onClose = nil
     quicClientConn.lsquicConn = nil
+    quicClientConn.connectedFut = nil
     GC_unref(quicClientConn)
   lsquic_conn_set_ctx(conn, nil)
 
@@ -167,6 +169,7 @@ proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
 
   ctx.engine = lsquic_engine_new(0, addr ctx.api)
   if ctx.engine.isNil:
+    ctx.destroy()
     return err("failed to create lsquic engine")
 
   ctx.tickTimeout = newTimeout(

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -276,7 +276,7 @@ proc verifyCertificate(
     return ssl_verify_invalid
 
 proc setupSSLContext*(quicCtx: QuicContext) =
-  let sslCtx = SSL_CTX_new(
+  var sslCtx = SSL_CTX_new(
     if quicCtx is ServerContext:
       TLS_server_method()
     else:
@@ -284,6 +284,12 @@ proc setupSSLContext*(quicCtx: QuicContext) =
   )
   if sslCtx.isNil:
     raiseAssert "failed to create sslCtx"
+
+  var sslCtxInstalled = false
+  defer:
+    if not sslCtxInstalled and not sslCtx.isNil:
+      SSL_CTX_free(sslCtx)
+      sslCtx = nil
 
   if SSL_CTX_set_ex_data(sslCtx, SSL_CTX_ID, cast[pointer](quicCtx)) != 1:
     raiseAssert "could not set data in sslCtx"
@@ -296,13 +302,13 @@ proc setupSSLContext*(quicCtx: QuicContext) =
   if quicCtx.tlsConfig.key.len != 0 and quicCtx.tlsConfig.certificate.len != 0:
     let pkey = quicCtx.tlsConfig.key.toPKey().valueOr:
       raiseAssert "could not convert certificate to pkey: " & error
+    defer:
+      EVP_PKEY_free(pkey)
 
     let cert = quicCtx.tlsConfig.certificate.toX509().valueOr:
       raiseAssert "could not convert certificate to x509: " & error
-
     defer:
       X509_free(cert)
-      EVP_PKEY_free(pkey)
 
     if SSL_CTX_use_certificate(sslCtx, cert) != 1:
       raiseAssert "could not use certificate"
@@ -335,6 +341,7 @@ proc setupSSLContext*(quicCtx: QuicContext) =
   discard SSL_CTX_set_max_proto_version(sslCtx, TLS1_3_VERSION)
 
   quicCtx.sslCtx = sslCtx
+  sslCtxInstalled = true
 
 proc getSSLCtx*(peer_ctx: pointer, sockaddr: ptr SockAddr): ptr SSL_CTX {.cdecl.} =
   let quicCtx = cast[QuicContext](peer_ctx)

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -20,7 +20,7 @@ proc onNewConn(
 
   let x509chain = lsquic_conn_get_full_cert_chain(conn)
   let certChain = x509chain.getCertChain()
-  OPENSSL_sk_free(cast[ptr OPENSSL_STACK](x509chain))
+  x509chain.freeCertChain()
 
   # TODO: should use a constructor
   let quicConn = QuicConnection(
@@ -46,6 +46,7 @@ proc onConnClosed(conn: ptr lsquic_conn_t) {.cdecl.} =
     let quicConn = cast[QuicConnection](conn_ctx)
     quicConn.cancelPending()
     quicConn.onClose()
+    quicConn.onClose = nil
     quicConn.lsquicConn = nil
     GC_unref(quicConn)
   lsquic_conn_set_ctx(conn, nil)
@@ -101,6 +102,7 @@ proc new*(T: typedesc[ServerContext], tlsConfig: TLSConfig): Result[T, string] =
 
   ctx.engine = lsquic_engine_new(LSENG_SERVER, addr ctx.api)
   if ctx.engine.isNil:
+    ctx.destroy()
     return err("failed to create lsquic engine")
 
   ctx.tickTimeout = newTimeout(

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -167,9 +167,21 @@ proc new*(
   )
   endpoint.udp = endpoint.createUdp(address)
 
+  var initialized = false
+
+  defer:
+    if not initialized:
+      if not endpoint.serverContext.isNil:
+        endpoint.serverContext.destroy()
+      if not endpoint.clientContext.isNil:
+        endpoint.clientContext.destroy()
+      if not endpoint.udp.isNil:
+        endpoint.udp.close()
+
   if CanListen in capabilities:
     endpoint.serverContext = createServerContext(tlsConfig, cint(endpoint.udp.fd))
 
+  initialized = true
   endpoint
 
 proc new*(


### PR DESCRIPTION
## Summary

Fix native resource leaks in QUIC/TLS lifecycle paths:

- release both the returned certificate-chain stack and its `X509` references
- clean up `SSL_CTX`, parsed certificates, and keys when SSL context setup fails before ownership is transferred
- destroy partially initialized client/server contexts when engine creation fails
- close endpoint resources if endpoint construction fails after opening UDP transport
- clear connection-held callbacks/futures on close to release references sooner

## Affected Areas

- [x] Transports
  QUIC context, endpoint, and connection cleanup paths.

## Impact on Library Users

No API changes. This reduces retained native and Nim-side resources in failure and close paths.

## Risk Assessment

Low. The changes are scoped to cleanup paths and ownership handoff around existing QUIC/TLS resources.
