### PR TITLE
feat(transport): support per-dial certificate verification

### DIFF
--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import chronos
-import ./[errors, connection, tlsconfig, endpoint]
+import ./[errors, connection, tlsconfig, endpoint, certificateverifier]
 
 type QuicClient* = ref object of RootObj
   tlsConfig: TLSConfig
@@ -35,6 +35,16 @@ proc dial*(
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
   await self.getEndpoint(address.family).dial(address)
+
+proc dial*(
+    self: QuicClient, address: TransportAddress, certVerifier: CertificateVerifier
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  if certVerifier.isNil:
+    raise newException(QuicError, "certificate verifier is nil")
+
+  await self.getEndpoint(address.family).dial(address, certVerifier)
 
 proc stop*(self: QuicClient) {.async: (raises: [CancelledError]).} =
   var stops: seq[Future[void]]

--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -41,9 +41,6 @@ proc dial*(
 ): Future[Connection] {.
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
-  if certVerifier.isNil:
-    raise newException(QuicError, "certificate verifier is nil")
-
   await self.getEndpoint(address.family).dial(address, certVerifier)
 
 proc stop*(self: QuicClient) {.async: (raises: [CancelledError]).} =

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -2,8 +2,8 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import chronicles
-import chronos
-import ./[errors, stream, lsquic_ffi]
+import chronos, results
+import ./[errors, stream, lsquic_ffi, certificateverifier]
 import ./context/context
 
 type
@@ -21,6 +21,7 @@ type
   IncomingConnection = ref object of Connection
 
   OutgoingConnection = ref object of Connection
+    certVerifier: Opt[CertificateVerifier]
 
 proc ensureClosed(connection: Connection) {.async: (raises: [CancelledError]).} =
   await connection.closedWaiter
@@ -46,7 +47,10 @@ proc abort*(conn: Connection) {.gcsafe, raises: [].} =
 # TODO: refactor this into a single newConnection
 
 proc newOutgoingConnection*(
-    quicContext: QuicContext, local: TransportAddress, remote: TransportAddress
+    quicContext: QuicContext,
+    local: TransportAddress,
+    remote: TransportAddress,
+    certVerifier: Opt[CertificateVerifier] = Opt.none(CertificateVerifier),
 ): OutgoingConnection =
   let closed = newAsyncEvent()
   let closedWaiter = closed.wait()
@@ -55,6 +59,7 @@ proc newOutgoingConnection*(
     local: local,
     remote: remote,
     closed: closed,
+    certVerifier: certVerifier,
     closedWaiter: closedWaiter,
   )
   conn.ensureClosedFut = conn.ensureClosed()
@@ -90,7 +95,7 @@ proc dial*(
     connection.closed.fire()
 
   connection.quicConn = connection.quicContext.dial(
-    connection.local, connection.remote, retFut, onClose
+    connection.local, connection.remote, retFut, onClose, connection.certVerifier
   ).valueOr:
     retFut.fail(newException(DialError, "could not dial: " & error))
     nil

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -7,7 +7,8 @@ import chronicles
 import chronos
 import chronos/osdefs
 import ./[context, io, stream]
-import ../[lsquic_ffi, errors, tlsconfig, timeout, stream, certificates, certificateverifier]
+import
+  ../[lsquic_ffi, errors, tlsconfig, timeout, stream, certificates, certificateverifier]
 import ../helpers/sequninit
 
 proc onNewConn(

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -7,7 +7,7 @@ import chronicles
 import chronos
 import chronos/osdefs
 import ./[context, io, stream]
-import ../[lsquic_ffi, errors, tlsconfig, timeout, stream, certificates]
+import ../[lsquic_ffi, errors, tlsconfig, timeout, stream, certificates, certificateverifier]
 import ../helpers/sequninit
 
 proc onNewConn(
@@ -72,6 +72,7 @@ method dial*(
     remote: TransportAddress,
     connectedFut: Future[void],
     onClose: proc() {.gcsafe, raises: [].},
+    certVerifier: Opt[CertificateVerifier],
 ): Result[QuicConnection, string] {.raises: [], gcsafe.} =
   var
     localAddress: Sockaddr_storage
@@ -90,6 +91,7 @@ method dial*(
     remote: remote,
     incoming: newAsyncQueue[Stream](),
     onClose: onClose,
+    certVerifier: certVerifier,
   )
   GC_ref(quicClientConn) # Keep it pinned until on_conn_closed is called
   let conn = lsquic_engine_connect(
@@ -120,9 +122,6 @@ const Cubic = 1
 const Adaptive = 3
 
 proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
-  if tlsConfig.certVerifier.isNone:
-    return err("client TLSConfig requires a certificate verifier")
-
   var ctx = ClientContext()
   ctx.tlsConfig = tlsConfig
   ctx.running = true

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -164,6 +164,7 @@ type QuicConnection* = ref object of RootObj
   local*: TransportAddress
   remote*: TransportAddress
   lsquicConn*: ptr lsquic_conn_t
+  certVerifier*: Opt[CertificateVerifier]
   onClose*: proc() {.gcsafe, raises: [].}
   closedLocal*: bool
   closedRemote*: bool
@@ -256,14 +257,28 @@ proc verifyCertificate(
       return ssl_verify_invalid
 
     let quicCtx = cast[QuicContext](SSL_CTX_get_ex_data(sslCtx, SSL_CTX_ID))
-    if quicCtx.isNil or quicCtx.tlsConfig.certVerifier.isNone:
+    if quicCtx.isNil:
+      if not out_alert.isNil:
+        out_alert[] = SSL_AD_INTERNAL_ERROR
+      return ssl_verify_invalid
+
+    var certVerifier = quicCtx.tlsConfig.certVerifier
+    let conn = lsquic_ssl_to_conn(ssl)
+    if not conn.isNil:
+      let connCtx = lsquic_conn_get_ctx(conn)
+      if not connCtx.isNil:
+        let quicConn = cast[QuicConnection](connCtx)
+        if quicConn.certVerifier.isSome:
+          certVerifier = quicConn.certVerifier
+
+    if certVerifier.isNone:
       if not out_alert.isNil:
         out_alert[] = SSL_AD_INTERNAL_ERROR
       return ssl_verify_invalid
 
     let derCertificates = getFullCertChain(ssl)
     let serverName = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name)
-    if quicCtx.tlsConfig.certVerifier.get().verify($serverName, derCertificates):
+    if certVerifier.get().verify($serverName, derCertificates):
       return ssl_verify_ok
 
     if not out_alert.isNil:
@@ -322,7 +337,7 @@ proc setupSSLContext*(quicCtx: QuicContext) =
   if (SSL_CTX_set1_sigalgs_list(sslCtx, "ed25519:ecdsa_secp256r1_sha256") != 1):
     raiseAssert "could not set supported algorithm list"
 
-  if quicCtx.tlsConfig.certVerifier.isSome:
+  if quicCtx of ClientContext or quicCtx.tlsConfig.certVerifier.isSome:
     SSL_CTX_set_custom_verify(
       sslCtx, SSL_VERIFY_PEER or SSL_VERIFY_FAIL_IF_NO_PEER_CERT, verifyCertificate
     )
@@ -363,6 +378,7 @@ method dial*(
     remote: TransportAddress,
     connectedFut: Future[void],
     onClose: proc() {.gcsafe, raises: [].},
+    certVerifier: Opt[CertificateVerifier],
 ): Result[QuicConnection, string] {.base, gcsafe, raises: [].} =
   raiseAssert "dial not implemented"
 

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -271,7 +271,7 @@ proc verifyCertificate(
         if quicConn.certVerifier.isSome:
           certVerifier = quicConn.certVerifier
 
-    if certVerifier.isNone:
+    if certVerifier.isNone or certVerifier.get().isNil:
       if not out_alert.isNil:
         out_alert[] = SSL_AD_INTERNAL_ERROR
       return ssl_verify_invalid

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 import chronos, chronicles, results
-import ./[errors, connection, tlsconfig, datagram, connectionmanager, lsquic_ffi]
+import ./[errors, connection, tlsconfig, datagram, connectionmanager, lsquic_ffi, certificateverifier]
 import ./context/[server, client, context, io]
 
 type
@@ -238,13 +238,16 @@ proc accept*(
     endpoint.connman.addConnection(conn)
     return conn
 
-proc dial*(
-    endpoint: QuicEndpoint, address: TransportAddress
+proc dial(
+    endpoint: QuicEndpoint,
+    address: TransportAddress,
+    certVerifier: Opt[CertificateVerifier],
 ): Future[Connection] {.
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
   let ctx = endpoint.ensureClientContext()
-  let connection = newOutgoingConnection(ctx, endpoint.udp.localAddress(), address)
+  let connection =
+    newOutgoingConnection(ctx, endpoint.udp.localAddress(), address, certVerifier)
   endpoint.connman.addConnection(connection)
   var connected = false
   try:
@@ -255,6 +258,23 @@ proc dial*(
       endpoint.connman.removeConnection(connection)
 
   connection
+
+proc dial*(
+    endpoint: QuicEndpoint, address: TransportAddress
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  await endpoint.dial(address, Opt.none(CertificateVerifier))
+
+proc dial*(
+    endpoint: QuicEndpoint, address: TransportAddress, certVerifier: CertificateVerifier
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  if certVerifier.isNil:
+    raise newException(QuicError, "certificate verifier is nil")
+
+  await endpoint.dial(address, Opt.some(certVerifier))
 
 proc localAddress*(
     endpoint: QuicEndpoint

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -270,8 +270,7 @@ proc dial*(
 .} =
   if endpoint.tlsConfig.certVerifier.isNone:
     raise newException(
-      QuicError,
-      "certificate verifier is required; use dial(address, certVerifier)"
+      QuicError, "certificate verifier is required; use dial(address, certVerifier)"
     )
 
   await endpoint.dial(address, Opt.none(CertificateVerifier))

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -2,7 +2,11 @@
 # Copyright (c) Status Research & Development GmbH
 
 import chronos, chronicles, results
-import ./[errors, connection, tlsconfig, datagram, connectionmanager, lsquic_ffi, certificateverifier]
+import
+  ./[
+    errors, connection, tlsconfig, datagram, connectionmanager, lsquic_ffi,
+    certificateverifier,
+  ]
 import ./context/[server, client, context, io]
 
 type
@@ -264,6 +268,12 @@ proc dial*(
 ): Future[Connection] {.
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
+  if endpoint.tlsConfig.certVerifier.isNone:
+    raise newException(
+      QuicError,
+      "certificate verifier is required; use dial(address, certVerifier)"
+    )
+
   await endpoint.dial(address, Opt.none(CertificateVerifier))
 
 proc dial*(

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import chronos, results
-import ./[errors, connection, tlsconfig, endpoint]
+import ./[errors, connection, tlsconfig, endpoint, certificateverifier]
 
 type
   QuicServer* = ref object of RootObj
@@ -44,6 +44,16 @@ proc dial*(
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
   await listener.endpoint.dial(address)
+
+proc dial*(
+    listener: Listener, address: TransportAddress, certVerifier: CertificateVerifier
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  if certVerifier.isNil:
+    raise newException(QuicError, "certificate verifier is nil")
+
+  await listener.endpoint.dial(address, certVerifier)
 
 proc localAddress*(
     listener: Listener

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -15,6 +15,10 @@ type RejectVerifierRecorder = ref object
   rejectCount: int
   fired: AsyncEvent
 
+type VerifierRecorder = ref object
+  count: int
+  fired: AsyncEvent
+
 proc acceptingCertificateCb(
     serverName: string, derCertificates: seq[seq[byte]]
 ): bool {.gcsafe.} =
@@ -38,12 +42,28 @@ proc raisingCertificateCb(
 proc makeRejectingCertificateCb(
     recorder: RejectVerifierRecorder
 ): certificateVerifierCB =
-  return proc(serverName: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
-    discard serverName
-    discard derCertificates
+  return proc(_: string, _: seq[seq[byte]]): bool {.gcsafe.} =
     inc recorder.rejectCount
     recorder.fired.fire()
     false
+
+proc makeCertificateCb(
+    recorder: VerifierRecorder, accepted: bool
+): certificateVerifierCB =
+  return proc(_: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
+    inc recorder.count
+    recorder.fired.fire()
+    if accepted:
+      derCertificates.len > 0
+    else:
+      false
+
+proc makeClientWithoutVerifier(): QuicClient {.raises: [QuicConfigError].} =
+  QuicClient.new(
+    TLSConfig.new(
+      certificate = testCertificate(), key = testPrivateKey(), alpn = makeAlpn()
+    )
+  )
 
 suite "certificate verifier":
   asyncTest "accepting custom verifier allows handshake":
@@ -73,6 +93,92 @@ suite "certificate verifier":
 
     expect DialError:
       discard await client.dial(listener.localAddress())
+
+  asyncTest "per-dial accepting verifier overrides rejecting default":
+    let client = makeClient(CustomCertificateVerifier.init(rejectingCertificateCb))
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let listener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), listener.stop())
+
+    let accepting = listener.accept()
+    let outgoing = await client.dial(
+      listener.localAddress(), CustomCertificateVerifier.init(acceptingCertificateCb)
+    )
+    let incoming = await accepting
+
+    check:
+      outgoing.certificates().len == 1
+      incoming.certificates().len == 1
+
+    outgoing.close()
+    incoming.close()
+
+  asyncTest "per-dial rejecting verifier overrides accepting default":
+    let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let listener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), listener.stop())
+
+    expect DialError:
+      discard await client.dial(
+        listener.localAddress(), CustomCertificateVerifier.init(rejectingCertificateCb)
+      )
+
+  asyncTest "per-dial verifier works without default verifier":
+    let client = makeClientWithoutVerifier()
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let listener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), listener.stop())
+
+    let accepting = listener.accept()
+    let outgoing = await client.dial(
+      listener.localAddress(), CustomCertificateVerifier.init(acceptingCertificateCb)
+    )
+    let incoming = await accepting
+
+    check:
+      outgoing.certificates().len == 1
+      incoming.certificates().len == 1
+
+    outgoing.close()
+    incoming.close()
+
+  asyncTest "concurrent per-dial verifiers stay isolated":
+    let client = makeClientWithoutVerifier()
+    let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
+    let okListener = server.listen(AutoAddressIP4)
+    let rejectListener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), okListener.stop(), rejectListener.stop())
+
+    let okRecorder = VerifierRecorder(fired: newAsyncEvent())
+    let rejectRecorder = VerifierRecorder(fired: newAsyncEvent())
+    let accepting = okListener.accept()
+    let okDial = client.dial(
+      okListener.localAddress(),
+      CustomCertificateVerifier.init(okRecorder.makeCertificateCb(true)),
+    )
+    let rejectDial = client.dial(
+      rejectListener.localAddress(),
+      CustomCertificateVerifier.init(rejectRecorder.makeCertificateCb(false)),
+    )
+
+    let outgoing = await okDial
+    let incoming = await accepting
+    expect DialError:
+      discard await rejectDial
+
+    check:
+      outgoing.certificates().len == 1
+      incoming.certificates().len == 1
+      okRecorder.count == 1
+      rejectRecorder.count == 1
+
+    outgoing.close()
+    incoming.close()
 
   asyncTest "raising client verifier rejects handshake":
     let client = makeClient(CustomCertificateVerifier.init(raisingCertificateCb))

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -146,6 +146,14 @@ suite "certificate verifier":
     outgoing.close()
     incoming.close()
 
+  asyncTest "dial without default or per-dial verifier fails fast":
+    let client = makeClientWithoutVerifier()
+    defer:
+      await client.stop()
+
+    expect QuicError:
+      discard await client.dial(AutoAddressIP4)
+
   asyncTest "concurrent per-dial verifiers stay isolated":
     let client = makeClientWithoutVerifier()
     let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
@@ -159,11 +167,11 @@ suite "certificate verifier":
     let accepting = okListener.accept()
     let okDial = client.dial(
       okListener.localAddress(),
-      CustomCertificateVerifier.init(okRecorder.makeCertificateCb(true)),
+      CustomCertificateVerifier.init(okRecorder.makeCertificateCb(true))
     )
     let rejectDial = client.dial(
       rejectListener.localAddress(),
-      CustomCertificateVerifier.init(rejectRecorder.makeCertificateCb(false)),
+      CustomCertificateVerifier.init(rejectRecorder.makeCertificateCb(false))
     )
 
     let outgoing = await okDial

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -167,11 +167,11 @@ suite "certificate verifier":
     let accepting = okListener.accept()
     let okDial = client.dial(
       okListener.localAddress(),
-      CustomCertificateVerifier.init(okRecorder.makeCertificateCb(true))
+      CustomCertificateVerifier.init(okRecorder.makeCertificateCb(true)),
     )
     let rejectDial = client.dial(
       rejectListener.localAddress(),
-      CustomCertificateVerifier.init(rejectRecorder.makeCertificateCb(false))
+      CustomCertificateVerifier.init(rejectRecorder.makeCertificateCb(false)),
     )
 
     let outgoing = await okDial


### PR DESCRIPTION
## Summary

Adds per-dial certificate verifier overrides for outgoing QUIC connections. Callers can now pass a `CertificateVerifier` when dialing through `QuicClient`, `QuicEndpoint`, or `Listener`.

The TLS verification callback uses the per-connection verifier when present and falls back to `TLSConfig.certVerifier`, preserving existing default behavior while allowing connection-specific certificate checks.

## Affected Areas

- [x] Transports  
  QUIC client/endpoint dial path and TLS certificate verification.
- [x] Other  
  Certificate verifier coverage for override, fallback, missing default verifier, and concurrent dial cases.

## Impact on Library Users

This adds optional dial overloads for users that need per-connection certificate validation. Existing callers can keep using `TLSConfig.certVerifier` without changing their code.

Clients can now be constructed without a default verifier if each dial supplies its own verifier; dials without any effective verifier still fail certificate validation.

## Risk Assessment

This touches client TLS verification behavior. The intended verifier order is per-dial verifier first, then `TLSConfig.certVerifier`, then handshake rejection if neither exists. Server-side verifier setup remains gated by `TLSConfig.certVerifier`.

## References

- https://github.com/vacp2p/roadmap/blob/master/content/p2p/ift/2026q3-nim-lsquic-per-connection-cert-validators.md
