### PR TITLE
replace deprecated actions/cache@v4 with actions/cache@v5

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -37,17 +37,6 @@ runs:
         chmod 755 external/bin/gcc external/bin/g++
         echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
 
-    - name: MSYS2 (Windows i386)
-      if: inputs.os == 'Windows' && inputs.cpu == 'i386'
-      uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        msystem: MINGW32
-        install: >-
-          base-devel
-          git
-          mingw-w64-i686-toolchain
-
     - name: MSYS2 (Windows amd64)
       if: inputs.os == 'Windows' && inputs.cpu == 'amd64'
       uses: msys2/setup-msys2@v2
@@ -61,7 +50,7 @@ runs:
     - name: Restore Nim DLLs dependencies (Windows) from cache
       if: inputs.os == 'Windows'
       id: windows-dlls-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: external/dlls
         key: 'dlls'
@@ -116,7 +105,7 @@ runs:
 
     - name: Restore Nim from cache
       id: nim-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: '${{ github.workspace }}/nim'
         key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_ref }}-cache-${{ env.cache_nonce }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-mingw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: external/mingw-${{ matrix.platform.cpu }}
           key: 'mingw-llvm-17-${{ matrix.platform.cpu }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: "recursive"
 

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -15,7 +15,7 @@ requires "unittest2"
 requires "chronicles >= 0.11.0"
 requires "https://github.com/vacp2p/nim-boringssl >= 0.0.4"
 
-import os, strutils, sequtils
+import std/[os, strutils, sequtils]
 
 var flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 


### PR DESCRIPTION
Triggers
> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Also, i386 Windows is [EOL](https://support.microsoft.com/en-US/Windows/Deployment/Updates-Lifecycle/windows-10-support-has-ended-on-october-14-2025).