### PR TITLE
test: improvements 2

### DIFF
--- a/tests/helpers/futures.nim
+++ b/tests/helpers/futures.nim
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import chronos/futures, chronos, sequtils
+
+proc allFuturesRaising*(
+    args: varargs[FutureBase]
+): Future[void].Raising([CatchableError]) =
+  # This proc is only meant for use in tests / not suitable for general use.
+  # Swallowing errors arbitrarily instead of aggregating them is bad design
+  # It raises `CatchableError` instead of the union of the `futs` errors,
+  # inflating the caller's `raises` list unnecessarily. `macro` could fix it.
+  let futs = @args
+  (
+    proc() {.async: (raises: [CatchableError]).} =
+      await allFutures(futs)
+      var firstErr: ref CatchableError
+      for fut in futs:
+        if fut.failed:
+          let err = fut.error()
+          if err of CancelledError:
+            raise err
+          if firstErr == nil:
+            firstErr = err
+      if firstErr != nil:
+        raise firstErr
+  )()
+
+proc allFuturesRaising*[T](
+    futs: varargs[Future[T]]
+): Future[void].Raising([CatchableError]) =
+  allFuturesRaising(futs.mapIt(FutureBase(it)))
+
+proc allFuturesRaising*[T, E]( # https://github.com/nim-lang/Nim/issues/23432
+    futs: varargs[InternalRaisesFuture[T, E]]
+): Future[void].Raising([CatchableError]) =
+  allFuturesRaising(futs.mapIt(FutureBase(it)))

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -3,11 +3,9 @@
 
 {.used.}
 
-import chronos, chronos/unittest2/asynctests, results, chronicles, sequtils
+import chronos, chronos/unittest2/asynctests, results, sequtils
 import lsquic
 import ./helpers/[address, clientserver]
-
-trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
 initializeLsquic(true, true)
 

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -5,7 +5,7 @@
 
 import chronos, chronos/unittest2/asynctests, results, sequtils
 import lsquic
-import ./helpers/[address, clientserver]
+import ./helpers/[address, clientserver, futures, stream]
 
 initializeLsquic(true, true)
 
