### PR TITLE
test: improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tests/**
+!tests/**/
 !tests/**/*.nim

--- a/tests/helpers/address.nim
+++ b/tests/helpers/address.nim
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH 
+
+import chronos
+
+template AutoAddressIP4*(): TransportAddress =
+  initTAddress("127.0.0.1:0")
+
+template AutoAddressIP6*(): TransportAddress =
+  initTAddress("[::1]:0")
+
+template WildcardIP6*(): TransportAddress =
+  initTAddress("[::]:0")

--- a/tests/helpers/certificate.nim
+++ b/tests/helpers/certificate.nim
@@ -3,6 +3,7 @@
 
 import sequtils
 import os
+import std/sets
 
 const certificateStr =
   staticRead(parentDir(currentSourcePath()) / "testCertificate.pem")
@@ -16,3 +17,8 @@ proc testCertificate*(): seq[byte] =
 
 proc testPrivateKey*(): seq[byte] =
   strToSeq(privateKeyStr)
+
+proc singleAlpn*(name: string = "test"): HashSet[string] =
+  var alpn = initHashSet[string]()
+  alpn.incl(name)
+  alpn

--- a/tests/helpers/certificate.nim
+++ b/tests/helpers/certificate.nim
@@ -18,7 +18,7 @@ proc testCertificate*(): seq[byte] =
 proc testPrivateKey*(): seq[byte] =
   strToSeq(privateKeyStr)
 
-proc singleAlpn*(name: string = "test"): HashSet[string] =
+proc makeAlpn*(name: string = "test"): HashSet[string] =
   var alpn = initHashSet[string]()
   alpn.incl(name)
   alpn

--- a/tests/helpers/clientserver.nim
+++ b/tests/helpers/clientserver.nim
@@ -12,23 +12,26 @@ proc certificateCb(
 ): bool {.gcsafe.} =
   return derCertificates.len > 0
 
-proc makeTLSConfig*(): TLSConfig {.raises: [QuicConfigError].} =
-  let customCertVerif: CertificateVerifier =
-    CustomCertificateVerifier.init(certificateCb)
-  TLSConfig.new(
-    testCertificate(),
-    testPrivateKey(),
-    @["test"].toHashSet(),
-    Opt.some(customCertVerif),
-  )
+proc defaultCertificateVerifier*(): CertificateVerifier =
+  CustomCertificateVerifier.init(certificateCb)
 
-proc makeClient*(): QuicClient {.
-    raises: [QuicConfigError, QuicError, TransportOsError]
-.} =
-  return QuicClient.new(makeTLSConfig())
+proc makeTLSConfig*(
+    verifier: CertificateVerifier = defaultCertificateVerifier(),
+    alpn: HashSet[string] = singleAlpn(),
+): TLSConfig {.raises: [QuicConfigError].} =
+  TLSConfig.new(testCertificate(), testPrivateKey(), alpn, Opt.some(verifier))
 
