### PR TITLE
feat: configure UDP receive buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The snippet expects `cert.pem` and `key.pem` in PEM format and embeds them at co
 - Server-side `TLSConfig` must include both a certificate and a private key.
 - Client and server ALPN values must match or the handshake will fail.
 - `Connection.close()` and `Stream.close()` perform a graceful shutdown. `abort()` is the hard-stop path.
+- UDP sockets request an 8 MiB receive buffer by default. Pass `QuicSocketConfig(receiveBufferBytes: 0)` to keep the OS default, or set another byte value; Linux may cap the effective size at `net.core.rmem_max`.
 
 For more complete usage patterns, see:
 

--- a/lsquic.nim
+++ b/lsquic.nim
@@ -4,9 +4,9 @@
 import
   ./lsquic/[
     errors, endpoint, client, server, connection, stream, lsquic, tlsconfig,
-    certificateverifier,
+    certificateverifier, socketconfig,
   ]
 
 export
   errors, endpoint, client, server, connection, stream, lsquic, tlsconfig,
-  certificateverifier
+  certificateverifier, socketconfig

--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -2,15 +2,20 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import chronos
-import ./[errors, connection, tlsconfig, endpoint, certificateverifier]
+import ./[errors, connection, tlsconfig, endpoint, certificateverifier, socketconfig]
 
 type QuicClient* = ref object of RootObj
   tlsConfig: TLSConfig
+  socketConfig: QuicSocketConfig
   ip4Endpoint: QuicEndpoint
   ip6Endpoint: QuicEndpoint
 