@@ -48,29 +48,18 @@ proc runConnectionTest(
   let incomingBehaviour = proc() {.async.} =
     let stream = await incomingConn.incomingStream()
 
-    var buf = newSeq[byte](16)
-    var received: seq[byte]
-    while true:
-      let n = await stream.readOnce(buf)
-      if n == 0:
-        break
-      received.add(buf[0 ..< n])
+    let received = await readStreamTillEOF(stream)
 
     check:
       received == @[1'u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       stream.isEof
 
-    let eofRead = await stream.readOnce(buf)
-    check eofRead == 0
+    var buf = newSeq[byte](8)
+    check (await stream.readOnce(buf)) == 0
 
     await stream.close()
 
-  # Run both concurrently, then await each so a failure in either surfaces
-  let clientBehaviour = outgoingBehaviour()
-  let serverBehaviour = incomingBehaviour()
-  await allFutures(clientBehaviour, serverBehaviour)
-  await clientBehaviour
-  await serverBehaviour
+  await allFuturesRaising(outgoingBehaviour(), incomingBehaviour())
 
   outgoingConn.close()
   incomingConn.close()

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -9,6 +9,8 @@ import ./helpers/[address, clientserver]
 
 initializeLsquic(true, true)
 
+const dialTimeout = 5.seconds
+
 proc runConnectionTest(
     listenAddress: TransportAddress, dialAddress: TransportAddress
 ) {.async.} =
@@ -36,53 +38,39 @@ proc runConnectionTest(
     incomingConn.localAddress().port == boundAddress.port
     outgoingConn.localAddress().port == incomingConn.remoteAddress().port
 
-  echo "Connected!"
-
   let outgoingBehaviour = proc() {.async.} =
     let stream = await outgoingConn.openStream()
 
     await stream.write(@[1'u8, 2, 3, 4, 5])
     await stream.write(@[6'u8, 7, 8, 9, 10])
-
-    echo "Closing client stream"
-
-    echo "Client closed"
     await stream.close()
 
-    #echo "Client aborted"
-    # stream.abort() # Not interested in RW anything else
-
   let incomingBehaviour = proc() {.async.} =
-    try:
-      let stream = await incomingConn.incomingStream()
-      echo "Received stream in server"
+    let stream = await incomingConn.incomingStream()
 
-      var buf = newSeq[byte](16)
-      var received: seq[byte]
-      while true:
-        let n = await stream.readOnce(buf)
-        if n == 0:
-          break
-        received.add(buf[0 ..< n])
+    var buf = newSeq[byte](16)
+    var received: seq[byte]
+    while true:
+      let n = await stream.readOnce(buf)
+      if n == 0:
+        break
+      received.add(buf[0 ..< n])
 
-      check:
-        received == @[1'u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        stream.isEof
+    check:
+      received == @[1'u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      stream.isEof
 
-      let eofRead = await stream.readOnce(buf)
-      check eofRead == 0
+    let eofRead = await stream.readOnce(buf)
+    check eofRead == 0
 
-      echo "Server closed"
-      await stream.close()
+    await stream.close()
 
-      #echo "Server aborted"
-      #stream.abort() # Not interested in RW anything else
-    except StreamError:
-      raiseAssert "Stream error: " & getCurrentExceptionMsg()
-    except CancelledError:
-      raiseAssert "Canceled incoming behavior"
-
-  await allFutures(outgoingBehaviour(), incomingBehaviour())
+  # Run both concurrently, then await each so a failure in either surfaces
+  let clientBehaviour = outgoingBehaviour()
+  let serverBehaviour = incomingBehaviour()
+  await allFutures(clientBehaviour, serverBehaviour)
+  await clientBehaviour
+  await serverBehaviour
 
   outgoingConn.close()
   incomingConn.close()
@@ -179,10 +167,10 @@ proc runEndpointSharedSocketCrossDialTest(address: TransportAddress) {.async.} =
     dialBtoA = endpointB.dial(addressA)
 
   let
-    outgoingAtoB = await dialAtoB.wait(5.seconds)
-    outgoingBtoA = await dialBtoA.wait(5.seconds)
-    incomingA = await acceptA.wait(5.seconds)
-    incomingB = await acceptB.wait(5.seconds)
+    outgoingAtoB = await dialAtoB.wait(dialTimeout)
+    outgoingBtoA = await dialBtoA.wait(dialTimeout)
+    incomingA = await acceptA.wait(dialTimeout)
+    incomingB = await acceptB.wait(dialTimeout)
 
   check:
     outgoingAtoB.localAddress().port == addressA.port

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -12,6 +12,8 @@ import ./helpers/[address, certificate, clientserver, stream]
 
 initializeLsquic(true, true)
 
+const timeout = 2.seconds
+
 suite "lifecycle":
   asyncTest "listener stop makes accept fail":
     let server = makeServer()
@@ -46,8 +48,8 @@ suite "lifecycle":
 
     peers.outgoing.close()
 
-    check (await peers.outgoing.closedFuture().withTimeout(2.seconds))
-    check (await peers.incoming.closedFuture().withTimeout(2.seconds))
+    check (await peers.outgoing.closedFuture().withTimeout(timeout))
+    check (await peers.incoming.closedFuture().withTimeout(timeout))
     check peers.incoming.isClosed
 
   asyncTest "accept skips closed connection and client redials":
@@ -66,17 +68,17 @@ suite "lifecycle":
 
     let stale = await client.dial(address)
     stale.abort()
-    check (await stale.closedFuture().withTimeout(2.seconds))
+    check (await stale.closedFuture().withTimeout(timeout))
 
     accepted = listener.accept()
     let outgoing = await client.dial(address)
-    check (await accepted.withTimeout(2.seconds))
+    check (await accepted.withTimeout(timeout))
     let incoming = await accepted
 
     incomingStream = incoming.incomingStream()
     let outgoingStream = await outgoing.openStream()
     await outgoingStream.write(@[1'u8])
-    check (await incomingStream.withTimeout(2.seconds))
+    check (await incomingStream.withTimeout(timeout))
 
     let acceptedStream = await incomingStream
     var buf = newSeq[byte](1)
@@ -93,8 +95,8 @@ suite "lifecycle":
 
     await peers.client.stop()
 
-    check (await peers.outgoing.closedFuture().withTimeout(2.seconds))
-    check (await peers.incoming.closedFuture().withTimeout(2.seconds))
+    check (await peers.outgoing.closedFuture().withTimeout(timeout))
+    check (await peers.incoming.closedFuture().withTimeout(timeout))
 
     peers.incoming.close()
     await peers.listener.stop()
@@ -105,8 +107,8 @@ suite "lifecycle":
       await peers.stop()
 
     peers.outgoing.close()
-    check (await peers.outgoing.closedFuture().withTimeout(2.seconds))
-    check (await peers.incoming.closedFuture().withTimeout(2.seconds))
+    check (await peers.outgoing.closedFuture().withTimeout(timeout))
+    check (await peers.incoming.closedFuture().withTimeout(timeout))
 
     expect ConnectionClosedError:
       discard await peers.outgoing.openStream()
@@ -147,9 +149,9 @@ suite "lifecycle":
 
     let opening = peers.outgoing.openStream()
     peers.outgoing.abort()
-    check (await opening.withTimeout(2.seconds))
+    check (await opening.withTimeout(timeout))
     let stream = await opening
-    check (await peers.outgoing.closedFuture().withTimeout(2.seconds))
+    check (await peers.outgoing.closedFuture().withTimeout(timeout))
 
     expect StreamError:
       await stream.write(@[1'u8])
@@ -227,7 +229,7 @@ suite "lifecycle":
 
     await outgoingStream.close()
 
-    check (await reading.withTimeout(2.seconds))
+    check (await reading.withTimeout(timeout))
     check (await reading) == 0
     await incomingStream.close()
 
@@ -285,7 +287,7 @@ suite "lifecycle":
     let incomingWaiting = peers.incoming.incomingStream()
     let outgoingStream = await peers.outgoing.openStream()
     await outgoingStream.write(@[1'u8])
-    check (await incomingWaiting.withTimeout(2.seconds))
+    check (await incomingWaiting.withTimeout(timeout))
     let incomingStream = await incomingWaiting
 
     var firstByte = newSeq[byte](1)
@@ -309,7 +311,7 @@ suite "lifecycle":
 
     var buf = newSeq[byte](1)
     let nextRead = incomingStream.readOnce(buf)
-    check (await nextRead.withTimeout(2.seconds))
+    check (await nextRead.withTimeout(timeout))
     check (await nextRead) == 1
     check buf[0] == 99
     await incomingStream.close()
@@ -332,7 +334,7 @@ suite "lifecycle":
 
     outgoingStream.abort()
 
-    check (await reading.withTimeout(2.seconds))
+    check (await reading.withTimeout(timeout))
     check (await reading) == 0
     check incomingStream.isEof
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -4,13 +4,11 @@
 {.used.}
 
 import std/sets
-import chronos, chronos/unittest2/asynctests, results, chronicles
+import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import lsquic/[datagram]
 import lsquic/context/[client, context, io]
 import ./helpers/[address, certificate, clientserver, stream]
-
-trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
 initializeLsquic(true, true)
 

--- a/tests/test_perf.nim
+++ b/tests/test_perf.nim
@@ -3,12 +3,9 @@
 
 {.used.}
 
-import
-  chronos, chronos/unittest2/asynctests, results, stew/endians2, sequtils, chronicles
+import chronos, chronos/unittest2/asynctests, results, stew/endians2, sequtils
 import lsquic
 import ./helpers/[address, clientserver, param]
-
-trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
 initializeLsquic(true, true)
 

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -3,18 +3,32 @@
 
 {.used.}
 
-import unittest2
+import chronos, chronos/unittest2/asynctests
 import lsquic
+import ./helpers/[address, clientserver]
 
 suite "runtime":
-  test "initialize and cleanup are repeatable":
+  asyncTest "init and cleanup are repeatable and leave a usable global":
+    # start from a known-clean global regardless of prior state
     cleanupLsquic()
 
     for _ in 0 ..< 3:
       initializeLsquic(true, true)
-      initializeLsquic(true, true)
+      initializeLsquic(true, true) # second init is a no-op via the `initialized` guard
       cleanupLsquic()
-      cleanupLsquic()
+      cleanupLsquic() # second cleanup is a safe no-op
 
+    # after the repeated cycle a fresh init must leave a working stack:
+    # QuicServer.listen builds a real lsquic engine
     initializeLsquic(true, true)
+    let listener = QuicServer.new(makeTLSConfig()).listen(AutoAddressIP4)
+    check listener.localAddress().port != Port(0)
+    await listener.stop()
+    cleanupLsquic()
+
+  test "per-role init flags are accepted":
+    cleanupLsquic()
+    initializeLsquic(client = true, server = false) # `if server:` false path
+    cleanupLsquic()
+    initializeLsquic(client = false, server = true) # `if client:` false path
     cleanupLsquic()

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -28,7 +28,7 @@ suite "runtime":
 
   test "per-role init flags are accepted":
     cleanupLsquic()
-    initializeLsquic(client = true, server = false) # `if server:` false path
+    initializeLsquic(client = true, server = false)
     cleanupLsquic()
-    initializeLsquic(client = false, server = true) # `if client:` false path
+    initializeLsquic(client = false, server = true)
     cleanupLsquic()

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -22,9 +22,11 @@ suite "runtime":
     # QuicServer.listen builds a real lsquic engine
     initializeLsquic(true, true)
     let listener = QuicServer.new(makeTLSConfig()).listen(AutoAddressIP4)
+    defer:
+      await listener.stop()
+      cleanupLsquic()
+
     check listener.localAddress().port != Port(0)
-    await listener.stop()
-    cleanupLsquic()
 
   test "per-role init flags are accepted":
     cleanupLsquic()

--- a/tests/test_stress.nim
+++ b/tests/test_stress.nim
@@ -3,11 +3,9 @@
 
 {.used.}
 
-import chronos, chronos/unittest2/asynctests, results, chronicles
+import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import ./helpers/[address, clientserver, param, stream]
-
-trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
 initializeLsquic(true, true)
 

--- a/tests/test_stress.nim
+++ b/tests/test_stress.nim
@@ -24,6 +24,7 @@ const
       16 * 1024
     else:
       64 * 1024
+  timeout = 2.seconds
 
 proc payload(id: int, size: int): seq[byte] =
   var data = newSeq[byte](size)
@@ -55,8 +56,8 @@ proc runSequentialRound(round: int) {.async.} =
     await incomingStream.close()
 
   outgoing.close()
-  check (await outgoing.closedFuture().withTimeout(2.seconds))
-  check (await incoming.closedFuture().withTimeout(2.seconds))
+  check (await outgoing.closedFuture().withTimeout(timeout))
+  check (await incoming.closedFuture().withTimeout(timeout))
 
 suite "stress":
   asyncTest "repeated connect and transfer":
@@ -138,7 +139,7 @@ suite "stress":
               await stream.write(@[got[0]])
               await stream.close()
               conn.close()
-              check (await conn.closedFuture().withTimeout(2.seconds))
+              check (await conn.closedFuture().withTimeout(timeout))
           )(incoming)
         )
 
@@ -161,7 +162,7 @@ suite "stress":
       check ack[0] == byte(id)
       check (await stream.readOnce(ack)) == 0
       conn.close()
-      check (await conn.closedFuture().withTimeout(2.seconds))
+      check (await conn.closedFuture().withTimeout(timeout))
 
     var clients: seq[Future[void]]
     for id in 0 ..< ConcurrentClients:

--- a/tests/test_timeout.nim
+++ b/tests/test_timeout.nim
@@ -6,34 +6,38 @@
 import chronos, chronos/unittest2/asynctests
 import lsquic/timeout
 
+const fireTimeout = 2.seconds
+
 suite "timeout":
   asyncTest "earlier deadline replaces later deadline":
-    var fired = 0
+    let fired = newAsyncEvent()
+    var fireCount = 0
     let timeout = newTimeout(
       proc() =
-        inc fired
+        inc fireCount
+        fired.fire()
     )
 
     timeout.set(400.milliseconds)
     timeout.set(50.milliseconds)
 
-    await sleepAsync(200.milliseconds)
-
-    check fired == 1
+    check (await fired.wait().withTimeout(fireTimeout))
+    check fireCount == 1
 
   asyncTest "later deadline does not replace earlier deadline":
-    var fired = 0
+    let fired = newAsyncEvent()
+    var fireCount = 0
     let timeout = newTimeout(
       proc() =
-        inc fired
+        inc fireCount
+        fired.fire()
     )
 
     timeout.set(50.milliseconds)
     timeout.set(400.milliseconds)
 
-    await sleepAsync(200.milliseconds)
-
-    check fired == 1
+    check (await fired.wait().withTimeout(fireTimeout))
+    check fireCount == 1
 
   asyncTest "stop cancels expiry":
     var fired = 0

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -3,6 +3,7 @@
 
 {.used.}
 
+import std/sets
 import results
 import unittest2
 import boringssl
@@ -21,8 +22,9 @@ suite "tls config":
       discard TLSConfig.new(key = testPrivateKey())
 
   test "server requires certificate":
+    let cfg = TLSConfig.new()
     expect QuicConfigError:
-      discard QuicServer.new(TLSConfig.new())
+      discard QuicServer.new(cfg)
 
   test "single alpn value is encoded":
     let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpn())

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -3,11 +3,9 @@
 
 {.used.}
 
-import chronos, chronos/unittest2/asynctests, results, chronicles
+import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import ./helpers/[address, certificate, clientserver]
-
-trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
 initializeLsquic(true, true)
 


### PR DESCRIPTION
## Changes

Test cleanup and hardening:
- **test_runtime**: the init/cleanup idempotency test had no `check`, it only proved the calls did not crash. It now builds a real lsquic engine after the cycle and checks the socket actually bound, plus a new case that exercises per-role init flags.
- **test_connection**: dropped debug `echo`s and commented-out `abort()` leftovers, and removed the `try/except ... raiseAssert` around the server behaviour. That block swallowed `CancelledError` and turned a `StreamError` into a `Defect`. Both behaviours now run concurrently and are awaited after `allFutures`, so a real exception surfaces as a normal failure. `allFutures` on its own does not re-raise a child failure.
- **test_timeout**: the two deadline tests slept a fixed `200ms` before checking the callback ran. Replaced with an `AsyncEvent` the callback fires, awaited with a timeout. Deterministic, and the tests finish as soon as the timer fires.
- **test_tlsconfig**: split the `expect QuicConfigError` that wrapped both `TLSConfig.new()` and `QuicServer.new()` so the assertion only covers the call under test. Added `import std/sets` so the file compiles standalone.
- **test_lifecycle**, **test_stress**, **test_connection**: hoisted repeated `2.seconds` / `5.seconds` timeout literals into named consts.
- Removed the `trace "chronicles has to be imported ..."` workaround from the suites that no longer need it.