### PR TITLE
test: certificate verifier and TLS config

### DIFF
--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -117,17 +117,19 @@ suite "tls config":
     # copy of the i2d buffer.
     let cert = testCertificate().toX509().valueOr:
         raiseAssert "test certificate must parse: " & error
+    defer:
+      X509_free(cert)
+
     let der = cert.x509toDERBytes().valueOr:
       raiseAssert "test certificate must convert to DER"
 
     var readPos = cast[ptr uint8](unsafeAddr der[0])
     let reparsed = d2i_X509(nil, addr readPos, der.len.clong)
+    defer:
+      X509_free(reparsed)
 
     # a rejected encoding leaves reparsed nil, which converts back to Opt.none
     check reparsed.x509toDERBytes() == Opt.some(der)
-
-    X509_free(reparsed)
-    X509_free(cert)
 
   test "nil x509 DER conversion is rejected":
     let cert: ptr X509 = nil

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import std/sets
+import std/[sets, strutils]
 import results
 import unittest2
 import boringssl
@@ -11,6 +11,33 @@ import lsquic
 import lsquic/certificates
 import lsquic/lsquic_ffi
 import ./helpers/certificate
+
+proc decodeAlpnWire(wire: string): HashSet[string] =
+  ## Reverses the ALPN encoding that TLSConfig.new applies, so a test can check
+  ## which protocol names ended up on the wire.
+  ##
+  ## Each name is stored as one byte holding its length followed by the name
+  ## itself, and those pairs are concatenated:
+  ##
+  ##   {"test", "quic-echo"}  ->  "\x04test" & "\x09quic-echo"
+  ##
+  ## A length byte that points past the end of the buffer means the encoding is
+  ## broken, so decoding stops there and the caller gets the names read so far.
+  var decoded = initHashSet[string]()
+  var i = 0
+  while i < wire.len:
+    let length = wire[i].byte.int
+    if i + 1 + length > wire.len:
+      return decoded
+    decoded.incl(wire[i + 1 ..< i + 1 + length])
+    i += 1 + length
+  decoded
+
+proc makeAlpnSet(protocols: varargs[string]): HashSet[string] =
+  var alpn = initHashSet[string]()
+  for protocol in protocols:
+    alpn.incl(protocol)
+  alpn
 
 suite "tls config":
   test "certificate requires key":
@@ -31,6 +58,44 @@ suite "tls config":
 
     check cfg.alpnWire == "\x04test"
 
+  test "every alpn value gets its own length prefix":
+    let alpn = makeAlpnSet("test", "quic-echo")
+
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), alpn)
+
+    # alpn is a HashSet, so the encoder has no order to preserve: decode the
+    # wire form back instead of pinning a byte string.
+    check:
+      cfg.alpnWire.len == (1 + "test".len) + (1 + "quic-echo".len)
+      cfg.alpnWire.decodeAlpnWire() == alpn
+
+  test "alpn value of 255 bytes still encodes":
+    let protocol = repeat('a', 255)
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpnSet(protocol))
+
+    check:
+      cfg.alpnWire.len == 256
+      cfg.alpnWire[0].byte.int == 255
+      cfg.alpnWire.decodeAlpnWire() == makeAlpnSet(protocol)
+
+  test "alpn value over 255 bytes is not encodable":
+    # TODO: vacp2p/nim-lsquic#113
+    # TLSConfig.new does not validate the protocol length, so chr(len) trips the range check
+    # and a RangeDefect escapes an API that reports every other misconfiguration as a QuicConfigError.
+    let alpn = makeAlpnSet(repeat('a', 256))
+
+    expect RangeDefect:
+      discard TLSConfig.new(testCertificate(), testPrivateKey(), alpn)
+
+  test "empty alpn value encodes to a zero length entry":
+    # TODO: vacp2p/nim-lsquic#113
+    # RFC 7301 forbids an empty protocol name, but TLSConfig.new emits one and
+    # reports nothing. BoringSSL rejects the buffer later, at dial time, where it
+    # surfaces as AssertionDefect instead of a QuicConfigError.
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpnSet(""))
+
+    check cfg.alpnWire == "\x00"
+
   test "valid pem certificate parses":
     let parsed = testCertificate().toX509()
 
