### PR TITLE
 test: lifecycle guards and stream peer-reset behavior

### DIFF
--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -7,8 +7,9 @@ import std/sets
 import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import lsquic/[datagram]
-import lsquic/context/[client, context, io]
+import lsquic/context/[client, context, io, stream]
 import ./helpers/[address, certificate, clientserver, stream]
+from lsquic/lsquic_ffi import lsquic_stream_ctx_t
 
 initializeLsquic(true, true)
 
@@ -374,3 +375,46 @@ suite "lifecycle":
     ctx.destroy()
     ctx.receive(Datagram(data: @[4'u8, 5, 6]), local, remote)
     ctx.processWhenReady()
+
+  asyncTest "peer reset in both directions merges to read-write":
+    let stream = Stream.new()
+
+    onReset(nil, cast[ptr lsquic_stream_ctx_t](stream), 0.cint)
+    check:
+      stream.resetHow == ResetRead
+      stream.readResetByPeer()
+      not stream.writeResetByPeer()
+      not stream.closeWrite
+
+    onReset(nil, cast[ptr lsquic_stream_ctx_t](stream), 1.cint)
+    check:
+      stream.resetHow == ResetReadWrite
+      stream.readResetByPeer()
+      stream.writeResetByPeer()
+      stream.closeWrite
+
+  asyncTest "peer read reset fails a parked read":
+    let stream = Stream.new()
+    var buf = newSeq[byte](8)
+    let doneFut =
+      Future[int].Raising([CancelledError, StreamError]).init("test parked read")
+    stream.toRead =
+      Opt.some(ReadTask(data: buf[0].addr, dataLen: buf.len, doneFut: doneFut))
+
+    onReset(nil, cast[ptr lsquic_stream_ctx_t](stream), 0.cint)
+
+    check:
+      stream.resetHow == ResetRead
+      stream.toRead.isNone()
+
+    expect StreamResetError:
+      discard await doneFut
+
+  asyncTest "read after read reset raises":
+    let stream = Stream.new()
+    stream.markResetByPeer(ResetRead)
+    check stream.resetHow == ResetRead
+
+    var buf = newSeq[byte](8)
+    expect StreamResetError:
+      discard await stream.readOnce(buf)

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -9,7 +9,7 @@ import lsquic
 import lsquic/[datagram]
 import lsquic/context/[client, context, io, stream]
 import ./helpers/[address, certificate, clientserver, stream]
-from lsquic/lsquic_ffi import lsquic_stream_ctx_t
+from lsquic/lsquic_ffi import lsquic_stream_ctx_t, lsquic_conn_t
 
 initializeLsquic(true, true)
 
@@ -375,6 +375,55 @@ suite "lifecycle":
     ctx.destroy()
     ctx.receive(Datagram(data: @[4'u8, 5, 6]), local, remote)
     ctx.processWhenReady()
+
+  asyncTest "connection operations are guarded after context stops":
+    let ctx = ClientContext.new(makeTLSConfig()).valueOr:
+      raiseAssert error
+    defer:
+      ctx.destroy()
+
+    # A stopped context must not act on any connection. We prove that by using an invalid connection pointer
+    # While the context is stopped, the calls below must skip it, so the pointer is never used.
+    # If a call went through, it would dereference the pointer and crash.
+    # The pointer has to be non-nil: these calls already skip a nil connection.
+    let quicConn = QuicConnection(lsquicConn: cast[ptr lsquic_conn_t](0xF00D))
+
+    check ctx.isRunning()
+    ctx.stop()
+    check not ctx.isRunning()
+
+    # While stopped, close and abort must do nothing (never reach the connection).
+    ctx.close(quicConn)
+    ctx.abort(quicConn)
+
+    # While stopped, makeStream must fail cleanly instead of opening a stream.
+    expect ConnectionClosedError:
+      ctx.makeStream(quicConn)
+
+  asyncTest "context destroy is idempotent":
+    let ctx = ClientContext.new(makeTLSConfig()).valueOr:
+      raiseAssert error
+
+    ctx.stop()
+    ctx.destroy()
+    check not ctx.isRunning()
+
+    # second destroy is a safe no-op: it must not free the engine or SSL_CTX twice.
+    ctx.destroy()
+    check not ctx.isRunning()
+
+  asyncTest "listen-capable endpoint requires a certificate":
+    # QuicEndpoint.new rejects a listen-capable endpoint with no certificate,
+    # before any socket or context is created.
+    expect QuicConfigError:
+      discard QuicEndpoint.new(TLSConfig.new(), AutoAddressIP4, {CanListen})
+
+  asyncTest "endpoint stop is idempotent":
+    let endpoint = makeEndpoint(AutoAddressIP4)
+
+    await endpoint.stop()
+    # second stop is a safe no-op: the socket is not closed twice.
+    await endpoint.stop()
 
   asyncTest "peer reset in both directions merges to read-write":
     let stream = Stream.new()


### PR DESCRIPTION
Adds test coverage to `tests/test_lifecycle.nim` for lifecycle edge cases and stream reset handling.

- A stopped context must not act on any connection. The test stops the context, then calls `close`, `abort`, and `makeStream` with a invalid non-nil connection pointer. If any call reached the connection it would dereference the pointer and crash, so the guards are what keep it alive. `makeStream` is expected to raise `ConnectionClosedError`.
- `destroy` is idempotent. Calling it a second time is a no-op and must not free the engine or SSL_CTX twice.
- `QuicEndpoint.new` rejects a listen-capable endpoint (`{CanListen}`) with no certificate and raises `QuicConfigError`, before any socket or context is created.
- `stop` is idempotent. A second `stop` must not close the socket twice.
- A peer reset in both directions merges into `ResetReadWrite` and flips the matching read/write reset flags.
- A peer read reset fails a parked read. The waiting future resolves with `StreamResetError`.
- Reading after a peer read reset raises `StreamResetError`.