-proc makeServer*(): QuicServer {.raises: [QuicConfigError].} =
-  return QuicServer.new(makeTLSConfig())
+proc makeClient*(
+    verifier: CertificateVerifier = defaultCertificateVerifier(),
+    alpn: HashSet[string] = singleAlpn(),
+): QuicClient {.raises: [QuicConfigError, QuicError, TransportOsError].} =
+  return QuicClient.new(makeTLSConfig(verifier, alpn))
+
+proc makeServer*(
+    verifier: CertificateVerifier = defaultCertificateVerifier(),
+    alpn: HashSet[string] = singleAlpn(),
+): QuicServer {.raises: [QuicConfigError].} =
+  return QuicServer.new(makeTLSConfig(verifier, alpn))
 
 proc makeEndpoint*(
     address: TransportAddress,
@@ -40,3 +43,25 @@ proc makeDialEndpoint*(
     family: AddressFamily
 ): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
   QuicEndpoint.new(makeTLSConfig(), family)
+
+type ConnectedPeers* =
+  tuple[
+    client: QuicClient, listener: Listener, outgoing: Connection, incoming: Connection
+  ]
+
+proc connectPeers*(): Future[ConnectedPeers] {.async.} =
+  let client = makeClient()
+  let server = makeServer()
+  let listener = server.listen(initTAddress("127.0.0.1:0"))
+  let accepting = listener.accept()
+  let outgoing = await client.dial(listener.localAddress())
+  let incoming = await accepting
+
+  (client, listener, outgoing, incoming)
+
+proc stopPeers*(peers: ConnectedPeers) {.async.} =
+  if not peers.outgoing.isNil:
+    peers.outgoing.close()
+  if not peers.incoming.isNil:
+    peers.incoming.close()
+  await allFutures(peers.client.stop(), peers.listener.stop())

--- a/tests/helpers/clientserver.nim
+++ b/tests/helpers/clientserver.nim
@@ -3,7 +3,7 @@
 
 import results, std/sets, chronos, chronicles
 import lsquic
-import ./certificate
+import ./[address, certificate]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -17,19 +17,19 @@ proc defaultCertificateVerifier*(): CertificateVerifier =
 
 proc makeTLSConfig*(
     verifier: CertificateVerifier = defaultCertificateVerifier(),
-    alpn: HashSet[string] = singleAlpn(),
+    alpn: HashSet[string] = makeAlpn(),
 ): TLSConfig {.raises: [QuicConfigError].} =
   TLSConfig.new(testCertificate(), testPrivateKey(), alpn, Opt.some(verifier))
 
 proc makeClient*(
     verifier: CertificateVerifier = defaultCertificateVerifier(),
-    alpn: HashSet[string] = singleAlpn(),
+    alpn: HashSet[string] = makeAlpn(),
 ): QuicClient {.raises: [QuicConfigError, QuicError, TransportOsError].} =
   return QuicClient.new(makeTLSConfig(verifier, alpn))
 
 proc makeServer*(
     verifier: CertificateVerifier = defaultCertificateVerifier(),
-    alpn: HashSet[string] = singleAlpn(),
+    alpn: HashSet[string] = makeAlpn(),
 ): QuicServer {.raises: [QuicConfigError].} =
   return QuicServer.new(makeTLSConfig(verifier, alpn))
 
@@ -52,14 +52,14 @@ type ConnectedPeers* =
 proc connectPeers*(): Future[ConnectedPeers] {.async.} =
   let client = makeClient()
   let server = makeServer()
-  let listener = server.listen(initTAddress("127.0.0.1:0"))
+  let listener = server.listen(AutoAddressIP4)
   let accepting = listener.accept()
   let outgoing = await client.dial(listener.localAddress())
   let incoming = await accepting
 
   (client, listener, outgoing, incoming)
 
-proc stopPeers*(peers: ConnectedPeers) {.async.} =
+proc stop*(peers: ConnectedPeers) {.async.} =
   if not peers.outgoing.isNil:
     peers.outgoing.close()
   if not peers.incoming.isNil:

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -245,9 +245,6 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
     check seen
 
 suite "connection":
-  teardown:
-    cleanupLsquic()
-
   asyncTest "ipv4":
     await runConnectionTest(initTAddress("127.0.0.1:12345"))
 

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -18,6 +18,9 @@ proc runConnectionTest(
   let server = makeServer()
   let listener = server.listen(listenAddress)
   let boundAddress = listener.localAddress()
+  # dial the requested address on the port the listener actually bound
+  var dialAddress = dialAddress
+  dialAddress.port = boundAddress.port
   defer:
     await allFutures(client.stop(), listener.stop())
   let accepting = listener.accept()
@@ -207,11 +210,12 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
   let client = makeClient()
   let server = makeServer()
   let listener = server.listen(address)
+  let boundAddress = listener.localAddress()
   defer:
     await allFutures(client.stop(), listener.stop())
 
   let accepting = listener.accept()
-  let dialing = client.dial(address)
+  let dialing = client.dial(boundAddress)
 
   let outgoingConn = await dialing
   let incomingConn = await accepting
@@ -246,16 +250,16 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
 
 suite "connection":
   asyncTest "ipv4":
-    await runConnectionTest(initTAddress("127.0.0.1:12345"))
+    await runConnectionTest(initTAddress("127.0.0.1:0"))
 
   asyncTest "ipv6":
-    await runConnectionTest(initTAddress("[::1]:12345"))
+    await runConnectionTest(initTAddress("[::1]:0"))
 
   asyncTest "ipv6 dual-stack listener accepts ipv4 dial":
-    await runConnectionTest(initTAddress("[::]:12347"), initTAddress("127.0.0.1:12347"))
+    await runConnectionTest(initTAddress("[::]:0"), initTAddress("127.0.0.1:0"))
 
   asyncTest "multiple concurrent stream opens":
-    await runConcurrentStreamOpenTest(initTAddress("127.0.0.1:12346"))
+    await runConcurrentStreamOpenTest(initTAddress("127.0.0.1:0"))
 
   asyncTest "endpoint accepts inbound quic":
     await runEndpointAcceptTest(initTAddress("127.0.0.1:0"))

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -5,7 +5,7 @@
 
 import chronos, chronos/unittest2/asynctests, results, chronicles, sequtils
 import lsquic
-import ./helpers/clientserver
+import ./helpers/[address, clientserver]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -19,12 +19,12 @@ proc runConnectionTest(
   let listener = server.listen(listenAddress)
   let boundAddress = listener.localAddress()
   # dial the requested address on the port the listener actually bound
-  var dialAddress = dialAddress
-  dialAddress.port = boundAddress.port
+  var effectiveDialAddress = dialAddress
+  effectiveDialAddress.port = boundAddress.port
   defer:
     await allFutures(client.stop(), listener.stop())
   let accepting = listener.accept()
-  let dialing = client.dial(dialAddress)
+  let dialing = client.dial(effectiveDialAddress)
 
   let outgoingConn = await dialing
   let incomingConn = await accepting
@@ -32,8 +32,8 @@ proc runConnectionTest(
   check:
     outgoingConn.certificates().len == 1
     incomingConn.certificates().len == 1
-    outgoingConn.remoteAddress().family == dialAddress.family
-    outgoingConn.remoteAddress().port == dialAddress.port
+    outgoingConn.remoteAddress().family == effectiveDialAddress.family
+    outgoingConn.remoteAddress().port == effectiveDialAddress.port
     incomingConn.localAddress().family == boundAddress.family
     incomingConn.localAddress().port == boundAddress.port
     outgoingConn.localAddress().port == incomingConn.remoteAddress().port
@@ -250,25 +250,25 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
 
 suite "connection":
   asyncTest "ipv4":
-    await runConnectionTest(initTAddress("127.0.0.1:0"))
+    await runConnectionTest(AutoAddressIP4)
 
   asyncTest "ipv6":
-    await runConnectionTest(initTAddress("[::1]:0"))
+    await runConnectionTest(AutoAddressIP6)
 
   asyncTest "ipv6 dual-stack listener accepts ipv4 dial":
-    await runConnectionTest(initTAddress("[::]:0"), initTAddress("127.0.0.1:0"))
+    await runConnectionTest(WildcardIP6, AutoAddressIP4)
 
   asyncTest "multiple concurrent stream opens":
-    await runConcurrentStreamOpenTest(initTAddress("127.0.0.1:0"))
+    await runConcurrentStreamOpenTest(AutoAddressIP4)
 
   asyncTest "endpoint accepts inbound quic":
-    await runEndpointAcceptTest(initTAddress("127.0.0.1:0"))
+    await runEndpointAcceptTest(AutoAddressIP4)
 
   asyncTest "endpoint dials from listener socket":
-    await runEndpointSharedSocketDialTest(initTAddress("127.0.0.1:0"))
+    await runEndpointSharedSocketDialTest(AutoAddressIP4)
 
   asyncTest "dial-only endpoint works without listener":
-    await runEndpointDialOnlyTest(initTAddress("127.0.0.1:0"))
+    await runEndpointDialOnlyTest(AutoAddressIP4)
 
   asyncTest "endpoints cross-dial from shared listener sockets":
-    await runEndpointSharedSocketCrossDialTest(initTAddress("127.0.0.1:0"))
+    await runEndpointSharedSocketCrossDialTest(AutoAddressIP4)

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -8,7 +8,7 @@ import chronos, chronos/unittest2/asynctests, results, chronicles
 import lsquic
 import lsquic/[datagram]
 import lsquic/context/[client, context, io]
-import ./helpers/[certificate, clientserver, stream]
+import ./helpers/[address, certificate, clientserver, stream]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -17,7 +17,7 @@ initializeLsquic(true, true)
 suite "lifecycle":
   asyncTest "listener stop makes accept fail":
     let server = makeServer()
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     let accepting = listener.accept()
 
     await listener.stop()
@@ -27,7 +27,7 @@ suite "lifecycle":
 
   asyncTest "listener stop fails all pending accepts":
     let server = makeServer()
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     let accepting1 = listener.accept()
     let accepting2 = listener.accept()
     let accepting3 = listener.accept()
@@ -44,7 +44,7 @@ suite "lifecycle":
   asyncTest "connection close propagates to peer":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     peers.outgoing.close()
 
@@ -54,7 +54,7 @@ suite "lifecycle":
 
   asyncTest "accept skips closed connection and client redials":
     let server = makeServer()
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     let address = listener.localAddress()
     let client = makeClient()
     var accepted: Future[Connection]
@@ -104,7 +104,7 @@ suite "lifecycle":
   asyncTest "operations fail after connection close":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     peers.outgoing.close()
     check (await peers.outgoing.closedFuture().withTimeout(2.seconds))
@@ -119,7 +119,7 @@ suite "lifecycle":
   asyncTest "abort wakes pending incoming stream":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let incomingWaiting = peers.incoming.incomingStream()
     peers.outgoing.abort()
@@ -145,7 +145,7 @@ suite "lifecycle":
   asyncTest "abort after open stream still closes connection":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let opening = peers.outgoing.openStream()
     peers.outgoing.abort()
@@ -159,7 +159,7 @@ suite "lifecycle":
   asyncTest "write after close raises stream error":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let outgoingStream = await peers.outgoing.openStream()
     await outgoingStream.write(@[1'u8])
@@ -180,7 +180,7 @@ suite "lifecycle":
   asyncTest "cancel pending write clears stream write task":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let outgoingStream = await peers.outgoing.openStream()
     # 16 MB exceeds the send window, so the write parks with a pending write task
@@ -195,7 +195,7 @@ suite "lifecycle":
   asyncTest "read once returns zero repeatedly after eof":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let outgoingStream = await peers.outgoing.openStream()
     await outgoingStream.write(@[9'u8, 8, 7, 6])
@@ -212,7 +212,7 @@ suite "lifecycle":
   asyncTest "blocked read completes when peer half closes":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let outgoingStream = await peers.outgoing.openStream()
     await outgoingStream.write(@[42'u8])
@@ -238,7 +238,7 @@ suite "lifecycle":
     const StreamCreditTimeout = 30.seconds
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     proc openStreamWithTimeout(
         conn: Connection
@@ -282,7 +282,7 @@ suite "lifecycle":
   asyncTest "cancelled blocked read clears pending read":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let incomingWaiting = peers.incoming.incomingStream()
     let outgoingStream = await peers.outgoing.openStream()
@@ -319,7 +319,7 @@ suite "lifecycle":
   asyncTest "peer reset":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let outgoingStream = await peers.outgoing.openStream()
     await outgoingStream.write(@[1'u8])

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -37,9 +37,6 @@ proc stopPeers(peers: ConnectedPeers) {.async.} =
   await allFutures(peers.client.stop(), peers.listener.stop())
 
 suite "lifecycle":
-  teardown:
-    cleanupLsquic()
-
   asyncTest "listener stop makes accept fail":
     let server = makeServer()
     let listener = server.listen(initTAddress("127.0.0.1:0"))

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -144,7 +144,6 @@ suite "lifecycle":
       await stopPeers(peers)
 
     let incomingWaiting = peers.incoming.incomingStream()
-    await sleepAsync(100.milliseconds)
     peers.outgoing.abort()
 
     expect ConnectionClosedError:
@@ -206,20 +205,12 @@ suite "lifecycle":
       await stopPeers(peers)
 
     let outgoingStream = await peers.outgoing.openStream()
+    # 16 MB exceeds the send window, so the write parks with a pending write task
     let writing = outgoingStream.write(newData(16 * 1024 * 1024, 0x7A'u8))
 
-    var observedPending = false
-    for _ in 0 ..< 200:
-      if outgoingStream.toWrite.isSome:
-        observedPending = true
-        break
-      if writing.finished:
-        break
-      await sleepAsync(10.milliseconds)
+    check outgoingStream.toWrite.isSome
 
-    check observedPending
-    if not writing.finished:
-      await writing.cancelAndWait()
+    await writing.cancelAndWait()
 
     check outgoingStream.toWrite.isNone()
 
@@ -363,7 +354,6 @@ suite "lifecycle":
     var buf = newSeq[byte](8)
     let reading = incomingStream.readOnce(buf)
 
-    await sleepAsync(100.milliseconds)
     outgoingStream.abort()
 
     check (await reading.withTimeout(2.seconds))

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -14,28 +14,6 @@ trace "chronicles has to be imported to fix Error: undeclared identifier: 'activ
 
 initializeLsquic(true, true)
 
-type ConnectedPeers =
-  tuple[
-    client: QuicClient, listener: Listener, outgoing: Connection, incoming: Connection
-  ]
-
-proc connectPeers(): Future[ConnectedPeers] {.async.} =
-  let client = makeClient()
-  let server = makeServer()
-  let listener = server.listen(initTAddress("127.0.0.1:0"))
-  let accepting = listener.accept()
-  let outgoing = await client.dial(listener.localAddress())
-  let incoming = await accepting
-
-  (client, listener, outgoing, incoming)
-
-proc stopPeers(peers: ConnectedPeers) {.async.} =
-  if not peers.outgoing.isNil:
-    peers.outgoing.close()
-  if not peers.incoming.isNil:
-    peers.incoming.close()
-  await allFutures(peers.client.stop(), peers.listener.stop())
-
 suite "lifecycle":
   asyncTest "listener stop makes accept fail":
     let server = makeServer()

--- a/tests/test_perf.nim
+++ b/tests/test_perf.nim
@@ -19,12 +19,13 @@ const
   chunkSize = 65536 # 64KB chunks like perf
 
 proc runPerf(): Future[Duration] {.async.} =
-  let address = initTAddress("127.0.0.1:12345")
+  let address = initTAddress("127.0.0.1:0")
   let client = makeClient()
   let server = makeServer()
   let listener = server.listen(address)
+  let boundAddress = listener.localAddress()
   let accepting = listener.accept()
-  let dialing = client.dial(address)
+  let dialing = client.dial(boundAddress)
 
   let outgoingConn = await dialing
   let incomingConn = await accepting

--- a/tests/test_perf.nim
+++ b/tests/test_perf.nim
@@ -6,7 +6,7 @@
 import
   chronos, chronos/unittest2/asynctests, results, stew/endians2, sequtils, chronicles
 import lsquic
-import ./helpers/[clientserver, param]
+import ./helpers/[address, clientserver, param]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -19,7 +19,7 @@ const
   chunkSize = 65536 # 64KB chunks like perf
 
 proc runPerf(): Future[Duration] {.async.} =
-  let address = initTAddress("127.0.0.1:0")
+  let address = AutoAddressIP4
   let client = makeClient()
   let server = makeServer()
   let listener = server.listen(address)

--- a/tests/test_perf.nim
+++ b/tests/test_perf.nim
@@ -118,9 +118,6 @@ proc runPerf(): Future[Duration] {.async.} =
   return duration
 
 suite "perf protocol simulation":
-  teardown:
-    cleanupLsquic()
-
   asyncTest "test":
     var total: Duration
 

--- a/tests/test_stress.nim
+++ b/tests/test_stress.nim
@@ -5,7 +5,7 @@
 
 import chronos, chronos/unittest2/asynctests, results, chronicles
 import lsquic
-import ./helpers/[clientserver, param, stream]
+import ./helpers/[address, clientserver, param, stream]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -37,7 +37,7 @@ proc payload(id: int, size: int): seq[byte] =
 proc runSequentialRound(round: int) {.async.} =
   let client = makeClient()
   let server = makeServer()
-  let listener = server.listen(initTAddress("127.0.0.1:0"))
+  let listener = server.listen(AutoAddressIP4)
   defer:
     await allFutures(client.stop(), listener.stop())
 
@@ -68,7 +68,7 @@ suite "stress":
   asyncTest "large single write roundtrip":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let sent = payload(99, LargeWriteSize)
     let outgoingStream = await peers.outgoing.openStream()
@@ -85,7 +85,7 @@ suite "stress":
   asyncTest "concurrent writes on one stream preserve chunk boundaries":
     let peers = await connectPeers()
     defer:
-      await stopPeers(peers)
+      await peers.stop()
 
     let outgoingStream = await peers.outgoing.openStream()
     var writes: seq[Future[void]]
@@ -118,7 +118,7 @@ suite "stress":
 
   asyncTest "multiple concurrent clients":
     let server = makeServer()
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     let address = listener.localAddress()
     defer:
       await listener.stop()

--- a/tests/test_stress.nim
+++ b/tests/test_stress.nim
@@ -71,9 +71,6 @@ proc runSequentialRound(round: int) {.async.} =
   check (await incoming.closedFuture().withTimeout(2.seconds))
 
 suite "stress":
-  teardown:
-    cleanupLsquic()
-
   asyncTest "repeated connect and transfer":
     for round in 0 ..< SequentialRounds:
       await runSequentialRound(round)

--- a/tests/test_stress.nim
+++ b/tests/test_stress.nim
@@ -34,16 +34,6 @@ proc payload(id: int, size: int): seq[byte] =
     data[i] = byte((id + i) mod 251)
   data
 
-proc connectPeers(): Future[(QuicClient, Listener, Connection, Connection)] {.async.} =
-  let client = makeClient()
-  let server = makeServer()
-  let listener = server.listen(initTAddress("127.0.0.1:0"))
-  let accepting = listener.accept()
-  let outgoing = await client.dial(listener.localAddress())
-  let incoming = await accepting
-
-  (client, listener, outgoing, incoming)
-
 proc runSequentialRound(round: int) {.async.} =
   let client = makeClient()
   let server = makeServer()
@@ -76,16 +66,14 @@ suite "stress":
       await runSequentialRound(round)
 
   asyncTest "large single write roundtrip":
-    let (client, listener, outgoing, incoming) = await connectPeers()
+    let peers = await connectPeers()
     defer:
-      outgoing.close()
-      incoming.close()
-      await allFutures(client.stop(), listener.stop())
+      await stopPeers(peers)
 
     let sent = payload(99, LargeWriteSize)
-    let outgoingStream = await outgoing.openStream()
+    let outgoingStream = await peers.outgoing.openStream()
     let writing = outgoingStream.write(sent)
-    let incomingStream = await incoming.incomingStream()
+    let incomingStream = await peers.incoming.incomingStream()
     let reading = incomingStream.readStreamTillEOF()
 
     await writing
@@ -95,18 +83,16 @@ suite "stress":
     await incomingStream.close()
 
   asyncTest "concurrent writes on one stream preserve chunk boundaries":
-    let (client, listener, outgoing, incoming) = await connectPeers()
+    let peers = await connectPeers()
     defer:
-      outgoing.close()
-      incoming.close()
-      await allFutures(client.stop(), listener.stop())
+      await stopPeers(peers)
 
-    let outgoingStream = await outgoing.openStream()
+    let outgoingStream = await peers.outgoing.openStream()
     var writes: seq[Future[void]]
     for chunkId in 0 ..< ConcurrentWriteChunks:
       writes.add(outgoingStream.write(payload(chunkId, ConcurrentWriteChunkSize)))
 
-    let incomingStream = await incoming.incomingStream()
+    let incomingStream = await peers.incoming.incomingStream()
     let reading = incomingStream.readStreamTillEOF()
 
     await allFutures(writes)

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -25,7 +25,7 @@ suite "tls config":
       discard QuicServer.new(TLSConfig.new())
 
   test "single alpn value is encoded":
-    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), singleAlpn())
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpn())
 
     check cfg.alpnWire == "\x04test"
 

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -3,7 +3,6 @@
 
 {.used.}
 
-import std/sets
 import results
 import unittest2
 import boringssl
@@ -11,11 +10,6 @@ import lsquic
 import lsquic/certificates
 import lsquic/lsquic_ffi
 import ./helpers/certificate
-
-proc singleAlpn(): HashSet[string] =
-  var alpn = initHashSet[string]()
-  alpn.incl("test")
-  alpn
 
 suite "tls config":
   test "certificate requires key":

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -14,6 +14,7 @@ initializeLsquic(true, true)
 
 type RejectVerifierRecorder = ref object
   rejectCount: int
+  fired: AsyncEvent
 
 proc singleAlpn(name: string = "test"): HashSet[string] =
   var alpn = initHashSet[string]()
@@ -47,6 +48,7 @@ proc makeRejectingCertificateCb(
     discard serverName
     discard derCertificates
     inc recorder.rejectCount
+    recorder.fired.fire()
     false
 
 proc makeClientWithVerifier(
@@ -123,7 +125,7 @@ suite "certificate verifier":
       discard await client.dial(listener.localAddress())
 
   asyncTest "server-side verifier callback does not fail handshake without client auth":
-    let recorder = RejectVerifierRecorder()
+    let recorder = RejectVerifierRecorder(fired: newAsyncEvent())
     let client =
       makeClientWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
     let server = makeServerWithVerifier(
@@ -134,7 +136,7 @@ suite "certificate verifier":
       await allFutures(client.stop(), listener.stop())
 
     let outgoing = await client.dial(listener.localAddress())
-    await sleepAsync(100.milliseconds)
+    check (await recorder.fired.wait().withTimeout(2.seconds))
 
     check:
       outgoing.certificates().len == 1

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -64,9 +64,6 @@ proc makeServerWithVerifier(
   QuicServer.new(tlsConfig)
 
 suite "certificate verifier":
-  teardown:
-    cleanupLsquic()
-
   asyncTest "accepting custom verifier allows handshake":
     let client =
       makeClientWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -3,10 +3,9 @@
 
 {.used.}
 
-import std/sets
 import chronos, chronos/unittest2/asynctests, results, chronicles
 import lsquic
-import ./helpers/certificate
+import ./helpers/[certificate, clientserver]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -15,11 +14,6 @@ initializeLsquic(true, true)
 type RejectVerifierRecorder = ref object
   rejectCount: int
   fired: AsyncEvent
-
-proc singleAlpn(name: string = "test"): HashSet[string] =
-  var alpn = initHashSet[string]()
-  alpn.incl(name)
-  alpn
 
 proc acceptingCertificateCb(
     serverName: string, derCertificates: seq[seq[byte]]
@@ -51,26 +45,10 @@ proc makeRejectingCertificateCb(
     recorder.fired.fire()
     false
 
-proc makeClientWithVerifier(
-    verifier: CertificateVerifier, alpn: HashSet[string] = singleAlpn()
-): QuicClient =
-  let tlsConfig =
-    TLSConfig.new(testCertificate(), testPrivateKey(), alpn, Opt.some(verifier))
-  QuicClient.new(tlsConfig)
-
-proc makeServerWithVerifier(
-    verifier: CertificateVerifier, alpn: HashSet[string] = singleAlpn()
-): QuicServer =
-  let tlsConfig =
-    TLSConfig.new(testCertificate(), testPrivateKey(), alpn, Opt.some(verifier))
-  QuicServer.new(tlsConfig)
-
 suite "certificate verifier":
   asyncTest "accepting custom verifier allows handshake":
-    let client =
-      makeClientWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
-    let server =
-      makeServerWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     defer:
       await allFutures(client.stop(), listener.stop())
@@ -87,10 +65,8 @@ suite "certificate verifier":
     incoming.close()
 
   asyncTest "rejecting client verifier rejects handshake":
-    let client =
-      makeClientWithVerifier(CustomCertificateVerifier.init(rejectingCertificateCb))
-    let server =
-      makeServerWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let client = makeClient(CustomCertificateVerifier.init(rejectingCertificateCb))
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     defer:
       await allFutures(client.stop(), listener.stop())
@@ -99,10 +75,8 @@ suite "certificate verifier":
       discard await client.dial(listener.localAddress())
 
   asyncTest "raising client verifier rejects handshake":
-    let client =
-      makeClientWithVerifier(CustomCertificateVerifier.init(raisingCertificateCb))
-    let server =
-      makeServerWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let client = makeClient(CustomCertificateVerifier.init(raisingCertificateCb))
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     defer:
       await allFutures(client.stop(), listener.stop())
@@ -111,10 +85,10 @@ suite "certificate verifier":
       discard await client.dial(listener.localAddress())
 
   asyncTest "alpn mismatch rejects handshake":
-    let client = makeClientWithVerifier(
+    let client = makeClient(
       CustomCertificateVerifier.init(acceptingCertificateCb), singleAlpn("client-proto")
     )
-    let server = makeServerWithVerifier(
+    let server = makeServer(
       CustomCertificateVerifier.init(acceptingCertificateCb), singleAlpn("server-proto")
     )
     let listener = server.listen(initTAddress("127.0.0.1:0"))
@@ -126,11 +100,9 @@ suite "certificate verifier":
 
   asyncTest "server-side verifier callback does not fail handshake without client auth":
     let recorder = RejectVerifierRecorder(fired: newAsyncEvent())
-    let client =
-      makeClientWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
-    let server = makeServerWithVerifier(
-      CustomCertificateVerifier.init(recorder.makeRejectingCertificateCb())
-    )
+    let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let server =
+      makeServer(CustomCertificateVerifier.init(recorder.makeRejectingCertificateCb()))
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     defer:
       await allFutures(client.stop(), listener.stop())
@@ -145,9 +117,8 @@ suite "certificate verifier":
     outgoing.close()
 
   asyncTest "insecure verifier allows handshake":
-    let client = makeClientWithVerifier(InsecureCertificateVerifier.init())
-    let server =
-      makeServerWithVerifier(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let client = makeClient(InsecureCertificateVerifier.init())
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
     let listener = server.listen(initTAddress("127.0.0.1:0"))
     defer:
       await allFutures(client.stop(), listener.stop())

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -5,7 +5,7 @@
 
 import chronos, chronos/unittest2/asynctests, results, chronicles
 import lsquic
-import ./helpers/[certificate, clientserver]
+import ./helpers/[address, certificate, clientserver]
 
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
@@ -49,7 +49,7 @@ suite "certificate verifier":
   asyncTest "accepting custom verifier allows handshake":
     let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
     let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())
 
@@ -67,7 +67,7 @@ suite "certificate verifier":
   asyncTest "rejecting client verifier rejects handshake":
     let client = makeClient(CustomCertificateVerifier.init(rejectingCertificateCb))
     let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())
 
@@ -77,7 +77,7 @@ suite "certificate verifier":
   asyncTest "raising client verifier rejects handshake":
     let client = makeClient(CustomCertificateVerifier.init(raisingCertificateCb))
     let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())
 
@@ -86,12 +86,12 @@ suite "certificate verifier":
 
   asyncTest "alpn mismatch rejects handshake":
     let client = makeClient(
-      CustomCertificateVerifier.init(acceptingCertificateCb), singleAlpn("client-proto")
+      CustomCertificateVerifier.init(acceptingCertificateCb), makeAlpn("client-proto")
     )
     let server = makeServer(
-      CustomCertificateVerifier.init(acceptingCertificateCb), singleAlpn("server-proto")
+      CustomCertificateVerifier.init(acceptingCertificateCb), makeAlpn("server-proto")
     )
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())
 
@@ -103,7 +103,7 @@ suite "certificate verifier":
     let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
     let server =
       makeServer(CustomCertificateVerifier.init(recorder.makeRejectingCertificateCb()))
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())
 
@@ -119,7 +119,7 @@ suite "certificate verifier":
   asyncTest "insecure verifier allows handshake":
     let client = makeClient(InsecureCertificateVerifier.init())
     let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
-    let listener = server.listen(initTAddress("127.0.0.1:0"))
+    let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())
 


### PR DESCRIPTION
 ## Changes

- **Remove per-test `cleanupLsquic()` teardown.** It gave false isolation. `initializeLsquic` runs once at module scope (like production), the lsquic global is a process singleton, and v1 `lsquic_global_cleanup()` frees nothing tests use. `test_runtime` still covers the init/cleanup contract.
- **Bind to port 0 instead of fixed ports** in `test_connection` and `test_perf`, then read the real port back from `localAddress()`. This unifies the tests and guards against clashing on a port that's already in use or taken by another run. The dual-stack test still dials `127.0.0.1` on the bound port.
- **Drop `sleepAsync` used to synchronize.** In `test_lifecycle`, `readOnce`, `write`, and `incomingStream` are already parked by the time they return, so the sleeps and the manual retry loop that waited for that weren't needed. In `test_verifier`, the test now waits on an `AsyncEvent` that the verify callback fires, instead of sleeping 100ms. Kept the negative-assertion sleeps.
- **Dedup fixtures.** Lifted `connectPeers`/`stopPeers`/`ConnectedPeers` to `helpers/clientserver.nim` and `singleAlpn` to `helpers/certificate.nim`. `makeClient`/`makeServer` take optional `verifier`/`alpn`, replacing `makeClientWithVerifier`/`makeServerWithVerifier`.