-proc new*(t: typedesc[QuicClient], tlsConfig: TLSConfig): QuicClient {.raises: [].} =
-  QuicClient(tlsConfig: tlsConfig)
+proc new*(
+    t: typedesc[QuicClient],
+    tlsConfig: TLSConfig,
+    socketConfig: QuicSocketConfig = DefaultQuicSocketConfig,
+): QuicClient {.raises: [].} =
+  QuicClient(tlsConfig: tlsConfig, socketConfig: socketConfig)
 
 proc getEndpoint(
     self: QuicClient, family: AddressFamily
@@ -18,12 +23,12 @@ proc getEndpoint(
   case family
   of AddressFamily.IPv4:
     if self.ip4Endpoint.isNil:
-      self.ip4Endpoint = QuicEndpoint.new(self.tlsConfig, family)
+      self.ip4Endpoint = QuicEndpoint.new(self.tlsConfig, family, self.socketConfig)
 
     return self.ip4Endpoint
   of AddressFamily.IPv6:
     if self.ip6Endpoint.isNil:
-      self.ip6Endpoint = QuicEndpoint.new(self.tlsConfig, family)
+      self.ip6Endpoint = QuicEndpoint.new(self.tlsConfig, family, self.socketConfig)
 
     return self.ip6Endpoint
   else:

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -2,8 +2,15 @@
 # Copyright (c) Status Research & Development GmbH
 
 import chronos, chronicles, results
+when defined(windows):
+  from chronos/osdefs import SOL_SOCKET, SO_RCVBUF
+else:
+  from posix import SOL_SOCKET, SO_RCVBUF
 import
-  ./[errors, connection, tlsconfig, connectionmanager, lsquic_ffi, certificateverifier]
+  ./[
+    errors, connection, tlsconfig, connectionmanager, lsquic_ffi, certificateverifier,
+    socketconfig,
+  ]
 import ./context/[server, client, context, io]
 
 type
@@ -23,6 +30,40 @@ type
     stopped: bool
 
 const CloseWait: Duration = 300.milliseconds
+
+proc socketReceiveBufferBytes(
+    udp: DatagramTransport
+): int {.raises: [TransportOsError].} =
+  let value = getSockOpt2(udp.fd, int(SOL_SOCKET), int(SO_RCVBUF)).valueOr:
+    raiseTransportOsError(error)
+    return
+  value.int
+
+proc configureReceiveBuffer(
+    udp: DatagramTransport, socketConfig: QuicSocketConfig
+) {.raises: [TransportOsError].} =
+  let requested = socketConfig.receiveBufferBytes
+  if requested == 0:
+    # Zero keeps the OS default socket buffer.
+    return
+
+  let setRes = setSockOpt2(udp.fd, int(SOL_SOCKET), int(SO_RCVBUF), requested)
+  if setRes.isErr():
+    raiseTransportOsError(setRes.error())
+
+  let effective = udp.socketReceiveBufferBytes()
+  if effective < requested:
+    when defined(linux):
+      warn "QUIC UDP receive buffer capped below requested size",
+        requestedBytes = requested,
+        effectiveBytes = effective,
+        hint = "raise net.core.rmem_max if Linux caps SO_RCVBUF"
+    else:
+      warn "QUIC UDP receive buffer capped below requested size",
+        requestedBytes = requested, effectiveBytes = effective
+  else:
+    debug "Configured QUIC UDP receive buffer",
+      requestedBytes = requested, effectiveBytes = effective
 
 proc createServerContext(
     tlsConfig: TLSConfig, fd: cint
@@ -130,50 +171,61 @@ proc receiveFromUdp(
     warn "Could not read received datagram", errorMsg = e.msg
 
 proc createUdp(
-    endpoint: QuicEndpoint, address: TransportAddress
+    endpoint: QuicEndpoint, address: TransportAddress, socketConfig: QuicSocketConfig
 ): DatagramTransport {.raises: [QuicError, TransportOsError].} =
   proc onReceive(
       udp: DatagramTransport, remote: TransportAddress
   ) {.async: (raises: []).} =
     endpoint.receiveFromUdp(udp, remote)
 
-  case address.family
-  of AddressFamily.IPv4:
-    newDatagramTransport(onReceive, local = address)
-  of AddressFamily.IPv6:
-    newDatagramTransport6(onReceive, local = address)
-  else:
-    raise newException(QuicError, "only IPv4/IPv6 address is supported")
+  let udp =
+    case address.family
+    of AddressFamily.IPv4:
+      newDatagramTransport(onReceive, local = address)
+    of AddressFamily.IPv6:
+      newDatagramTransport6(onReceive, local = address)
+    else:
+      raise newException(QuicError, "only IPv4/IPv6 address is supported")
+
+  udp.configureReceiveBuffer(socketConfig)
+  udp
 
 proc createUdp(
-    endpoint: QuicEndpoint, family: AddressFamily
+    endpoint: QuicEndpoint, family: AddressFamily, socketConfig: QuicSocketConfig
 ): DatagramTransport {.raises: [QuicError, TransportOsError].} =
   proc onReceive(
       udp: DatagramTransport, remote: TransportAddress
   ) {.async: (raises: []).} =
     endpoint.receiveFromUdp(udp, remote)
 
-  case family
-  of AddressFamily.IPv4:
-    newDatagramTransport(onReceive)
-  of AddressFamily.IPv6:
-    newDatagramTransport6(onReceive)
-  else:
-    raise newException(QuicError, "endpoint supports only IPv4/IPv6 address")
+  let udp =
+    case family
+    of AddressFamily.IPv4:
+      newDatagramTransport(onReceive)
+    of AddressFamily.IPv6:
+      newDatagramTransport6(onReceive)
+    else:
+      raise newException(QuicError, "endpoint supports only IPv4/IPv6 address")
+
+  udp.configureReceiveBuffer(socketConfig)
+  udp
 
 proc new*(
     _: type QuicEndpoint,
     tlsConfig: TLSConfig,
     address: TransportAddress,
     capabilities: QuicEndpointCapabilities = {CanListen, CanDial},
+    socketConfig: QuicSocketConfig = DefaultQuicSocketConfig,
 ): QuicEndpoint {.raises: [QuicConfigError, QuicError, TransportOsError].} =
   if CanListen in capabilities and tlsConfig.certificate.len == 0:
     raise newException(QuicConfigError, "tlsConfig does not contain a certificate")
 
+  socketConfig.validate()
+
   var endpoint = QuicEndpoint(
     tlsConfig: tlsConfig, capabilities: capabilities, connman: ConnectionManager.new()
   )
-  endpoint.udp = endpoint.createUdp(address)
+  endpoint.udp = endpoint.createUdp(address, socketConfig)
 
   var initialized = false
 
@@ -193,12 +245,17 @@ proc new*(
   endpoint
 
 proc new*(
-    _: type QuicEndpoint, tlsConfig: TLSConfig, family: AddressFamily
+    _: type QuicEndpoint,
+    tlsConfig: TLSConfig,
+    family: AddressFamily,
+    socketConfig: QuicSocketConfig = DefaultQuicSocketConfig,
 ): QuicEndpoint {.raises: [QuicError, TransportOsError].} =
+  socketConfig.validate()
+
   var endpoint = QuicEndpoint(
     tlsConfig: tlsConfig, capabilities: {CanDial}, connman: ConnectionManager.new()
   )
-  endpoint.udp = endpoint.createUdp(family)
+  endpoint.udp = endpoint.createUdp(family, socketConfig)
   endpoint
 
 proc ensureClientContext(

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -2,35 +2,51 @@
 # Copyright (c) Status Research & Development GmbH 
 
 import chronos, results
-import ./[errors, connection, tlsconfig, endpoint, certificateverifier]
+import ./[errors, connection, tlsconfig, endpoint, certificateverifier, socketconfig]
 
 type
   QuicServer* = ref object of RootObj
     tlsConfig: TLSConfig
+    socketConfig: QuicSocketConfig
 
   Listener* = ref object of RootObj
     endpoint: QuicEndpoint
 
 proc new*(
-    t: typedesc[QuicServer], tlsConfig: TLSConfig
+    t: typedesc[QuicServer],
+    tlsConfig: TLSConfig,
+    socketConfig: QuicSocketConfig = DefaultQuicSocketConfig,
 ): QuicServer {.raises: [QuicConfigError].} =
   if tlsConfig.certificate.len == 0:
     raise newException(QuicConfigError, "tlsConfig does not contain a certificate")
-
-  return QuicServer(tlsConfig: tlsConfig)
+  socketConfig.validate()
+  return QuicServer(tlsConfig: tlsConfig, socketConfig: socketConfig)
 
 proc newListener*(
-    tlsConfig: TLSConfig, address: TransportAddress
+    tlsConfig: TLSConfig,
+    address: TransportAddress,
+    socketConfig: QuicSocketConfig = DefaultQuicSocketConfig,
 ): Result[Listener, string] =
   try:
-    ok(Listener(endpoint: QuicEndpoint.new(tlsConfig, address, {CanListen, CanDial})))
+    ok(
+      Listener(
+        endpoint:
+          QuicEndpoint.new(tlsConfig, address, {CanListen, CanDial}, socketConfig)
+      )
+    )
   except QuicConfigError, QuicError, TransportOsError:
     err(getCurrentExceptionMsg())
 
 proc listen*(
     self: QuicServer, address: TransportAddress
-): Listener {.raises: [QuicError, TransportOsError].} =
-  newListener(self.tlsConfig, address).valueOr:
+): Listener {.raises: [QuicError].} =
+  newListener(self.tlsConfig, address, self.socketConfig).valueOr:
+    raise newException(QuicError, error)
+
+proc listen*(
+    self: QuicServer, address: TransportAddress, socketConfig: QuicSocketConfig
+): Listener {.raises: [QuicError].} =
+  newListener(self.tlsConfig, address, socketConfig).valueOr:
     raise newException(QuicError, error)
 
 proc accept*(

--- a/lsquic/socketconfig.nim
+++ b/lsquic/socketconfig.nim
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import ./errors
+
+type QuicSocketConfig* = object
+  receiveBufferBytes*: int
+
+const
+  DefaultQuicReceiveBufferBytes* = 8 * 1024 * 1024
+  DefaultQuicSocketConfig* =
+    QuicSocketConfig(receiveBufferBytes: DefaultQuicReceiveBufferBytes)
+
+proc validate*(config: QuicSocketConfig) {.raises: [QuicConfigError].} =
+  if config.receiveBufferBytes < 0:
+    raise
+      newException(QuicConfigError, "socket receive buffer size must be non-negative")

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -3,9 +3,21 @@
 
 {.used.}
 
-import chronos, chronos/unittest2/asynctests
+import chronos, chronos/unittest2/asynctests, results
+when defined(windows):
+  from chronos/osdefs import SOL_SOCKET, SO_RCVBUF
+else:
+  from posix import SOL_SOCKET, SO_RCVBUF
 import lsquic
 import ./helpers/[address, clientserver]
+
+proc socketReceiveBufferBytes(
+    udp: DatagramTransport
+): int {.raises: [TransportOsError].} =
+  let res = getSockOpt2(udp.fd, int(SOL_SOCKET), int(SO_RCVBUF))
+  if res.isErr():
+    raiseTransportOsError(res.error())
+  int(res.get())
 
 suite "runtime":
   asyncTest "init and cleanup are repeatable and leave a usable global":
@@ -34,3 +46,59 @@ suite "runtime":
     cleanupLsquic()
     initializeLsquic(client = false, server = true)
     cleanupLsquic()
+
+  asyncTest "default socket config creates endpoint with receive buffer":
+    cleanupLsquic()
+    initializeLsquic(true, true)
+    let endpoint = QuicEndpoint.new(makeTLSConfig(), AutoAddressIP4)
+    defer:
+      await endpoint.stop()
+      cleanupLsquic()
+
+    check endpoint.datagramTransport().socketReceiveBufferBytes() > 0
+
+  asyncTest "socket receive buffer can be disabled":
+    cleanupLsquic()
+    initializeLsquic(true, true)
+    let endpoint = QuicEndpoint.new(
+      makeTLSConfig(),
+      AutoAddressIP4,
+      {CanListen, CanDial},
+      QuicSocketConfig(receiveBufferBytes: 0),
+    )
+    defer:
+      await endpoint.stop()
+      cleanupLsquic()
+
+    check endpoint.datagramTransport().socketReceiveBufferBytes() > 0
+
+  asyncTest "socket receive buffer setting is readable":
+    cleanupLsquic()
+    initializeLsquic(true, true)
+    const requested = 64 * 1024
+    let endpoint = QuicEndpoint.new(
+      makeTLSConfig(),
+      AutoAddressIP4,
+      {CanListen, CanDial},
+      QuicSocketConfig(receiveBufferBytes: requested),
+    )
+    defer:
+      await endpoint.stop()
+      cleanupLsquic()
+
+    check endpoint.datagramTransport().socketReceiveBufferBytes() >= requested
+
+  test "negative socket receive buffer is rejected":
+    expect QuicConfigError:
+      discard QuicEndpoint.new(
+        makeTLSConfig(),
+        AutoAddressIP4,
+        {CanListen, CanDial},
+        QuicSocketConfig(receiveBufferBytes: -1),
+      )
+
+  test "negative server socket receive buffer is rejected":
+    expect QuicConfigError:
+      discard QuicServer.new(
+        makeTLSConfig(), QuicSocketConfig(receiveBufferBytes: -1)
+      )

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -99,6 +99,4 @@ suite "runtime":
 
   test "negative server socket receive buffer is rejected":
     expect QuicConfigError:
-      discard QuicServer.new(
-        makeTLSConfig(), QuicSocketConfig(receiveBufferBytes: -1)
-      )
+      discard QuicServer.new(makeTLSConfig(), QuicSocketConfig(receiveBufferBytes: -1))


### PR DESCRIPTION
Adds socket receive-buffer configuration for QUIC UDP transports.

By default, nim-lsquic now requests an 8 MiB UDP receive buffer for each QUIC socket. Callers can override the requested size with `QuicSocketConfig`, or pass `receiveBufferBytes: 0` to keep the OS default.

This helps avoid kernel-level UDP drops when incoming QUIC traffic bursts exceed small Linux defaults such as `net.core.rmem_default = 212992`.

Existing call sites keep working with the new default receive-buffer behavior.

Users that want the previous OS-default behavior can pass:

```nim
QuicSocketConfig(receiveBufferBytes: 0)
```

Linux may cap the effective socket buffer below the requested value depending on `net.core.rmem_max`; nim-lsquic logs a warning when that happens.

Part of fixes for https://github.com/vacp2p/nim-lsquic/issues/108

cc: @tersec 