### PR TITLE
test: connection

### DIFF
--- a/tests/helpers/stream.nim
+++ b/tests/helpers/stream.nim
@@ -11,6 +11,30 @@ proc newData*(size: int, val: byte = byte(0xEE)): seq[byte] =
     data[i] = val
   return data
 
+proc patternData*(size: int): seq[byte] =
+  var data = newSeq[byte](size)
+  for i in 0 ..< size:
+    data[i] = byte(i mod 251)
+  return data
+
+proc readAllChunked*(
+    stream: Stream, bufSize: int
+): Future[tuple[data: seq[byte], reads: int]] {.async.} =
+  ## Drains `stream` to EOF using a fixed `bufSize` buffer, asserting that no
+  ## read ever returns more than the buffer can hold. Returns the reassembled
+  ## data together with the number of non-empty reads it took to receive it.
+  var buf = newSeq[byte](bufSize)
+  var received: seq[byte]
+  var reads = 0
+  while true:
+    let n = await stream.readOnce(buf)
+    if n == 0:
+      break
+    check n <= bufSize
+    received.add(buf[0 ..< n])
+    inc reads
+  return (received, reads)
+
 proc readStreamTillEOF*(
     stream: Stream, maxBytes: int = int.high
 ): Future[seq[byte]] {.async.} =

--- a/tests/helpers/stream.nim
+++ b/tests/helpers/stream.nim
@@ -5,13 +5,7 @@ import chronos
 import unittest2
 import lsquic
 
-proc newData*(size: int, val: byte = byte(0xEE)): seq[byte] =
-  var data = newSeq[byte](size)
-  for i in 0 ..< size:
-    data[i] = val
-  return data
-
-proc patternData*(size: int): seq[byte] =
+proc makeData*(size: int): seq[byte] =
   var data = newSeq[byte](size)
   for i in 0 ..< size:
     data[i] = byte(i mod 251)