@@ -42,6 +107,24 @@ suite "tls config":
       check cert.x509toDERBytes().isSome()
     if not cert.isNil:
       X509_free(cert)
+
+  test "der bytes round trip back to the same certificate":
+    # Peers receive these bytes through certificates() and parse them back, so
+    # they have to be a complete DER encoding, not a truncated or over-sized
+    # copy of the i2d buffer.
+    let cert = testCertificate().toX509().valueOr:
+        raiseAssert "test certificate must parse: " & error
+    let der = cert.x509toDERBytes().valueOr:
+      raiseAssert "test certificate must convert to DER"
+
+    var readPos = cast[ptr uint8](unsafeAddr der[0])
+    let reparsed = d2i_X509(nil, addr readPos, der.len.clong)
+
+    # a rejected encoding leaves reparsed nil, which converts back to Opt.none
+    check reparsed.x509toDERBytes() == Opt.some(der)
+
+    X509_free(reparsed)
+    X509_free(cert)
 
   test "nil x509 DER conversion is rejected":
     let cert: ptr X509 = nil

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -64,6 +64,28 @@ proc makeClientWithoutVerifier(): QuicClient {.raises: [QuicConfigError].} =
   )
 
 suite "certificate verifier":
+  test "base verifier requires an override":
+    # Guard for a subtype that forgets to implement verify: it must raise
+    # rather than silently accept or reject a peer.
+    let verifier = CertificateVerifier()
+
+    expect AssertionDefect:
+      discard verifier.verify("example.com", @[])
+
+  test "custom verifier requires a callback":
+    let verifier = CustomCertificateVerifier.init(nil)
+
+    expect AssertionDefect:
+      discard verifier.verify("example.com", @[])
+
+  test "insecure verifier accepts any input":
+    let verifier = InsecureCertificateVerifier.init()
+
+    check:
+      verifier.verify("example.com", @[testCertificate()])
+      # a server verifying a client that sent no certificate sees an empty chain
+      verifier.verify("", @[])
+
   asyncTest "accepting custom verifier allows handshake":
     let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
     let server = makeServer(CustomCertificateVerifier.init(acceptingCertificateCb))
@@ -151,6 +173,15 @@ suite "certificate verifier":
 
     expect QuicError:
       discard await client.dial(AutoAddressIP4)
+
+  asyncTest "nil per-dial verifier does not fall back to the default":
+    let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))
+    defer:
+      await client.stop()
+
+    let noVerifier: CertificateVerifier = nil
+    expect QuicError:
+      discard await client.dial(AutoAddressIP4, noVerifier)
 
   asyncTest "concurrent per-dial verifiers stay isolated":
     let client = makeClientWithoutVerifier()


### PR DESCRIPTION
Adds test coverage to `tests/test_verifier.nim` and `tests/test_tlsconfig.nim` for the certificate verifier hierarchy and for TLSConfig ALPN and DER encoding.

`tests/test_verifier.nim`:
- Base `CertificateVerifier.verify` raises when not overridden
- `CustomCertificateVerifier` with a nil callback raises
- `InsecureCertificateVerifier.verify` returns true for an empty server name and an empty chain
- `dial(address, certVerifier)` with a nil verifier raises `QuicError` and does not fall back to the default

`tests/test_tlsconfig.nim`:
- Every ALPN value gets its own length prefix
- A 255 byte ALPN value still encodes
- An ALPN value over 255 bytes raises `RangeDefect` (reproduction for #113)
- An empty ALPN value encodes to `\x00` (reproduction for #113)
- DER bytes round trip back to the same certificate