### PR TITLE
fix: avoid copying inbound UDP datagrams

### DIFF
--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -5,7 +5,7 @@ import chronos
 import chronos/osdefs
 import ./context
 import ../[lsquic_ffi, datagram]
-import ../helpers/[openarray, sequninit, transportaddr]
+import ../helpers/[sequninit, transportaddr]
 import std/[nativesockets, net]
 
 when not defined(windows):
@@ -56,11 +56,12 @@ proc prepareDestAddr(
 
 proc receive*(
     ctx: QuicContext,
-    datagram: sink Datagram,
+    data: openArray[byte],
     local: TransportAddress,
     remote: TransportAddress,
+    ecn: cint = 0,
 ) =
-  if datagram.len == 0 or not ctx.isRunning():
+  if data.len == 0 or not ctx.isRunning():
     return
 
   var
@@ -74,15 +75,23 @@ proc receive*(
 
   discard lsquic_engine_packet_in(
     ctx.engine,
-    datagram.data.toPtr,
-    datagram.data.len.csize_t,
+    cast[ptr uint8](addr data[0]),
+    data.len.csize_t,
     cast[ptr SockAddr](addr localAddress),
     cast[ptr SockAddr](addr remoteAddress),
     cast[pointer](ctx),
-    datagram.ecn,
+    ecn,
   )
 
   ctx.processWhenReady()
+
+proc receive*(
+    ctx: QuicContext,
+    datagram: sink Datagram,
+    local: TransportAddress,
+    remote: TransportAddress,
+) =
+  ctx.receive(datagram.data, local, remote, datagram.ecn)
 
 proc sendPacketsOut*(
     ctx: pointer, specs: ptr struct_lsquic_out_spec, nspecs: cuint

--- a/lsquic/context/stream.nim
+++ b/lsquic/context/stream.nim
@@ -10,9 +10,9 @@ import ../helpers/sequninit
 proc onReset*(
     stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t, how: cint
 ) {.cdecl.} =
-  debug "Stream reset", how
+  trace "Stream reset", how
   if ctx.isNil:
-    debug "stream_ctx is nil onReset"
+    trace "stream_ctx is nil onReset"
     return
 
   let streamCtx = cast[Stream](ctx)
@@ -33,9 +33,9 @@ proc onReset*(
     streamCtx.abortPendingWrites(streamCtx.newStreamResetError("stream write"))
 
 proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.} =
-  debug "Stream closed"
+  trace "Stream closed"
   if ctx.isNil:
-    debug "stream_ctx is nil onClose"
+    trace "stream_ctx is nil onClose"
     return
 
   let streamCtx = cast[Stream](ctx)
@@ -66,14 +66,14 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
 proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.} =
   trace "stream read"
   if ctx.isNil:
-    debug "stream_ctx is nil onRead"
+    trace "stream_ctx is nil onRead"
     return
 
   let streamCtx = cast[Stream](ctx)
 
   let task = streamCtx.toRead.valueOr:
     if lsquic_stream_wantread(stream, 0) == -1:
-      error "could not set stream wantread", streamId = lsquic_stream_id(stream)
+      trace "could not set stream wantread", streamId = lsquic_stream_id(stream)
       streamCtx.abort()
     return
 
@@ -89,20 +89,20 @@ proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.
       streamCtx.failPendingRead(streamCtx.newStreamResetError("stream read"))
       return
     else:
-      error "could not read", streamId = lsquic_stream_id(stream), errno = errno
+      trace "could not read", streamId = lsquic_stream_id(stream), errno = errno
       streamCtx.abort()
       return
 
   if n == 0:
     streamCtx.isEof = true
     if not streamCtx.closeIfDone():
-      error "could not close stream after EOF", streamId = lsquic_stream_id(stream)
+      trace "could not close stream after EOF", streamId = lsquic_stream_id(stream)
       streamCtx.failPendingRead(newException(StreamError, "could not close the stream"))
       streamCtx.abort()
       return
 
   if lsquic_stream_wantread(stream, 0) == -1:
-    error "could not set stream wantread", streamId = lsquic_stream_id(stream)
+    trace "could not set stream wantread", streamId = lsquic_stream_id(stream)
     streamCtx.abort()
 
   task.doneFut.complete(int(n))
@@ -113,14 +113,14 @@ proc onWrite*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
   trace "onWrite"
 
   if ctx.isNil:
-    debug "stream_ctx is nil onWrite"
+    trace "stream_ctx is nil onWrite"
     return
 
   let streamCtx = cast[Stream](ctx)
 
   var w = streamCtx.toWrite.valueOr:
     if lsquic_stream_wantwrite(stream, 0) == -1:
-      error "could not set stream wantwrite", streamId = lsquic_stream_id(stream)
+      trace "could not set stream wantwrite", streamId = lsquic_stream_id(stream)
       streamCtx.abort()
     return
 
@@ -157,5 +157,5 @@ proc onWrite*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
   streamCtx.toWrite = Opt.none(WriteTask)
 
   if lsquic_stream_wantwrite(stream, 0) == -1:
-    error "could not set stream wantwrite", streamId = lsquic_stream_id(stream)
+    trace "could not set stream wantwrite", streamId = lsquic_stream_id(stream)
     streamCtx.abort()

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -3,10 +3,7 @@
 
 import chronos, chronicles, results
 import
-  ./[
-    errors, connection, tlsconfig, datagram, connectionmanager, lsquic_ffi,
-    certificateverifier,
-  ]
+  ./[errors, connection, tlsconfig, connectionmanager, lsquic_ffi, certificateverifier]
 import ./context/[server, client, context, io]
 
 type
@@ -53,7 +50,7 @@ proc scidLen(endpoint: QuicEndpoint): cuint {.raises: [].} =
   LSQUIC_DF_SCID_LEN.cuint
 
 proc packetDcid(
-    endpoint: QuicEndpoint, packet: seq[byte], cid: var CidKey
+    endpoint: QuicEndpoint, packet: openArray[byte], cid: var CidKey
 ): bool {.raises: [].} =
   if packet.len == 0:
     return false
@@ -74,13 +71,13 @@ proc packetDcid(
     cid.bytes[i] = packet[start + i]
   true
 
-func isIetfInitial(packet: seq[byte]): bool {.raises: [].} =
+func isIetfInitial(packet: openArray[byte]): bool {.raises: [].} =
   if packet.len == 0:
     return false
   (packet[0] and 0xC0'u8) == 0xC0'u8 and (packet[0] and 0x30'u8) == 0
 
 proc receiveDatagram(
-    endpoint: QuicEndpoint, data: seq[byte], local, remote: TransportAddress
+    endpoint: QuicEndpoint, data: openArray[byte], local, remote: TransportAddress
 ) {.raises: [].} =
   if endpoint.isNil or endpoint.stopped:
     return
@@ -93,26 +90,26 @@ proc receiveDatagram(
   if endpoint.packetDcid(data, cid):
     if hasClientContext and endpoint.clientContext.ownsCid(cid):
       trace "Routing datagram to client context", cid
-      endpoint.clientContext.receive(Datagram(data: data), local, remote)
+      endpoint.clientContext.receive(data, local, remote)
       return
 
     if hasServerContext and endpoint.serverContext.ownsCid(cid):
       trace "Routing datagram to server context", cid
-      endpoint.serverContext.receive(Datagram(data: data), local, remote)
+      endpoint.serverContext.receive(data, local, remote)
       return
 
   if hasClientContext and not hasServerContext:
-    endpoint.clientContext.receive(Datagram(data: data), local, remote)
+    endpoint.clientContext.receive(data, local, remote)
     return
 
   if hasServerContext and not hasClientContext:
-    endpoint.serverContext.receive(Datagram(data: data), local, remote)
+    endpoint.serverContext.receive(data, local, remote)
     return
 
   if hasServerContext and data.isIetfInitial():
     trace "Routing initial datagram with unknown CID to server context",
       bytes = data.len, local, remote
-    endpoint.serverContext.receive(Datagram(data: data), local, remote)
+    endpoint.serverContext.receive(data, local, remote)
     return
 
   trace "Dropping datagram with unknown CID", bytes = data.len, local, remote
@@ -121,7 +118,14 @@ proc receiveFromUdp(
     endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress
 ) {.raises: [].} =
   try:
-    endpoint.receiveDatagram(udp.getMessage(), udp.localAddress(), remote)
+    var
+      msg: seq[byte]
+      msgLen: int
+    udp.peekMessage(msg, msgLen)
+    if msgLen > 0:
+      endpoint.receiveDatagram(
+        msg.toOpenArray(0, msgLen - 1), udp.localAddress(), remote
+      )
   except TransportError as e:
     warn "Could not read received datagram", errorMsg = e.msg
 


### PR DESCRIPTION
Avoid allocating a fresh `seq[byte]` for each inbound QUIC UDP datagram.

The endpoint receive path now peeks Chronos' datagram buffer, keeps the received `msgLen` bounds, and passes a borrowed byte view through routing into `lsquic_engine_packet_in`. The existing `Datagram` receive API is preserved as a wrapper for callers that already provide owned data.

This also lowers stream callback log verbosity from `debug`/`error` to `trace`.

- Fixes https://github.com/vacp2p/nim-lsquic/issues/107