### PR TITLE
fix: send CONNECTION_CLOSE on locally initiated close

### DIFF
--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -34,7 +34,7 @@ proc close*(conn: Connection) {.raises: [].} =
     return
   conn.isClosed = true
   conn.quicConn.closedLocal = true
-  conn.quicContext.close(conn.quicConn)
+  conn.quicContext.abort(conn.quicConn)
 
 proc abort*(conn: Connection) {.gcsafe, raises: [].} =
   if conn.isClosed:

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -244,6 +244,64 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
   for seen in received:
     check seen
 
+proc runCloseNotifiesPeerOnce(
+    address: TransportAddress, closeIncomingSide: bool
+) {.async.} =
+  let client = makeClient()
+  let server = makeServer()
+  let listener = server.listen(address)
+  let boundAddress = listener.localAddress()
+  defer:
+    await allFutures(client.stop(), listener.stop())
+
+  let accepting = listener.accept()
+  let outgoingConn = await client.dial(boundAddress)
+  let incomingConn = await accepting
+
+  let (closingConn, victimConn) =
+    if closeIncomingSide:
+      (incomingConn, outgoingConn)
+    else:
+      (outgoingConn, incomingConn)
+
+  let victimStream = await victimConn.openStream()
+  await victimStream.write(@[1'u8, 2, 3])
+  let closerStream = await closingConn.incomingStream()
+  var buf = newSeq[byte](3)
+  discard await closerStream.readOnce(buf)
+
+  closingConn.close()
+
+  # The victim, not yet aware of the close, keeps opening streams, like
+  # keepalive pings and gossip traffic. Streams that reach the closing
+  # side after its own streams were torn down must not prevent the close
+  # from being signaled.
+  let opener = proc() {.async.} =
+    try:
+      let s = await victimConn.openStream()
+      await s.write(@[0'u8])
+    except CatchableError:
+      discard
+
+  var opens: seq[Future[void]]
+  for _ in 0 ..< 20:
+    opens.add(opener())
+  defer:
+    for fut in opens:
+      await fut.cancelAndWait()
+
+  # Both sides must observe the close promptly, not via the 30s idle
+  # timeout or retransmission give-up.
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture()).wait(
+    1.seconds
+  )
+
+proc runCloseNotifiesPeerTest(
+    address: TransportAddress, closeIncomingSide: bool
+) {.async.} =
+  for _ in 0 ..< 3:
+    await runCloseNotifiesPeerOnce(address, closeIncomingSide)
+
 suite "connection":
   teardown:
     cleanupLsquic()
@@ -271,3 +329,9 @@ suite "connection":
 
   asyncTest "endpoints cross-dial from shared listener sockets":
     await runEndpointSharedSocketCrossDialTest(initTAddress("127.0.0.1:0"))
+
+  asyncTest "close by accepting side reaches the dialer":
+    await runCloseNotifiesPeerTest(initTAddress("127.0.0.1:0"), true)
+
+  asyncTest "close by dialing side reaches the acceptor":
+    await runCloseNotifiesPeerTest(initTAddress("127.0.0.1:0"), false)


### PR DESCRIPTION
**NOTE: I have NOT validated this fix myself. This needs to be tested; this is a candidate fix.**

Candidate fix for issue reported on Discord:

```
Pearson White — 1:23 PMMonday, July 20, 2026 at 1:23 PM
I ran into some problems when looking at Quic vs Yamux in nWaku notion: Quic vs Yamux

When running 500+ relay nodes with 5 bootstrap nodes, Yamux connects fine, but Quic fails. We see the total libp2p_gossipsub_healthy_peers_topics increases with the curve we expect, but levels off prematurely, never reaching the target number of nodes. It gets stuck around ~495/500 ready relay nodes.

The logs show plenty of errors in all pods: Connection reading error, failed to send the buffer", pingPeer: failed dialing peer.

For the nodes that never make it, eventually we see stopping sendNonHighPriorityTask, and the node becomes idle. If the failing pods are killed, when they respawn, they are able to connect. It seems that the issue is simply that the nodes accumulate too many failed connections and give up. But why are so many connections failing?
```

Description for this PR (entirely GenAI - Claude Fable):

```
  fix: send CONNECTION_CLOSE when closing a connection locally

  Connection.close() used lsquic_conn_close(), whose graceful-close path
  never generates a CONNECTION_CLOSE frame for server-side connections
  outside HTTP/3: in ietf_full_conn_ci_tick() the frame is only packed
  for clients, for servers that have sent GOAWAY (IFC_GOAWAY_CLOSE), or
  in response to a received CONNECTION_CLOSE. Raw-QUIC servers satisfy
  none of these, and conn_ok_to_close() further defers closing until all
  bidi streams wind down.

  As a result, locally closing an inbound connection only emitted
  per-stream RESET_STREAM frames: the remote peer kept the session alive
  until the idle timeout (30s by default) and on_conn_closed never fired
  on either side. At scale this leaves half-dead sessions pinning
  per-peer resources in consumers, observed in nim-libp2p/nwaku as
  connection slots held by zombie sessions during mesh formation.

  Use lsquic_conn_abort() instead. It takes lsquic's immediate_close()
  path, which packs CONNECTION_CLOSE (NO_ERROR) on the next engine tick
  for both client- and server-side connections and fires on_conn_closed
  on both ends, matching the close semantics of other QUIC stacks (e.g.
  quic-go's CloseWithError). No application data is lost relative to the
  previous behavior: callers close or reset their streams before closing
  the connection, and the graceful path never delivered a close signal
  anyway.
```

EDIT: Added regression tests (also full GenAI):

```
## What the test does

`tests/test_connection.nim` — two new cases in the `connection` suite:

- **"close by accepting side reaches the dialer"** — the regression. This is the direction that was broken.
- **"close by dialing side reaches the acceptor"** — completeness; client-side close always worked.

Each runs the scenario 3×: connect, exchange data on a stream, one side closes the connection, and — critically — the victim immediately opens a burst of 20 new streams (the ping/gossip pattern of a peer that hasn't been told). Both sides' `closedFuture()` must fire within **1 second**.

## Getting it red was the hard part, and it sharpened the root cause

My first four attempts all passed on the old code, and each failure taught something now worth putting in the upstream issue:

1. **Every stream that exists at close time tears itself down** — `ci_close` sends STOP_SENDING/RESET, the peer's lsquic auto-responds, done. Pre-existing streams can't pin the connection.
2. **Only streams arriving *after* `ci_close` pin it** — nothing ever answers them, `have_bidi_streams` stays true, `conn_ok_to_close` never passes, CONNECTION_CLOSE is never sent and the conn is never destroyed.
3. **The old code sometimes gets lucky**: if an ok-to-close tick happens to have ACKs scheduled, CONNECTION_CLOSE piggybacks (the "or we have packets to send" clause) — at ~1–1.5s. That's why the 1s deadline matters: it fails both the wedge *and* the lucky path.
4. **The victim has no other signal**: lsquic's stateless resets are off by default (`es_send_prst=0`), so a silently-destroyed conn means literally dead air until the 30s idle timeout. This is precisely why it's intermittent at 2 nodes and catastrophic at 500.

## Evidence

| Configuration                             | Result                                                 |
| ----------------------------------------- | ------------------------------------------------------ |
| Old code (`lsquic_conn_close`), 5 runs    | accepting-side test **fails 5/5**; dialing-side passes |
| Fixed code (`lsquic_conn_abort`), 10 runs | **20/20 OK**, ~0.9s per test                           |
| Full suite with fix                       | **52/52 OK**                                           |

Point 2–4 above are also the missing paragraph for the upstream issue: they explain *why* the existing 50 tests never caught this — every test closes cooperatively or has no post-close traffic, so the teardown dance always completed.
```