--- a/tests/helpers/stream.nim
+++ b/tests/helpers/stream.nim
@@ -31,7 +31,7 @@ proc readAllChunked*(
     if n == 0:
       break
     check n <= bufSize
-    received.add(buf[0 ..< n])
+    received.add(buf.toOpenArray(0, n - 1))
     inc reads
   return (received, reads)
 

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -223,6 +223,49 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
   for seen in received:
     check seen
 
+proc runServerInitiatedStreamTest(address: TransportAddress) {.async.} =
+  let client = makeClient()
+  let server = makeServer()
+  let listener = server.listen(address)
+  let boundAddress = listener.localAddress()
+  defer:
+    await allFuturesRaising(client.stop(), listener.stop())
+
+  let accepting = listener.accept()
+  let dialing = client.dial(boundAddress)
+
+  let outgoingConn = await dialing # client side
+  let incomingConn = await accepting # server side
+
+  # The accepting (server) side opens the stream, the dialing (client) side
+  # receives it. This drives the server-initiated (odd stream id) parity.
+  let serverBehaviour = proc() {.async.} =
+    let stream = await incomingConn.openStream()
+
+    await stream.write(@[1'u8, 2, 3, 4, 5])
+    await stream.write(@[6'u8, 7, 8, 9, 10])
+    await stream.close()
+
+  let clientBehaviour = proc() {.async.} =
+    let stream = await outgoingConn.incomingStream()
+
+    let received = await readStreamTillEOF(stream)
+
+    check:
+      received == @[1'u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      stream.isEof
+
+    var buf = newSeq[byte](8)
+    check (await stream.readOnce(buf)) == 0
+
+    await stream.close()
+
+  await allFuturesRaising(serverBehaviour(), clientBehaviour())
+
+  outgoingConn.close()
+  incomingConn.close()
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
+
 proc runChunkedReadTest(peers: ConnectedPeers, bufSize, payloadSize: int) {.async.} =
   let payload = patternData(payloadSize)
 
@@ -265,6 +308,9 @@ suite "connection":
 
   asyncTest "multiple concurrent stream opens":
     await runConcurrentStreamOpenTest(AutoAddressIP4)
+
+  asyncTest "server initiated stream reaches client incomingStream":
+    await runServerInitiatedStreamTest(AutoAddressIP4)
 
   asyncTest "endpoint accepts inbound quic":
     await runEndpointAcceptTest(AutoAddressIP4)

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -223,6 +223,36 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
   for seen in received:
     check seen
 
+proc runChunkedReadTest(peers: ConnectedPeers, bufSize, payloadSize: int) {.async.} =
+  let payload = patternData(payloadSize)
+
+  let sender = proc() {.async.} =
+    let stream = await peers.outgoing.openStream()
+    await stream.write(payload)
+    await stream.close()
+
+  let receiver = proc() {.async.} =
+    let stream = await peers.incoming.incomingStream()
+    let (received, reads) = await readAllChunked(stream, bufSize)
+
+    # A single readOnce never returns more than bufSize bytes, so draining the
+    # whole payload takes at least ceil(payloadSize / bufSize) reads.
+    # Chunked delivery can split it into more reads than that.
+    let minReads = (payloadSize + bufSize - 1) div bufSize
+
+    check:
+      received.len == payloadSize
+      received == payload
+      reads >= minReads
+      stream.isEof
+
+    var buf = newSeq[byte](bufSize)
+    check (await stream.readOnce(buf)) == 0
+
+    await stream.close()
+
+  await allFuturesRaising(sender(), receiver())
+
 suite "connection":
   asyncTest "ipv4":
     await runConnectionTest(AutoAddressIP4)
@@ -247,3 +277,21 @@ suite "connection":
 
   asyncTest "endpoints cross-dial from shared listener sockets":
     await runEndpointSharedSocketCrossDialTest(AutoAddressIP4)
+
+  asyncTest "reads reassemble payloads across buffer sizes":
+    # (bufSize, payloadSize):
+    #   (1, 10)     one byte at a time (max iterations)
+    #   (3, 10)     undersized buffer, non-divisor
+    #   (10, 10)    buffer exactly fits the payload
+    #   (16, 10)    oversized buffer
+    #   (100, 4096) non-divisor across the 4096 stream-buffer boundary
+    #   (1, 65536)  large payload one byte at a time
+    const cases = [(1, 10), (3, 10), (10, 10), (16, 10), (100, 4096), (1, 65536)]
+
+    let peers = await connectPeers()
+    defer:
+      await peers.stop()
+
+    for (bufSize, payloadSize) in cases:
+      checkpoint("bufSize=" & $bufSize & " payloadSize=" & $payloadSize)
+      await runChunkedReadTest(peers, bufSize, payloadSize)

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -267,7 +267,7 @@ proc runServerInitiatedStreamTest(address: TransportAddress) {.async.} =
   await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
 
 proc runChunkedReadTest(peers: ConnectedPeers, bufSize, payloadSize: int) {.async.} =
-  var payload = makeData(payloadSize)
+  let payload = makeData(payloadSize)
 
   let sender = proc() {.async.} =
     let stream = await peers.outgoing.openStream()

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -229,7 +229,7 @@ proc runServerInitiatedStreamTest(address: TransportAddress) {.async.} =
   let listener = server.listen(address)
   let boundAddress = listener.localAddress()
   defer:
-    await allFuturesRaising(client.stop(), listener.stop())
+    await allFutures(client.stop(), listener.stop())
 
   let accepting = listener.accept()
   let dialing = client.dial(boundAddress)
@@ -331,8 +331,7 @@ suite "connection":
     #   (10, 10)    buffer exactly fits the payload
     #   (16, 10)    oversized buffer
     #   (100, 4096) non-divisor across the 4096 stream-buffer boundary
-    #   (1, 65536)  large payload one byte at a time
-    const cases = [(1, 10), (3, 10), (10, 10), (16, 10), (100, 4096), (1, 65536)]
+    const cases = [(1, 10), (3, 10), (10, 10), (16, 10), (100, 4096)]
 
     let peers = await connectPeers()
     defer:

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -267,7 +267,7 @@ proc runServerInitiatedStreamTest(address: TransportAddress) {.async.} =
   await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
 
 proc runChunkedReadTest(peers: ConnectedPeers, bufSize, payloadSize: int) {.async.} =
-  let payload = patternData(payloadSize)
+  var payload = makeData(payloadSize)
 
   let sender = proc() {.async.} =
     let stream = await peers.outgoing.openStream()
@@ -283,9 +283,8 @@ proc runChunkedReadTest(peers: ConnectedPeers, bufSize, payloadSize: int) {.asyn
     # Chunked delivery can split it into more reads than that.
     let minReads = (payloadSize + bufSize - 1) div bufSize
 
+    checkEqual(received, payload)
     check:
-      received.len == payloadSize
-      received == payload
       reads >= minReads
       stream.isEof
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -184,7 +184,7 @@ suite "lifecycle":
 
     let outgoingStream = await peers.outgoing.openStream()
     # 16 MB exceeds the send window, so the write parks with a pending write task
-    let writing = outgoingStream.write(newData(16 * 1024 * 1024, 0x7A'u8))
+    let writing = outgoingStream.write(makeData(16 * 1024 * 1024))
 
     check outgoingStream.toWrite.isSome
 


### PR DESCRIPTION
Adds two connection-level test scenarios to `test_connection.nim` plus the helpers they need.

- **Server-initiated streams.** New `runServerInitiatedStreamTest` and the "server initiated stream reaches client incomingStream" case. The accepting (server) side calls `openStream` and the dialing (client) side receives it through `incomingStream`. This drives the server-initiated (odd stream id) parity in `onNewStream` that the rest of the suite never reaches. Every existing test opens streams from the client, so the `isOutgoing`/stream-id classification never ran with the roles reversed.
- **Chunked reads across buffer sizes.** New `runChunkedReadTest` and the "reads reassemble payloads across buffer sizes" case. It runs `readOnce` over a range of buffer and payload sizes, from one byte at a time up to 64 KiB, and checks the payload reassembles exactly, no single read exceeds the buffer, and EOF lands where expected.
- **Helpers.** `tests/helpers/stream.nim` adds `patternData` (deterministic byte pattern) and `readAllChunked` (drains a stream with a fixed buffer, returns the data plus the read count).