### PR TITLE
fix: android msg_iovlen type

### DIFF
--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -1,5 +1,5 @@
 packageName = "lsquic"
-version = "0.6.0"
+version = "0.5.5"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -1,5 +1,5 @@
 packageName = "lsquic"
-version = "0.5.4"
+version = "0.6.0"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -122,7 +122,7 @@ proc sendPacketsOut*(
         break
     else:
       let msg =
-        when defined(linux) and defined(x86_64):
+        when defined(linux) and defined(x86_64) and not defined(android):
           Tmsghdr(
             msg_name: cast[pointer](addr destStorage),
             msg_namelen: destAddrLen,


### PR DESCRIPTION
## Summary

Exclude Android from the Linux x86_64 `msg_iovlen` branch in `sendPacketsOut`.

Android x86_64 should use the `cint` field type, while the existing Linux x86_64 path keeps using `csize_t`.

This also bumps the package version to `0.5.5`.

## Affected Areas

- [x] Transports  
  QUIC packet output now selects the Android-compatible `Tmsghdr.msg_iovlen` type on Android x86_64.

- [x] Build / Tooling  
  Updates `lsquic.nimble` from `0.5.4` to `0.5.5`.

## Impact on Library Users

No API changes.

Downstream projects that cross-compile for Android x86_64 can consume this release instead of carrying a local patch for the `msg_iovlen` type mismatch.

## Risk Assessment

Low. The condition only changes behavior when `android` is defined; existing Linux x86_64 builds keep the previous `csize_t` path.