### PR TITLE
feat: add UDP GSO/USO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The snippet expects `cert.pem` and `key.pem` in PEM format and embeds them at co
 - Client and server ALPN values must match or the handshake will fail.
 - `Connection.close()` and `Stream.close()` perform a graceful shutdown. `abort()` is the hard-stop path.
 - UDP sockets request an 8 MiB receive buffer by default. Pass `QuicSocketConfig(receiveBufferBytes: 0)` to keep the OS default, or set another byte value; Linux may cap the effective size at `net.core.rmem_max`.
+- UDP segmentation offload (Linux GSO, kernel 4.18+; Windows USO, Windows 10 1803+) is enabled by default: outgoing packet batches are grouped per destination and handed to the kernel as single segmented datagrams, cutting per-packet syscall cost. Pass `QuicSocketConfig(segmentationOffload: false)` to opt out. When the socket or kernel lacks support the probe falls back to regular sends automatically, and a runtime send error (e.g. from an offload-hostile interface) permanently disables offload on that socket and resends unsegmented.
 
 For more complete usage patterns, see:
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The snippet expects `cert.pem` and `key.pem` in PEM format and embeds them at co
 - Client and server ALPN values must match or the handshake will fail.
 - `Connection.close()` and `Stream.close()` perform a graceful shutdown. `abort()` is the hard-stop path.
 - UDP sockets request an 8 MiB receive buffer by default. Pass `QuicSocketConfig(receiveBufferBytes: 0)` to keep the OS default, or set another byte value; Linux may cap the effective size at `net.core.rmem_max`.
-- UDP segmentation offload (Linux GSO, kernel 4.18+; Windows USO, Windows 10 1803+) is enabled by default: outgoing packet batches are grouped per destination and handed to the kernel as single segmented datagrams, cutting per-packet syscall cost. Pass `QuicSocketConfig(segmentationOffload: false)` to opt out. When the socket or kernel lacks support the probe falls back to regular sends automatically, and a runtime send error (e.g. from an offload-hostile interface) permanently disables offload on that socket and resends unsegmented.
+- UDP segmentation offload is on by default (Linux GSO on kernel 4.18 and later, Windows USO on Windows 10 1803 and later). The library gives each run of adjacent packets with the same destination to the kernel as one segmented datagram. This lowers the work the kernel does for each packet. It does not lower the number of system calls, because `sendmmsg` already sends many packets per call. To turn offload off, pass `QuicSocketConfig(segmentationOffload: false)`. If the socket or the kernel has no support, the probe fails and the library uses normal sends. A send error also disables offload for that socket, and the library sends those packets again without segmentation.
 
 For more complete usage patterns, see:
 

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -22,6 +22,12 @@ type
 
   LsquicCidArray = UncheckedArray[lsquic_cid_t]
 
+  SegmentationOffload* = ref object
+    ## UDP segmentation offload state for one socket. The server and client
+    ## contexts of an endpoint share a single cell, so a runtime disable
+    ## applies to the socket rather than to whichever context hit the error.
+    enabled: bool
+
   QuicContext* = ref object of RootObj
     settings*: struct_lsquic_engine_settings
     api*: struct_lsquic_engine_api
@@ -31,10 +37,20 @@ type
     tickTimeout*: Timeout
     sslCtx*: ptr SSL_CTX
     fd*: cint
-    gsoEnabled*: bool
+    gso*: SegmentationOffload
     processing: bool
     running*: bool
     ownedCids: HashSet[CidKey]
+
+proc newSegmentationOffload*(enabled: bool): SegmentationOffload {.raises: [].} =
+  SegmentationOffload(enabled: enabled)
+
+proc isEnabled*(gso: SegmentationOffload): bool {.raises: [].} =
+  not gso.isNil and gso.enabled
+
+proc disable*(gso: SegmentationOffload) {.raises: [].} =
+  if not gso.isNil:
+    gso.enabled = false
 
 func hash*(cid: CidKey): Hash =
   var h = hash(cid.len)

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -31,6 +31,7 @@ type
     tickTimeout*: Timeout
     sslCtx*: ptr SSL_CTX
     fd*: cint
+    gsoEnabled*: bool
     processing: bool
     running*: bool
     ownedCids: HashSet[CidKey]

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -24,9 +24,9 @@ type
 
   SegmentationOffload* = ref object
     ## UDP segmentation offload state for one socket. The server context and
-    ## the client context of an endpoint share one cell. A send error thus
-    ## disables offload for the socket, not for one context only.
-    enabled: bool
+    ## the client context of an endpoint share one cell, which is why this is a
+    ## ref: a send error disables offload for the socket, not for one context.
+    enabled*: bool
 
   QuicContext* = ref object of RootObj
     settings*: struct_lsquic_engine_settings
@@ -37,20 +37,10 @@ type
     tickTimeout*: Timeout
     sslCtx*: ptr SSL_CTX
     fd*: cint
-    gso*: SegmentationOffload
+    gso*: SegmentationOffload = SegmentationOffload()
     processing: bool
     running*: bool
     ownedCids: HashSet[CidKey]
-
-proc newSegmentationOffload*(enabled: bool): SegmentationOffload {.raises: [].} =
-  SegmentationOffload(enabled: enabled)
-
-proc isEnabled*(gso: SegmentationOffload): bool {.raises: [].} =
-  not gso.isNil and gso.enabled
-
-proc disable*(gso: SegmentationOffload) {.raises: [].} =
-  if not gso.isNil:
-    gso.enabled = false
 
 func hash*(cid: CidKey): Hash =
   var h = hash(cid.len)

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -23,9 +23,9 @@ type
   LsquicCidArray = UncheckedArray[lsquic_cid_t]
 
   SegmentationOffload* = ref object
-    ## UDP segmentation offload state for one socket. The server and client
-    ## contexts of an endpoint share a single cell, so a runtime disable
-    ## applies to the socket rather than to whichever context hit the error.
+    ## UDP segmentation offload state for one socket. The server context and
+    ## the client context of an endpoint share one cell. A send error thus
+    ## disables offload for the socket, not for one context only.
     enabled: bool
 
   QuicContext* = ref object of RootObj

--- a/lsquic/context/gso.nim
+++ b/lsquic/context/gso.nim
@@ -4,33 +4,29 @@
 import chronos/osdefs
 import ../lsquic_ffi
 
-## Groups an lsquic out_spec batch into runs of adjacent packets sharing a
-## destination, so each run can be sent as one segmented UDP datagram
-## (Linux GSO / Windows USO).
+## Groups an lsquic out_spec batch into runs of adjacent packets with the same
+## destination. The send path gives each run to the kernel as one segmented UDP
+## datagram (Linux GSO / Windows USO).
 ##
-## Only adjacent specs are grouped. lsquic's engine round-robins across
-## connections, so a batch drawn from many peers interleaves destinations and
-## the runs stay short — but such batches are themselves short, and grouping
-## across the whole batch was measured to gain nothing there while costing a
-## quadratic scan. Contiguous runs also keep a group's members at exactly
-## specs[firstSpec ..< firstSpec + count], which is what lets the send path
-## report a true prefix count back to lsquic.
+## The code groups only adjacent specs. A run then maps to a contiguous index
+## range, so the send path can report a true prefix count to lsquic.
 
 const
   MaxBatch* = 1024
     ## lsquic MAX_OUT_BATCH_SIZE: upper bound on specs per callback invocation.
   MaxGsoSegments* = 64 ## Linux UDP_MAX_SEGMENTS; reused as the segment cap on Windows.
   MaxGsoBytes* = 65507
-    ## Maximum total payload of one segmented datagram: the IPv4 ceiling of
-    ## 0xFFFF less the 20-byte IP and 8-byte UDP headers. Going over fails the
-    ## whole send with EMSGSIZE. IPv6 permits 65527; use the lower bound for both.
+    ## Maximum total payload of one segmented datagram. The IPv4 limit is 0xFFFF
+    ## minus the 20-byte IP header and the 8-byte UDP header. A larger payload
+    ## fails the whole send with EMSGSIZE. IPv6 allows 65527. Use the lower value
+    ## for both.
 
 type GsoGroup* = object
-  firstSpec*: uint16 ## index of the first member spec
+  firstSpec*: uint16
   count*: uint16 ## members are specs[firstSpec ..< firstSpec + count]
-  segSize*: uint32 ## segment size; only the last member may be smaller
+  segSize*: uint32 ## only the last member can be smaller
   totalBytes*: uint32
-  useGso*: bool ## false for solo groups: sent without a segmentation cmsg
+  useGso*: bool ## false for a solo group, which needs no segmentation cmsg
 
 proc sameDest(a, b: ptr SockAddr): bool =
   if a.sa_family != b.sa_family:
@@ -49,18 +45,13 @@ proc groupSpecs*(
     nspecs: int,
     groups: var array[MaxBatch, GsoGroup],
 ): int =
-  ## Buckets specs[0 ..< nspecs] into runs of adjacent same-destination specs.
-  ## Returns the number of groups.
-  ##
-  ## Invariant the send path's partial-failure accounting relies on: group k
-  ## holds exactly specs[firstSpec ..< firstSpec + count], and groups are
-  ## emitted in index order, so groups[k].firstSpec is the exact number of
-  ## specs preceding group k.
+  ## Returns the number of groups. The groups come in index order, so
+  ## groups[k].firstSpec is the exact number of specs before group k.
   doAssert nspecs <= MaxBatch
 
   var
     ngroups = 0
-    open = -1 # group the previous spec landed in, while it can still grow
+    open = -1 # group of the previous spec, while it can still grow
 
   for i in 0 ..< nspecs:
     let spec = addr specs[i]
@@ -74,7 +65,6 @@ proc groupSpecs*(
         if segLen == groups[open].segSize:
           inc groups[open].count
           groups[open].totalBytes += segLen
-          # close once another full segment cannot fit, so appends always fit
           if groups[open].count.int == MaxGsoSegments or
               groups[open].totalBytes + groups[open].segSize > MaxGsoBytes:
             open = -1
@@ -85,7 +75,7 @@ proc groupSpecs*(
           groups[open].totalBytes += segLen
           open = -1
           placed = true
-        # a larger packet (e.g. a PMTUD probe) falls through to a fresh group
+        # a larger packet, such as a PMTUD probe, starts a new group
 
     if not placed:
       groups[ngroups] = GsoGroup(firstSpec: uint16(i), count: 1)

--- a/lsquic/context/gso.nim
+++ b/lsquic/context/gso.nim
@@ -4,21 +4,30 @@
 import chronos/osdefs
 import ../lsquic_ffi
 
-## Groups an lsquic out_spec batch by destination so that packets to the same
-## peer can be sent as one segmented UDP datagram (Linux GSO / Windows USO).
-## lsquic's engine emits at most one packet per connection per iteration
-## (fairness round-robin), so packets to the same destination are rarely
-## adjacent in the batch — grouping must consider the whole batch.
+## Groups an lsquic out_spec batch into runs of adjacent packets sharing a
+## destination, so each run can be sent as one segmented UDP datagram
+## (Linux GSO / Windows USO).
+##
+## Only adjacent specs are grouped. lsquic's engine round-robins across
+## connections, so a batch drawn from many peers interleaves destinations and
+## the runs stay short — but such batches are themselves short, and grouping
+## across the whole batch was measured to gain nothing there while costing a
+## quadratic scan. Contiguous runs also keep a group's members at exactly
+## specs[firstSpec ..< firstSpec + count], which is what lets the send path
+## report a true prefix count back to lsquic.
 
 const
   MaxBatch* = 1024
     ## lsquic MAX_OUT_BATCH_SIZE: upper bound on specs per callback invocation.
   MaxGsoSegments* = 64 ## Linux UDP_MAX_SEGMENTS; reused as the segment cap on Windows.
-  MaxGsoBytes* = 65535 ## Maximum total payload of one segmented super-datagram.
+  MaxGsoBytes* = 65507
+    ## Maximum total payload of one segmented datagram: the IPv4 ceiling of
+    ## 0xFFFF less the 20-byte IP and 8-byte UDP headers. Going over fails the
+    ## whole send with EMSGSIZE. IPv6 permits 65527; use the lower bound for both.
 
 type GsoGroup* = object
   firstSpec*: uint16 ## index of the first member spec
-  count*: uint16 ## number of member specs
+  count*: uint16 ## members are specs[firstSpec ..< firstSpec + count]
   segSize*: uint32 ## segment size; only the last member may be smaller
   totalBytes*: uint32
   useGso*: bool ## false for solo groups: sent without a segmentation cmsg
@@ -39,81 +48,57 @@ proc groupSpecs*(
     specs: ptr UncheckedArray[struct_lsquic_out_spec],
     nspecs: int,
     groups: var array[MaxBatch, GsoGroup],
-    specOrder: var array[MaxBatch, uint16],
 ): int =
-  ## Buckets specs[0 ..< nspecs] into destination groups; member indices land
-  ## grouped-contiguously in specOrder. Returns the number of groups.
+  ## Buckets specs[0 ..< nspecs] into runs of adjacent same-destination specs.
+  ## Returns the number of groups.
   ##
-  ## Invariant the send path's partial-failure accounting relies on: groups are
-  ## ordered by ascending firstSpec, so every spec with an index below
-  ## groups[k].firstSpec belongs to a group before k. If k is the first group
-  ## not fully sent, groups[k].firstSpec is the exact prefix count to report
-  ## back to lsquic.
+  ## Invariant the send path's partial-failure accounting relies on: group k
+  ## holds exactly specs[firstSpec ..< firstSpec + count], and groups are
+  ## emitted in index order, so groups[k].firstSpec is the exact number of
+  ## specs preceding group k.
   doAssert nspecs <= MaxBatch
 
   var
-    specGroup {.noinit.}: array[MaxBatch, uint16]
-    open {.noinit.}: array[MaxBatch, uint16] # indices of open groups
-    nopen = 0
     ngroups = 0
-
-  template closeOpen(idx: int) =
-    open[idx] = open[nopen - 1]
-    dec nopen
+    open = -1 # group the previous spec landed in, while it can still grow
 
   for i in 0 ..< nspecs:
     let spec = addr specs[i]
     var placed = false
-    if spec.iovlen == 1:
-      let segLen = uint32(spec.iov[].iov_len)
-      var j = 0
-      while j < nopen:
-        let g = open[j].int
-        let head = addr specs[groups[g].firstSpec.int]
-        if head.ecn == spec.ecn and sameDest(head.dest_sa, spec.dest_sa):
-          if segLen == groups[g].segSize:
-            specGroup[i] = uint16(g)
-            inc groups[g].count
-            groups[g].totalBytes += segLen
-            # close once another full segment cannot fit, so appends always fit
-            if groups[g].count.int == MaxGsoSegments or
-                groups[g].totalBytes + groups[g].segSize > MaxGsoBytes:
-              closeOpen(j)
-            placed = true
-          elif segLen < groups[g].segSize:
-            # GSO allows exactly one trailing shorter segment
-            specGroup[i] = uint16(g)
-            inc groups[g].count
-            groups[g].totalBytes += segLen
-            closeOpen(j)
-            placed = true
-          else:
-            # larger packet (e.g. PMTUD probe): close and start a fresh group
-            closeOpen(j)
-          break
-        inc j
+
+    if open >= 0 and spec.iovlen == 1:
+      let
+        head = addr specs[groups[open].firstSpec.int]
+        segLen = uint32(spec.iov[].iov_len)
+      if head.ecn == spec.ecn and sameDest(head.dest_sa, spec.dest_sa):
+        if segLen == groups[open].segSize:
+          inc groups[open].count
+          groups[open].totalBytes += segLen
+          # close once another full segment cannot fit, so appends always fit
+          if groups[open].count.int == MaxGsoSegments or
+              groups[open].totalBytes + groups[open].segSize > MaxGsoBytes:
+            open = -1
+          placed = true
+        elif segLen < groups[open].segSize:
+          # GSO allows exactly one trailing shorter segment
+          inc groups[open].count
+          groups[open].totalBytes += segLen
+          open = -1
+          placed = true
+        # a larger packet (e.g. a PMTUD probe) falls through to a fresh group
 
     if not placed:
       groups[ngroups] = GsoGroup(firstSpec: uint16(i), count: 1)
-      specGroup[i] = uint16(ngroups)
+      open = -1
       if spec.iovlen == 1:
         let segLen = uint32(spec.iov[].iov_len)
         groups[ngroups].segSize = segLen
         groups[ngroups].totalBytes = segLen
         if segLen * 2 <= MaxGsoBytes:
-          open[nopen] = uint16(ngroups)
-          inc nopen
+          open = ngroups
       inc ngroups
 
-  var
-    offsets {.noinit.}: array[MaxBatch, int]
-    off = 0
   for g in 0 ..< ngroups:
-    offsets[g] = off
-    off += groups[g].count.int
     groups[g].useGso = groups[g].count >= 2
-  for i in 0 ..< nspecs:
-    specOrder[offsets[specGroup[i].int]] = uint16(i)
-    inc offsets[specGroup[i].int]
 
   ngroups

--- a/lsquic/context/gso.nim
+++ b/lsquic/context/gso.nim
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import chronos/osdefs
+import ../lsquic_ffi
+
+## Groups an lsquic out_spec batch by destination so that packets to the same
+## peer can be sent as one segmented UDP datagram (Linux GSO / Windows USO).
+## lsquic's engine emits at most one packet per connection per iteration
+## (fairness round-robin), so packets to the same destination are rarely
+## adjacent in the batch — grouping must consider the whole batch.
+
+const
+  MaxBatch* = 1024
+    ## lsquic MAX_OUT_BATCH_SIZE: upper bound on specs per callback invocation.
+  MaxGsoSegments* = 64 ## Linux UDP_MAX_SEGMENTS; reused as the segment cap on Windows.
+  MaxGsoBytes* = 65535 ## Maximum total payload of one segmented super-datagram.
+
+type GsoGroup* = object
+  firstSpec*: uint16 ## index of the first member spec
+  count*: uint16 ## number of member specs
+  segSize*: uint32 ## segment size; only the last member may be smaller
+  totalBytes*: uint32
+  useGso*: bool ## false for solo groups: sent without a segmentation cmsg
+
+proc sameDest(a, b: ptr SockAddr): bool =
+  if a.sa_family != b.sa_family:
+    return false
+  if int(a.sa_family) == int(AF_INET):
+    # family + port + address occupy the first 8 bytes of sockaddr_in
+    equalMem(a, b, 8)
+  elif int(a.sa_family) == int(AF_INET6):
+    # family + port + flowinfo + address + scope_id: first 28 bytes
+    equalMem(a, b, 28)
+  else:
+    false
+
+proc groupSpecs*(
+    specs: ptr UncheckedArray[struct_lsquic_out_spec],
+    nspecs: int,
+    groups: var array[MaxBatch, GsoGroup],
+    specOrder: var array[MaxBatch, uint16],
+): int =
+  ## Buckets specs[0 ..< nspecs] into destination groups; member indices land
+  ## grouped-contiguously in specOrder. Returns the number of groups.
+  ##
+  ## Invariant the send path's partial-failure accounting relies on: groups are
+  ## ordered by ascending firstSpec, so every spec with an index below
+  ## groups[k].firstSpec belongs to a group before k. If k is the first group
+  ## not fully sent, groups[k].firstSpec is the exact prefix count to report
+  ## back to lsquic.
+  doAssert nspecs <= MaxBatch
+
+  var
+    specGroup {.noinit.}: array[MaxBatch, uint16]
+    open {.noinit.}: array[MaxBatch, uint16] # indices of open groups
+    nopen = 0
+    ngroups = 0
+
+  template closeOpen(idx: int) =
+    open[idx] = open[nopen - 1]
+    dec nopen
+
+  for i in 0 ..< nspecs:
+    let spec = addr specs[i]
+    var placed = false
+    if spec.iovlen == 1:
+      let segLen = uint32(spec.iov[].iov_len)
+      var j = 0
+      while j < nopen:
+        let g = open[j].int
+        let head = addr specs[groups[g].firstSpec.int]
+        if head.ecn == spec.ecn and sameDest(head.dest_sa, spec.dest_sa):
+          if segLen == groups[g].segSize:
+            specGroup[i] = uint16(g)
+            inc groups[g].count
+            groups[g].totalBytes += segLen
+            # close once another full segment cannot fit, so appends always fit
+            if groups[g].count.int == MaxGsoSegments or
+                groups[g].totalBytes + groups[g].segSize > MaxGsoBytes:
+              closeOpen(j)
+            placed = true
+          elif segLen < groups[g].segSize:
+            # GSO allows exactly one trailing shorter segment
+            specGroup[i] = uint16(g)
+            inc groups[g].count
+            groups[g].totalBytes += segLen
+            closeOpen(j)
+            placed = true
+          else:
+            # larger packet (e.g. PMTUD probe): close and start a fresh group
+            closeOpen(j)
+          break
+        inc j
+
+    if not placed:
+      groups[ngroups] = GsoGroup(firstSpec: uint16(i), count: 1)
+      specGroup[i] = uint16(ngroups)
+      if spec.iovlen == 1:
+        let segLen = uint32(spec.iov[].iov_len)
+        groups[ngroups].segSize = segLen
+        groups[ngroups].totalBytes = segLen
+        if segLen * 2 <= MaxGsoBytes:
+          open[nopen] = uint16(ngroups)
+          inc nopen
+      inc ngroups
+
+  var
+    offsets {.noinit.}: array[MaxBatch, int]
+    off = 0
+  for g in 0 ..< ngroups:
+    offsets[g] = off
+    off += groups[g].count.int
+    groups[g].useGso = groups[g].count >= 2
+  for i in 0 ..< nspecs:
+    specOrder[offsets[specGroup[i].int]] = uint16(i)
+    inc offsets[specGroup[i].int]
+
+  ngroups

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -12,6 +12,9 @@ when not defined(windows):
   import chronicles
   import posix
 
+when defined(linux) or defined(windows):
+  import ./gso
+
 when defined(linux):
   {.passc: "-D_GNU_SOURCE".}
 
@@ -26,25 +29,81 @@ when defined(linux):
   ): cint {.importc, header: "<sys/socket.h>".}
 
 when defined(windows):
-  import std/winlean
-
   {.pragma: wsa, stdcall, dynlib: "ws2_32.dll".}
 
-  type WSABUF* = object
-    len*: culong
-    buf*: ptr char
+  type
+    WSABUF = object
+      len: culong
+      buf: ptr char
 
-  proc WSASendTo*(
+    WSAMSG = object
+      name: ptr SockAddr
+      namelen: cint
+      lpBuffers: ptr WSABUF
+      dwBufferCount: culong
+      control: WSABUF
+      dwFlags: culong
+
+    # struct _WSACMSGHDR: SIZE_T cmsg_len; INT cmsg_level; INT cmsg_type
+    WsaCmsgHdr = object
+      cmsg_len: csize_t
+      cmsg_level: cint
+      cmsg_type: cint
+
+  const
+    WsaCmsgDataOff =
+      (sizeof(WsaCmsgHdr) + sizeof(csize_t) - 1) and not (sizeof(csize_t) - 1)
+    WsaCmsgLen = WsaCmsgDataOff + sizeof(DWORD)
+    WsaCmsgSpace = (WsaCmsgLen + sizeof(csize_t) - 1) and not (sizeof(csize_t) - 1)
+    WSAEINVAL = 10022
+    WSAEWOULDBLOCK = 10035
+    WSAEMSGSIZE = 10040
+    WSAEOPNOTSUPP = 10045
+
+  proc WSASendMsg(
     s: SocketHandle,
-    lpBuffers: ptr WSABUF,
-    dwBufferCount: culong,
-    lpNumberOfBytesSent: ptr culong,
+    lpMsg: ptr WSAMSG,
     dwFlags: culong,
-    lpTo: ptr SockAddr,
-    iToLen: cint,
+    lpNumberOfBytesSent: ptr culong,
     lpOverlapped: pointer,
     lpCompletionRoutine: pointer,
-  ): cint {.wsa, importc: "WSASendTo".}
+  ): cint {.wsa, importc: "WSASendMsg".}
+
+  # lsquic inspects the CRT errno on Windows too (send_batch compares against
+  # EAGAIN/EMSGSIZE), so WSA errors must be bridged into it
+  var cErrno {.importc: "errno", header: "<errno.h>".}: cint
+  var cEAGAIN {.importc: "EAGAIN", header: "<errno.h>".}: cint
+  var cEMSGSIZE {.importc: "EMSGSIZE", header: "<errno.h>".}: cint
+  var cEIO {.importc: "EIO", header: "<errno.h>".}: cint
+
+  proc setSendErrno(wsaError: cint) =
+    cErrno =
+      if wsaError == WSAEWOULDBLOCK:
+        cEAGAIN
+      elif wsaError == WSAEMSGSIZE:
+        cEMSGSIZE
+      else:
+        cEIO
+
+when defined(linux):
+  const
+    SOL_UDP = 17
+    UDP_SEGMENT = 103
+
+when defined(windows):
+  const UDP_SEND_MSG_SIZE = 2
+
+proc probeSegmentationOffload*(fd: AsyncFD): bool =
+  ## Returns true when the socket supports UDP segmentation offload
+  ## (Linux GSO via UDP_SEGMENT, kernel 4.18+; Windows USO via
+  ## UDP_SEND_MSG_SIZE, Windows 10 1803+). Setting the option to 0 keeps
+  ## socket-wide segmentation off; the send path enables it per message.
+  when defined(linux):
+    setSockOpt2(fd, SOL_UDP, UDP_SEGMENT, 0).isOk()
+  elif defined(windows):
+    setSockOpt2(fd, IPPROTO_UDP, UDP_SEND_MSG_SIZE, 0).isOk()
+  else:
+    false
 
 proc prepareDestAddr(
     localSa: ptr SockAddr,
@@ -148,25 +207,24 @@ proc receive*(
 ) =
   ctx.receive(datagram.data, local, remote, datagram.ecn)
 
-proc sendPacketsOut*(
-    ctx: pointer, specs: ptr struct_lsquic_out_spec, nspecs: cuint
-): cint {.cdecl.} =
-  let quicCtx = cast[QuicContext](ctx)
-  if nspecs == 0:
-    return 0
-
-  let specsArr = cast[ptr UncheckedArray[struct_lsquic_out_spec]](specs)
-
+proc sendPlain(
+    quicCtx: QuicContext,
+    specsArr: ptr UncheckedArray[struct_lsquic_out_spec],
+    first: int,
+    nspecs: int,
+): cint =
+  ## Sends specs[first ..< nspecs] without segmentation offload; returns the
+  ## number of specs sent starting at `first`, with errno set on short returns.
   when defined(linux):
     var
       destStorages {.noinit.}: array[SendmmsgBatchSize, Sockaddr_storage]
       msgs {.noinit.}: array[SendmmsgBatchSize, MMsgHdr]
       sent = 0
 
-    while sent < nspecs.int:
-      let nmsgs = min(nspecs.int - sent, SendmmsgBatchSize)
+    while first + sent < nspecs:
+      let nmsgs = min(nspecs - first - sent, SendmmsgBatchSize)
       for i in 0 ..< nmsgs:
-        let curr = specsArr[sent + i]
+        let curr = specsArr[first + sent + i]
         var destAddrLen: SockLen
         prepareDestAddr(curr.local_sa, curr.dest_sa, destStorages[i], destAddrLen)
         msgs[i] =
@@ -190,7 +248,7 @@ proc sendPacketsOut*(
     sent.cint
   else:
     var sent = 0
-    for i in 0 ..< nspecs.int:
+    for i in first ..< nspecs:
       let curr = specsArr[i]
       var
         destStorage: Sockaddr_storage
@@ -206,19 +264,19 @@ proc sendPacketsOut*(
           bufs[j].len = culong(src.iov_len)
           bufs[j].buf = cast[ptr char](src.iov_base)
 
-        var bytesSent: culong = 0
-        let res = WSASendTo(
-          SocketHandle(quicCtx.fd),
-          addr bufs[0],
-          culong(curr.iovlen),
-          addr bytesSent,
-          0, # flags
-          cast[ptr SockAddr](addr destStorage),
-          cint(destAddrLen),
-          nil,
-          nil, # no overlapped
+        var msg = WSAMSG(
+          name: cast[ptr SockAddr](addr destStorage),
+          namelen: cint(destAddrLen),
+          lpBuffers: addr bufs[0],
+          dwBufferCount: culong(curr.iovlen),
+          control: WSABUF(len: 0, buf: nil),
+          dwFlags: 0,
         )
+        var bytesSent: culong = 0
+        let res =
+          WSASendMsg(SocketHandle(quicCtx.fd), addr msg, 0, addr bytesSent, nil, nil)
         if res != 0:
+          setSendErrno(wsaGetLastError())
           if sent == 0:
             return -1
           break
@@ -235,3 +293,305 @@ proc sendPacketsOut*(
       sent.inc
 
     sent.cint
+
+when defined(linux):
+  type GsoCmsgBuf = object
+    data {.align(8).}: array[32, byte] # >= CMSG_SPACE(sizeof(uint16)) everywhere
+
+  proc makeGsoMsgHdr(
+      destStorage: var Sockaddr_storage,
+      destAddrLen: SockLen,
+      iov: ptr IOVec,
+      iovlen: int,
+      control: pointer,
+      controllen: SockLen,
+  ): Tmsghdr =
+    when defined(x86_64) and not defined(android):
+      Tmsghdr(
+        msg_name: cast[pointer](addr destStorage),
+        msg_namelen: destAddrLen,
+        msg_iov: iov,
+        msg_iovlen: iovlen.csize_t,
+        msg_control: control,
+        msg_controllen: controllen,
+        msg_flags: 0,
+      )
+    else:
+      Tmsghdr(
+        msg_name: cast[pointer](addr destStorage),
+        msg_namelen: destAddrLen,
+        msg_iov: iov,
+        msg_iovlen: iovlen.cint,
+        msg_control: control,
+        msg_controllen: controllen,
+        msg_flags: 0,
+      )
+
+  proc sendOneSpec(quicCtx: QuicContext, spec: struct_lsquic_out_spec): int =
+    var
+      destStorage: Sockaddr_storage
+      destAddrLen: SockLen
+    prepareDestAddr(spec.local_sa, spec.dest_sa, destStorage, destAddrLen)
+    let msg = makeMsgHdr(spec, destStorage, destAddrLen)
+    sendmsg(SocketHandle(quicCtx.fd), msg.addr, 0)
+
+  proc sendSegmented(
+      quicCtx: QuicContext,
+      specsArr: ptr UncheckedArray[struct_lsquic_out_spec],
+      nspecs: int,
+  ): cint =
+    ## Sends the batch grouped by destination, each multi-packet group as one
+    ## GSO super-datagram. Returns a prefix count of sent specs: groups are
+    ## ordered by ascending firstSpec (see groupSpecs), so when group k is the
+    ## first not fully sent, every spec below groups[k].firstSpec is out.
+    var
+      groups {.noinit.}: array[MaxBatch, GsoGroup]
+      specOrder {.noinit.}: array[MaxBatch, uint16]
+      iovPool {.noinit.}: array[MaxBatch, IOVec]
+      destStorages {.noinit.}: array[SendmmsgBatchSize, Sockaddr_storage]
+      msgs {.noinit.}: array[SendmmsgBatchSize, MMsgHdr]
+      cmsgBufs {.noinit.}: array[SendmmsgBatchSize, GsoCmsgBuf]
+
+    let ngroups = groupSpecs(specsArr, nspecs, groups, specOrder)
+
+    var
+      g = 0
+      orderPos = 0 # specOrder index of group g's first member
+    while g < ngroups:
+      let nmsgs = min(ngroups - g, SendmmsgBatchSize)
+      var
+        iovUsed = 0
+        pos = orderPos
+      for m in 0 ..< nmsgs:
+        let
+          grp = addr groups[g + m]
+          head = addr specsArr[grp.firstSpec.int]
+        var destAddrLen: SockLen
+        prepareDestAddr(head.local_sa, head.dest_sa, destStorages[m], destAddrLen)
+        if grp.useGso:
+          let iovStart = iovUsed
+          for j in 0 ..< grp.count.int:
+            let s = addr specsArr[specOrder[pos + j].int]
+            iovPool[iovUsed] =
+              IOVec(iov_base: s.iov[].iov_base, iov_len: s.iov[].iov_len)
+            inc iovUsed
+          msgs[m] = MMsgHdr(
+            msg_hdr: makeGsoMsgHdr(
+              destStorages[m],
+              destAddrLen,
+              addr iovPool[iovStart],
+              grp.count.int,
+              cast[pointer](addr cmsgBufs[m]),
+              SockLen(CMSG_SPACE(2)),
+            ),
+            msg_len: 0,
+          )
+          let hdr = CMSG_FIRSTHDR(addr msgs[m].msg_hdr)
+          hdr.cmsg_level = SOL_UDP
+          hdr.cmsg_type = UDP_SEGMENT
+          hdr.cmsg_len = SockLen(CMSG_LEN(2))
+          cast[ptr uint16](CMSG_DATA(hdr))[] = uint16(grp.segSize)
+        else:
+          msgs[m] = MMsgHdr(
+            msg_hdr: makeMsgHdr(head[], destStorages[m], destAddrLen), msg_len: 0
+          )
+        pos += grp.count.int
+
+      let res = sendmmsg(SocketHandle(quicCtx.fd), addr msgs[0], nmsgs.cuint, 0)
+      if res < 0:
+        # the first message of this chunk failed, so groups[g] is the failing
+        # group and groups[g].firstSpec the exact sent-prefix
+        let
+          savedErrno = errno
+          p = groups[g].firstSpec.int
+        if savedErrno == EMSGSIZE and groups[g].useGso:
+          # a segmented datagram was oversized (path MTU shrank); resend its
+          # members individually so lsquic can attribute EMSGSIZE per packet
+          var allSent = true
+          for j in 0 ..< groups[g].count.int:
+            let idx = specOrder[orderPos + j].int
+            if sendOneSpec(quicCtx, specsArr[idx]) < 0:
+              let memberErrno = errno
+              var minUnsent = idx
+              if g + 1 < ngroups:
+                minUnsent = min(minUnsent, groups[g + 1].firstSpec.int)
+              trace "gso member resend failed", idx, minUnsent, nspecs
+              # exact attribution only when the failed spec is the first unsent
+              # one; otherwise defer via EAGAIN so it resurfaces later
+              errno = if idx == minUnsent: memberErrno else: EAGAIN
+              if minUnsent == 0:
+                return -1
+              return minUnsent.cint
+          orderPos += groups[g].count.int
+          inc g
+          continue
+        if savedErrno == EIO or savedErrno == EINVAL or savedErrno == ENOTSUP or
+            savedErrno == EOPNOTSUPP:
+          # kernel/driver rejected the segmented send: disable GSO on this
+          # socket for good and finish the batch unsegmented
+          quicCtx.gsoEnabled = false
+          info "UDP GSO disabled after send error", errorCode = savedErrno
+          let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
+          if plainSent < 0:
+            if p == 0:
+              return -1
+            return p.cint
+          return (p + plainSent).cint
+        trace "gso sendmmsg failed", p, nspecs
+        errno = if savedErrno == EWOULDBLOCK: EAGAIN else: savedErrno
+        if p == 0:
+          return -1
+        return p.cint
+
+      for m in 0 ..< res:
+        orderPos += groups[g + m].count.int
+      g += res
+      if res < nmsgs.cint:
+        # sendmmsg does not report the error that stopped it; back off and let
+        # lsquic retry the remainder
+        trace "gso sendmmsg partially sent", sentGroups = g, ngroups, nspecs
+        errno = EAGAIN
+        return groups[g].firstSpec.cint
+
+    nspecs.cint
+
+when defined(windows):
+  proc sendOneSpec(quicCtx: QuicContext, spec: struct_lsquic_out_spec): cint =
+    ## single unsegmented WSASendMsg; caller reads wsaGetLastError on failure
+    var
+      destStorage: Sockaddr_storage
+      destAddrLen: SockLen
+    prepareDestAddr(spec.local_sa, spec.dest_sa, destStorage, destAddrLen)
+    var buf =
+      WSABUF(len: culong(spec.iov[].iov_len), buf: cast[ptr char](spec.iov[].iov_base))
+    var msg = WSAMSG(
+      name: cast[ptr SockAddr](addr destStorage),
+      namelen: cint(destAddrLen),
+      lpBuffers: addr buf,
+      dwBufferCount: 1,
+      control: WSABUF(len: 0, buf: nil),
+      dwFlags: 0,
+    )
+    var bytesSent: culong = 0
+    WSASendMsg(SocketHandle(quicCtx.fd), addr msg, 0, addr bytesSent, nil, nil)
+
+  proc sendSegmented(
+      quicCtx: QuicContext,
+      specsArr: ptr UncheckedArray[struct_lsquic_out_spec],
+      nspecs: int,
+  ): cint =
+    ## Sends the batch grouped by destination, each multi-packet group as one
+    ## USO super-datagram (one WSASendMsg per group; Windows has no sendmmsg).
+    ## Same prefix-count accounting as the Linux path: groups are ordered by
+    ## ascending firstSpec, so when group g fails, groups[g].firstSpec specs
+    ## are known sent.
+    var
+      groups {.noinit.}: array[MaxBatch, GsoGroup]
+      specOrder {.noinit.}: array[MaxBatch, uint16]
+      bufPool {.noinit.}: array[MaxBatch, WSABUF]
+      cmsgBuf {.align(8).}: array[32, byte]
+
+    let ngroups = groupSpecs(specsArr, nspecs, groups, specOrder)
+
+    var
+      g = 0
+      orderPos = 0 # specOrder index of group g's first member
+    while g < ngroups:
+      let
+        grp = addr groups[g]
+        head = addr specsArr[grp.firstSpec.int]
+      var
+        destStorage: Sockaddr_storage
+        destAddrLen: SockLen
+      prepareDestAddr(head.local_sa, head.dest_sa, destStorage, destAddrLen)
+
+      var msg = WSAMSG(
+        name: cast[ptr SockAddr](addr destStorage),
+        namelen: cint(destAddrLen),
+        control: WSABUF(len: 0, buf: nil),
+        dwFlags: 0,
+      )
+      if grp.useGso:
+        for j in 0 ..< grp.count.int:
+          let s = addr specsArr[specOrder[orderPos + j].int]
+          bufPool[j] =
+            WSABUF(len: culong(s.iov[].iov_len), buf: cast[ptr char](s.iov[].iov_base))
+        msg.lpBuffers = addr bufPool[0]
+        msg.dwBufferCount = culong(grp.count)
+        let hdr = cast[ptr WsaCmsgHdr](addr cmsgBuf[0])
+        hdr.cmsg_len = csize_t(WsaCmsgLen)
+        hdr.cmsg_level = IPPROTO_UDP
+        hdr.cmsg_type = UDP_SEND_MSG_SIZE
+        cast[ptr DWORD](addr cmsgBuf[WsaCmsgDataOff])[] = DWORD(grp.segSize)
+        msg.control =
+          WSABUF(len: culong(WsaCmsgSpace), buf: cast[ptr char](addr cmsgBuf[0]))
+      else:
+        let iovArr = cast[ptr UncheckedArray[struct_iovec]](head.iov)
+        for j in 0 ..< head.iovlen.int:
+          bufPool[j] = WSABUF(
+            len: culong(iovArr[j].iov_len), buf: cast[ptr char](iovArr[j].iov_base)
+          )
+        msg.lpBuffers = addr bufPool[0]
+        msg.dwBufferCount = culong(head.iovlen)
+
+      var bytesSent: culong = 0
+      let res =
+        WSASendMsg(SocketHandle(quicCtx.fd), addr msg, 0, addr bytesSent, nil, nil)
+      if res != 0:
+        let
+          wsaErr = wsaGetLastError()
+          p = grp.firstSpec.int
+        if wsaErr == WSAEMSGSIZE and grp.useGso:
+          # a segmented datagram was oversized (path MTU shrank); resend its
+          # members individually so lsquic can attribute the error per packet
+          for j in 0 ..< grp.count.int:
+            let idx = specOrder[orderPos + j].int
+            if sendOneSpec(quicCtx, specsArr[idx]) != 0:
+              let memberWsaErr = wsaGetLastError()
+              var minUnsent = idx
+              if g + 1 < ngroups:
+                minUnsent = min(minUnsent, groups[g + 1].firstSpec.int)
+              # exact attribution only when the failed spec is the first
+              # unsent one; otherwise defer via EAGAIN so it resurfaces later
+              if idx == minUnsent:
+                setSendErrno(memberWsaErr)
+              else:
+                cErrno = cEAGAIN
+              if minUnsent == 0:
+                return -1
+              return minUnsent.cint
+          orderPos += grp.count.int
+          inc g
+          continue
+        if wsaErr == WSAEINVAL or wsaErr == WSAEOPNOTSUPP:
+          # the stack rejected the segmented send: disable USO on this socket
+          # for good and finish the batch unsegmented
+          quicCtx.gsoEnabled = false
+          let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
+          if plainSent < 0:
+            if p == 0:
+              return -1
+            return p.cint
+          return (p + plainSent).cint
+        setSendErrno(wsaErr)
+        if p == 0:
+          return -1
+        return p.cint
+
+      orderPos += grp.count.int
+      inc g
+
+    nspecs.cint
+
+proc sendPacketsOut*(
+    ctx: pointer, specs: ptr struct_lsquic_out_spec, nspecs: cuint
+): cint {.cdecl.} =
+  let quicCtx = cast[QuicContext](ctx)
+  if nspecs == 0:
+    return 0
+
+  let specsArr = cast[ptr UncheckedArray[struct_lsquic_out_spec]](specs)
+  when defined(linux) or defined(windows):
+    if quicCtx.gsoEnabled and nspecs.int <= MaxBatch:
+      return sendSegmented(quicCtx, specsArr, nspecs.int)
+  sendPlain(quicCtx, specsArr, 0, nspecs.int)

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -341,10 +341,8 @@ when defined(linux):
       specsArr: ptr UncheckedArray[struct_lsquic_out_spec],
       nspecs: int,
   ): cint =
-    ## Sends the batch grouped by destination, each multi-packet group as one
-    ## GSO super-datagram. Returns a prefix count of sent specs: a group holds
-    ## adjacent specs (see groupSpecs), so when group k is the first not fully
-    ## sent, groups[k].firstSpec is exactly what came before it.
+    ## Sends each multi-packet group as one segmented datagram. Returns the
+    ## number of specs sent, always as a prefix of the batch.
     var
       groups {.noinit.}: array[MaxBatch, GsoGroup]
       iovPool {.noinit.}: array[MaxBatch, IOVec]
@@ -395,19 +393,18 @@ when defined(linux):
 
       let res = sendmmsg(SocketHandle(quicCtx.fd), addr msgs[0], nmsgs.cuint, 0)
       if res < 0:
-        # the first message of this chunk failed, so groups[g] is the failing
-        # group and groups[g].firstSpec the exact sent-prefix
+        # the first message of this chunk failed, so groups[g] is the failed
+        # group
         let
           savedErrno = errno
           p = groups[g].firstSpec.int
         if savedErrno == EMSGSIZE and groups[g].useGso:
-          # a segmented datagram was oversized (path MTU shrank); resend its
-          # members individually so lsquic can attribute EMSGSIZE per packet
+          # send each member alone, so lsquic gets one EMSGSIZE per packet
           for j in 0 ..< groups[g].count.int:
             let idx = p + j
             if sendOneSpec(quicCtx, specsArr[idx]) < 0:
-              # members are adjacent, so the failing one is the first unsent
-              # spec of the whole batch and takes the errno verbatim
+              # members are adjacent, so this is the first unsent spec of the
+              # batch and can keep its own errno
               let memberErrno = errno
               trace "gso member resend failed", idx, nspecs
               errno = memberErrno
@@ -418,8 +415,7 @@ when defined(linux):
           continue
         if savedErrno == EIO or savedErrno == EINVAL or savedErrno == ENOTSUP or
             savedErrno == EOPNOTSUPP:
-          # kernel/driver rejected the segmented send: disable GSO on this
-          # socket for good and finish the batch unsegmented
+          # the kernel refused the segmented send
           quicCtx.gso.disable()
           info "UDP GSO disabled after send error", errorCode = savedErrno
           let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
@@ -436,8 +432,7 @@ when defined(linux):
 
       g += res
       if res < nmsgs.cint:
-        # sendmmsg does not report the error that stopped it; back off and let
-        # lsquic retry the remainder
+        # sendmmsg does not report the error that stopped it
         trace "gso sendmmsg partially sent", sentGroups = g, ngroups, nspecs
         errno = EAGAIN
         return groups[g].firstSpec.cint
@@ -446,8 +441,8 @@ when defined(linux):
 
 when defined(windows):
   proc sendOneSpec(quicCtx: QuicContext, spec: struct_lsquic_out_spec): cint =
-    ## single unsegmented WSASendMsg; caller reads wsaGetLastError on failure.
-    ## Only ever called on GSO group members, which carry one iovec each.
+    ## Sends one spec without segmentation. On failure the caller reads
+    ## wsaGetLastError. Only GSO group members use this proc.
     doAssert spec.iovlen == 1
     var
       destStorage: Sockaddr_storage
@@ -471,10 +466,9 @@ when defined(windows):
       specsArr: ptr UncheckedArray[struct_lsquic_out_spec],
       nspecs: int,
   ): cint =
-    ## Sends the batch grouped by destination, each multi-packet group as one
-    ## USO super-datagram (one WSASendMsg per group; Windows has no sendmmsg).
-    ## Same prefix-count accounting as the Linux path: a group holds adjacent
-    ## specs, so when group g fails, groups[g].firstSpec specs are known sent.
+    ## Sends each multi-packet group as one segmented datagram. Windows has no
+    ## sendmmsg, so this proc sends one WSASendMsg per group. Returns a prefix
+    ## count, as the Linux path does.
     var
       groups {.noinit.}: array[MaxBatch, GsoGroup]
       bufPool {.noinit.}: array[MaxBatch, WSABUF]
@@ -530,13 +524,12 @@ when defined(windows):
           wsaErr = wsaGetLastError()
           p = grp.firstSpec.int
         if wsaErr == WSAEMSGSIZE and grp.useGso:
-          # a segmented datagram was oversized (path MTU shrank); resend its
-          # members individually so lsquic can attribute the error per packet
+          # send each member alone, so lsquic gets one error per packet
           for j in 0 ..< grp.count.int:
             let idx = p + j
             if sendOneSpec(quicCtx, specsArr[idx]) != 0:
-              # members are adjacent, so the failing one is the first unsent
-              # spec of the whole batch and takes the error verbatim
+              # members are adjacent, so this is the first unsent spec of the
+              # batch and can keep its own error
               setSendErrno(wsaGetLastError())
               if idx == 0:
                 return -1
@@ -544,8 +537,7 @@ when defined(windows):
           inc g
           continue
         if wsaErr == WSAEINVAL or wsaErr == WSAEOPNOTSUPP or wsaErr == WSAENOPROTOOPT:
-          # the stack rejected the segmented send: disable USO on this socket
-          # for good and finish the batch unsegmented
+          # the stack refused the segmented send
           quicCtx.gso.disable()
           let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
           if plainSent < 0:

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -416,7 +416,7 @@ when defined(linux):
         if savedErrno == EIO or savedErrno == EINVAL or savedErrno == ENOTSUP or
             savedErrno == EOPNOTSUPP:
           # the kernel refused the segmented send
-          quicCtx.gso.disable()
+          quicCtx.gso.enabled = false
           info "UDP GSO disabled after send error", errorCode = savedErrno
           let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
           if plainSent < 0:
@@ -538,7 +538,7 @@ when defined(windows):
           continue
         if wsaErr == WSAEINVAL or wsaErr == WSAEOPNOTSUPP or wsaErr == WSAENOPROTOOPT:
           # the stack refused the segmented send
-          quicCtx.gso.disable()
+          quicCtx.gso.enabled = false
           let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
           if plainSent < 0:
             if p == 0:
@@ -563,6 +563,6 @@ proc sendPacketsOut*(
 
   let specsArr = cast[ptr UncheckedArray[struct_lsquic_out_spec]](specs)
   when defined(linux) or defined(windows):
-    if quicCtx.gso.isEnabled() and nspecs.int <= MaxBatch:
+    if quicCtx.gso.enabled and nspecs.int <= MaxBatch:
       return sendSegmented(quicCtx, specsArr, nspecs.int)
   sendPlain(quicCtx, specsArr, 0, nspecs.int)

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -58,6 +58,7 @@ when defined(windows):
     WSAEINVAL = 10022
     WSAEWOULDBLOCK = 10035
     WSAEMSGSIZE = 10040
+    WSAENOPROTOOPT = 10042
     WSAEOPNOTSUPP = 10045
 
   proc WSASendMsg(
@@ -341,37 +342,33 @@ when defined(linux):
       nspecs: int,
   ): cint =
     ## Sends the batch grouped by destination, each multi-packet group as one
-    ## GSO super-datagram. Returns a prefix count of sent specs: groups are
-    ## ordered by ascending firstSpec (see groupSpecs), so when group k is the
-    ## first not fully sent, every spec below groups[k].firstSpec is out.
+    ## GSO super-datagram. Returns a prefix count of sent specs: a group holds
+    ## adjacent specs (see groupSpecs), so when group k is the first not fully
+    ## sent, groups[k].firstSpec is exactly what came before it.
     var
       groups {.noinit.}: array[MaxBatch, GsoGroup]
-      specOrder {.noinit.}: array[MaxBatch, uint16]
       iovPool {.noinit.}: array[MaxBatch, IOVec]
       destStorages {.noinit.}: array[SendmmsgBatchSize, Sockaddr_storage]
       msgs {.noinit.}: array[SendmmsgBatchSize, MMsgHdr]
       cmsgBufs {.noinit.}: array[SendmmsgBatchSize, GsoCmsgBuf]
 
-    let ngroups = groupSpecs(specsArr, nspecs, groups, specOrder)
+    let ngroups = groupSpecs(specsArr, nspecs, groups)
 
-    var
-      g = 0
-      orderPos = 0 # specOrder index of group g's first member
+    var g = 0
     while g < ngroups:
       let nmsgs = min(ngroups - g, SendmmsgBatchSize)
-      var
-        iovUsed = 0
-        pos = orderPos
+      var iovUsed = 0
       for m in 0 ..< nmsgs:
         let
           grp = addr groups[g + m]
-          head = addr specsArr[grp.firstSpec.int]
+          first = grp.firstSpec.int
+          head = addr specsArr[first]
         var destAddrLen: SockLen
         prepareDestAddr(head.local_sa, head.dest_sa, destStorages[m], destAddrLen)
         if grp.useGso:
           let iovStart = iovUsed
           for j in 0 ..< grp.count.int:
-            let s = addr specsArr[specOrder[pos + j].int]
+            let s = addr specsArr[first + j]
             iovPool[iovUsed] =
               IOVec(iov_base: s.iov[].iov_base, iov_len: s.iov[].iov_len)
             inc iovUsed
@@ -395,7 +392,6 @@ when defined(linux):
           msgs[m] = MMsgHdr(
             msg_hdr: makeMsgHdr(head[], destStorages[m], destAddrLen), msg_len: 0
           )
-        pos += grp.count.int
 
       let res = sendmmsg(SocketHandle(quicCtx.fd), addr msgs[0], nmsgs.cuint, 0)
       if res < 0:
@@ -407,29 +403,24 @@ when defined(linux):
         if savedErrno == EMSGSIZE and groups[g].useGso:
           # a segmented datagram was oversized (path MTU shrank); resend its
           # members individually so lsquic can attribute EMSGSIZE per packet
-          var allSent = true
           for j in 0 ..< groups[g].count.int:
-            let idx = specOrder[orderPos + j].int
+            let idx = p + j
             if sendOneSpec(quicCtx, specsArr[idx]) < 0:
+              # members are adjacent, so the failing one is the first unsent
+              # spec of the whole batch and takes the errno verbatim
               let memberErrno = errno
-              var minUnsent = idx
-              if g + 1 < ngroups:
-                minUnsent = min(minUnsent, groups[g + 1].firstSpec.int)
-              trace "gso member resend failed", idx, minUnsent, nspecs
-              # exact attribution only when the failed spec is the first unsent
-              # one; otherwise defer via EAGAIN so it resurfaces later
-              errno = if idx == minUnsent: memberErrno else: EAGAIN
-              if minUnsent == 0:
+              trace "gso member resend failed", idx, nspecs
+              errno = memberErrno
+              if idx == 0:
                 return -1
-              return minUnsent.cint
-          orderPos += groups[g].count.int
+              return idx.cint
           inc g
           continue
         if savedErrno == EIO or savedErrno == EINVAL or savedErrno == ENOTSUP or
             savedErrno == EOPNOTSUPP:
           # kernel/driver rejected the segmented send: disable GSO on this
           # socket for good and finish the batch unsegmented
-          quicCtx.gsoEnabled = false
+          quicCtx.gso.disable()
           info "UDP GSO disabled after send error", errorCode = savedErrno
           let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
           if plainSent < 0:
@@ -443,8 +434,6 @@ when defined(linux):
           return -1
         return p.cint
 
-      for m in 0 ..< res:
-        orderPos += groups[g + m].count.int
       g += res
       if res < nmsgs.cint:
         # sendmmsg does not report the error that stopped it; back off and let
@@ -457,7 +446,9 @@ when defined(linux):
 
 when defined(windows):
   proc sendOneSpec(quicCtx: QuicContext, spec: struct_lsquic_out_spec): cint =
-    ## single unsegmented WSASendMsg; caller reads wsaGetLastError on failure
+    ## single unsegmented WSASendMsg; caller reads wsaGetLastError on failure.
+    ## Only ever called on GSO group members, which carry one iovec each.
+    doAssert spec.iovlen == 1
     var
       destStorage: Sockaddr_storage
       destAddrLen: SockLen
@@ -482,24 +473,21 @@ when defined(windows):
   ): cint =
     ## Sends the batch grouped by destination, each multi-packet group as one
     ## USO super-datagram (one WSASendMsg per group; Windows has no sendmmsg).
-    ## Same prefix-count accounting as the Linux path: groups are ordered by
-    ## ascending firstSpec, so when group g fails, groups[g].firstSpec specs
-    ## are known sent.
+    ## Same prefix-count accounting as the Linux path: a group holds adjacent
+    ## specs, so when group g fails, groups[g].firstSpec specs are known sent.
     var
       groups {.noinit.}: array[MaxBatch, GsoGroup]
-      specOrder {.noinit.}: array[MaxBatch, uint16]
       bufPool {.noinit.}: array[MaxBatch, WSABUF]
       cmsgBuf {.align(8).}: array[32, byte]
 
-    let ngroups = groupSpecs(specsArr, nspecs, groups, specOrder)
+    let ngroups = groupSpecs(specsArr, nspecs, groups)
 
-    var
-      g = 0
-      orderPos = 0 # specOrder index of group g's first member
+    var g = 0
     while g < ngroups:
       let
         grp = addr groups[g]
-        head = addr specsArr[grp.firstSpec.int]
+        first = grp.firstSpec.int
+        head = addr specsArr[first]
       var
         destStorage: Sockaddr_storage
         destAddrLen: SockLen
@@ -513,7 +501,7 @@ when defined(windows):
       )
       if grp.useGso:
         for j in 0 ..< grp.count.int:
-          let s = addr specsArr[specOrder[orderPos + j].int]
+          let s = addr specsArr[first + j]
           bufPool[j] =
             WSABUF(len: culong(s.iov[].iov_len), buf: cast[ptr char](s.iov[].iov_base))
         msg.lpBuffers = addr bufPool[0]
@@ -545,28 +533,20 @@ when defined(windows):
           # a segmented datagram was oversized (path MTU shrank); resend its
           # members individually so lsquic can attribute the error per packet
           for j in 0 ..< grp.count.int:
-            let idx = specOrder[orderPos + j].int
+            let idx = p + j
             if sendOneSpec(quicCtx, specsArr[idx]) != 0:
-              let memberWsaErr = wsaGetLastError()
-              var minUnsent = idx
-              if g + 1 < ngroups:
-                minUnsent = min(minUnsent, groups[g + 1].firstSpec.int)
-              # exact attribution only when the failed spec is the first
-              # unsent one; otherwise defer via EAGAIN so it resurfaces later
-              if idx == minUnsent:
-                setSendErrno(memberWsaErr)
-              else:
-                cErrno = cEAGAIN
-              if minUnsent == 0:
+              # members are adjacent, so the failing one is the first unsent
+              # spec of the whole batch and takes the error verbatim
+              setSendErrno(wsaGetLastError())
+              if idx == 0:
                 return -1
-              return minUnsent.cint
-          orderPos += grp.count.int
+              return idx.cint
           inc g
           continue
-        if wsaErr == WSAEINVAL or wsaErr == WSAEOPNOTSUPP:
+        if wsaErr == WSAEINVAL or wsaErr == WSAEOPNOTSUPP or wsaErr == WSAENOPROTOOPT:
           # the stack rejected the segmented send: disable USO on this socket
           # for good and finish the batch unsegmented
-          quicCtx.gsoEnabled = false
+          quicCtx.gso.disable()
           let plainSent = sendPlain(quicCtx, specsArr, p, nspecs)
           if plainSent < 0:
             if p == 0:
@@ -578,7 +558,6 @@ when defined(windows):
           return -1
         return p.cint
 
-      orderPos += grp.count.int
       inc g
 
     nspecs.cint
@@ -592,6 +571,6 @@ proc sendPacketsOut*(
 
   let specsArr = cast[ptr UncheckedArray[struct_lsquic_out_spec]](specs)
   when defined(linux) or defined(windows):
-    if quicCtx.gsoEnabled and nspecs.int <= MaxBatch:
+    if quicCtx.gso.isEnabled() and nspecs.int <= MaxBatch:
       return sendSegmented(quicCtx, specsArr, nspecs.int)
   sendPlain(quicCtx, specsArr, 0, nspecs.int)

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -447,8 +447,9 @@ proc datagramTransport*(endpoint: QuicEndpoint): DatagramTransport {.raises: [].
   endpoint.udp
 
 proc segmentationOffloadActive*(endpoint: QuicEndpoint): bool {.raises: [].} =
-  ## True while UDP segmentation offload is in use on this endpoint's socket:
-  ## requested, supported by the probe, and not disabled by a later send error.
+  ## True while the endpoint socket uses UDP segmentation offload. The config
+  ## must ask for it, the probe must find support, and no send error must
+  ## disable it.
   endpoint.gso.isEnabled()
 
 proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -37,6 +37,7 @@ type
     clientContext: ClientContext
     connman: ConnectionManager
     udp: DatagramTransport
+    gsoEnabled: bool
     stopped: bool
     drainBuf: seq[byte]
 
@@ -81,19 +82,21 @@ proc configureReceiveBuffer(
       requestedBytes = requested, effectiveBytes = effective
 
 proc createServerContext(
-    tlsConfig: TLSConfig, fd: cint
+    tlsConfig: TLSConfig, fd: cint, gsoEnabled: bool
 ): ServerContext {.raises: [QuicError].} =
   var context = ServerContext.new(tlsConfig).valueOr:
     raise newException(QuicError, error)
   context.fd = fd
+  context.gsoEnabled = gsoEnabled
   context
 
 proc createClientContext(
-    tlsConfig: TLSConfig, fd: cint
+    tlsConfig: TLSConfig, fd: cint, gsoEnabled: bool
 ): ClientContext {.raises: [QuicError].} =
   var context = ClientContext.new(tlsConfig).valueOr:
     raise newException(QuicError, error)
   context.fd = fd
+  context.gsoEnabled = gsoEnabled
   context
 
 proc scidLen(endpoint: QuicEndpoint): cuint {.raises: [].} =
@@ -270,6 +273,8 @@ proc createUdp(
       raise newException(QuicError, "only IPv4/IPv6 address is supported")
 
   udp.configureReceiveBuffer(socketConfig)
+  endpoint.gsoEnabled =
+    socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
   udp
 
 proc createUdp(
@@ -290,6 +295,8 @@ proc createUdp(
       raise newException(QuicError, "endpoint supports only IPv4/IPv6 address")
 
   udp.configureReceiveBuffer(socketConfig)
+  endpoint.gsoEnabled =
+    socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
   udp
 
 proc new*(
@@ -321,7 +328,8 @@ proc new*(
         endpoint.udp.close()
 
   if CanListen in capabilities:
-    endpoint.serverContext = createServerContext(tlsConfig, cint(endpoint.udp.fd))
+    endpoint.serverContext =
+      createServerContext(tlsConfig, cint(endpoint.udp.fd), endpoint.gsoEnabled)
 
   initialized = true
   endpoint
@@ -347,8 +355,9 @@ proc ensureClientContext(
     raise newException(QuicError, "endpoint is not dial-capable")
 
   if endpoint.clientContext.isNil:
-    endpoint.clientContext =
-      createClientContext(endpoint.tlsConfig, cint(endpoint.udp.fd))
+    endpoint.clientContext = createClientContext(
+      endpoint.tlsConfig, cint(endpoint.udp.fd), endpoint.gsoEnabled
+    )
 
   endpoint.clientContext
 
@@ -435,6 +444,10 @@ proc localAddress*(
 
 proc datagramTransport*(endpoint: QuicEndpoint): DatagramTransport {.raises: [].} =
   endpoint.udp
+
+proc segmentationOffloadActive*(endpoint: QuicEndpoint): bool {.raises: [].} =
+  ## True when UDP segmentation offload was requested and the socket supports it.
+  endpoint.gsoEnabled
 
 proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =
   if endpoint.stopped:

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -273,8 +273,8 @@ proc createUdp(
       raise newException(QuicError, "only IPv4/IPv6 address is supported")
 
   udp.configureReceiveBuffer(socketConfig)
-  endpoint.gso = newSegmentationOffload(
-    socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
+  endpoint.gso = SegmentationOffload(
+    enabled: socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
   )
   udp
 
@@ -296,8 +296,8 @@ proc createUdp(
       raise newException(QuicError, "endpoint supports only IPv4/IPv6 address")
 
   udp.configureReceiveBuffer(socketConfig)
-  endpoint.gso = newSegmentationOffload(
-    socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
+  endpoint.gso = SegmentationOffload(
+    enabled: socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
   )
   udp
 
@@ -450,7 +450,7 @@ proc segmentationOffloadActive*(endpoint: QuicEndpoint): bool {.raises: [].} =
   ## True while the endpoint socket uses UDP segmentation offload. The config
   ## must ask for it, the probe must find support, and no send error must
   ## disable it.
-  endpoint.gso.isEnabled()
+  endpoint.gso.enabled
 
 proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =
   if endpoint.stopped:

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -37,7 +37,7 @@ type
     clientContext: ClientContext
     connman: ConnectionManager
     udp: DatagramTransport
-    gsoEnabled: bool
+    gso: SegmentationOffload
     stopped: bool
     drainBuf: seq[byte]
 
@@ -82,21 +82,21 @@ proc configureReceiveBuffer(
       requestedBytes = requested, effectiveBytes = effective
 
 proc createServerContext(
-    tlsConfig: TLSConfig, fd: cint, gsoEnabled: bool
+    tlsConfig: TLSConfig, fd: cint, gso: SegmentationOffload
 ): ServerContext {.raises: [QuicError].} =
   var context = ServerContext.new(tlsConfig).valueOr:
     raise newException(QuicError, error)
   context.fd = fd
-  context.gsoEnabled = gsoEnabled
+  context.gso = gso
   context
 
 proc createClientContext(
-    tlsConfig: TLSConfig, fd: cint, gsoEnabled: bool
+    tlsConfig: TLSConfig, fd: cint, gso: SegmentationOffload
 ): ClientContext {.raises: [QuicError].} =
   var context = ClientContext.new(tlsConfig).valueOr:
     raise newException(QuicError, error)
   context.fd = fd
-  context.gsoEnabled = gsoEnabled
+  context.gso = gso
   context
 
 proc scidLen(endpoint: QuicEndpoint): cuint {.raises: [].} =
@@ -273,8 +273,9 @@ proc createUdp(
       raise newException(QuicError, "only IPv4/IPv6 address is supported")
 
   udp.configureReceiveBuffer(socketConfig)
-  endpoint.gsoEnabled =
+  endpoint.gso = newSegmentationOffload(
     socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
+  )
   udp
 
 proc createUdp(
@@ -295,8 +296,9 @@ proc createUdp(
       raise newException(QuicError, "endpoint supports only IPv4/IPv6 address")
 
   udp.configureReceiveBuffer(socketConfig)
-  endpoint.gsoEnabled =
+  endpoint.gso = newSegmentationOffload(
     socketConfig.segmentationOffload and probeSegmentationOffload(udp.fd)
+  )
   udp
 
 proc new*(
@@ -329,7 +331,7 @@ proc new*(
 
   if CanListen in capabilities:
     endpoint.serverContext =
-      createServerContext(tlsConfig, cint(endpoint.udp.fd), endpoint.gsoEnabled)
+      createServerContext(tlsConfig, cint(endpoint.udp.fd), endpoint.gso)
 
   initialized = true
   endpoint
@@ -355,9 +357,8 @@ proc ensureClientContext(
     raise newException(QuicError, "endpoint is not dial-capable")
 
   if endpoint.clientContext.isNil:
-    endpoint.clientContext = createClientContext(
-      endpoint.tlsConfig, cint(endpoint.udp.fd), endpoint.gsoEnabled
-    )
+    endpoint.clientContext =
+      createClientContext(endpoint.tlsConfig, cint(endpoint.udp.fd), endpoint.gso)
 
   endpoint.clientContext
 
@@ -446,8 +447,9 @@ proc datagramTransport*(endpoint: QuicEndpoint): DatagramTransport {.raises: [].
   endpoint.udp
 
 proc segmentationOffloadActive*(endpoint: QuicEndpoint): bool {.raises: [].} =
-  ## True when UDP segmentation offload was requested and the socket supports it.
-  endpoint.gsoEnabled
+  ## True while UDP segmentation offload is in use on this endpoint's socket:
+  ## requested, supported by the probe, and not disabled by a later send error.
+  endpoint.gso.isEnabled()
 
 proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =
   if endpoint.stopped:

--- a/lsquic/socketconfig.nim
+++ b/lsquic/socketconfig.nim
@@ -3,13 +3,13 @@
 
 import ./errors
 
-type QuicSocketConfig* = object
-  receiveBufferBytes*: int
+const DefaultQuicReceiveBufferBytes* = 8 * 1024 * 1024
 
-const
-  DefaultQuicReceiveBufferBytes* = 8 * 1024 * 1024
-  DefaultQuicSocketConfig* =
-    QuicSocketConfig(receiveBufferBytes: DefaultQuicReceiveBufferBytes)
+type QuicSocketConfig* = object
+  receiveBufferBytes*: int = DefaultQuicReceiveBufferBytes
+  segmentationOffload*: bool = true
+
+const DefaultQuicSocketConfig* = QuicSocketConfig()
 
 proc validate*(config: QuicSocketConfig) {.raises: [QuicConfigError].} =
   if config.receiveBufferBytes < 0:

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -5,7 +5,7 @@
 
 import
   test_connection, test_perf, test_tlsconfig, test_verifier, test_lifecycle,
-  test_timeout, test_stress, test_runtime
+  test_timeout, test_stress, test_runtime, test_gso
 
 from ./helpers/trackers import finalCheckTrackers
 finalCheckTrackers()

--- a/tests/test_gso.nim
+++ b/tests/test_gso.nim
@@ -46,35 +46,41 @@ proc build(
       iovecs[k] = struct_iovec(iov_base: nil, iov_len: csize_t(size))
       inc k
 
+proc checkGroupInvariants(
+    groups: array[MaxBatch, GsoGroup], ngroups: int, nspecs: int
+) =
+  ## Properties every grouping must hold regardless of input. The first is what
+  ## the send path's prefix accounting rests on: groups tile specs[0 ..< nspecs]
+  ## contiguously and in order, so groups[k].firstSpec is exactly the number of
+  ## specs preceding group k. The rest keep a segmented send within what the
+  ## kernel will accept.
+  var next = 0
+  for g in 0 ..< ngroups:
+    check groups[g].firstSpec.int == next
+    check groups[g].count.int >= 1
+    next += groups[g].count.int
+    if groups[g].useGso:
+      check groups[g].count.int <= MaxGsoSegments
+      check groups[g].totalBytes.int <= MaxGsoBytes
+  check next == nspecs
+
 proc run(
     dests: var seq[Sockaddr_storage],
     defs: seq[SpecDef],
     groups: var array[MaxBatch, GsoGroup],
-    order: var array[MaxBatch, uint16],
 ): int =
   var
     iovecs: seq[struct_iovec]
     specs: seq[struct_lsquic_out_spec]
   build(dests, defs, iovecs, specs)
-  groupSpecs(
-    cast[ptr UncheckedArray[struct_lsquic_out_spec]](addr specs[0]),
-    specs.len,
-    groups,
-    order,
+  result = groupSpecs(
+    cast[ptr UncheckedArray[struct_lsquic_out_spec]](addr specs[0]), specs.len, groups
   )
+  checkGroupInvariants(groups, result, specs.len)
 
-proc members(
-    groups: array[MaxBatch, GsoGroup], order: array[MaxBatch, uint16], g: int
-): seq[int] =
-  var start = 0
-  for k in 0 ..< g:
-    start += groups[k].count.int
+proc members(groups: array[MaxBatch, GsoGroup], g: int): seq[int] =
   for j in 0 ..< groups[g].count.int:
-    result.add order[start + j].int
-
-proc checkAscendingFirstSpec(groups: array[MaxBatch, GsoGroup], ngroups: int) =
-  for g in 1 ..< ngroups:
-    check groups[g].firstSpec > groups[g - 1].firstSpec
+    result.add groups[g].firstSpec.int + j
 
 suite "gso grouping":
   setup:
@@ -83,39 +89,61 @@ suite "gso grouping":
         makeAddr("127.0.0.1:1001"), makeAddr("127.0.0.1:1002"), makeAddr("[::1]:1003")
       ]
       groups: array[MaxBatch, GsoGroup]
-      order: array[MaxBatch, uint16]
 
-  test "round-robin interleave collapses to one group per destination":
+  test "adjacent packets to one destination form a single group":
+    var defs: seq[SpecDef]
+    for _ in 0 ..< 4:
+      defs.add spec(0, 1200)
+    let n = run(dests, defs, groups)
+
+    check n == 1
+    check groups[0].count == 4
+    check groups[0].segSize == 1200
+    check groups[0].totalBytes == 4800
+    check groups[0].useGso
+    check members(groups, 0) == @[0, 1, 2, 3]
+
+  test "interleaved destinations do not group":
     var defs: seq[SpecDef]
     for _ in 0 ..< 3:
       for d in 0 ..< 3:
         defs.add spec(d, 1200)
-    let n = run(dests, defs, groups, order)
+    let n = run(dests, defs, groups)
+
+    # Only adjacent specs are grouped, so a round-robin batch yields solo
+    # groups; the send path falls back to plain sendmmsg for them.
+    check n == 9
+    for g in 0 ..< n:
+      check groups[g].count == 1
+      check not groups[g].useGso
+
+  test "a run resumes after an interruption from another destination":
+    let defs =
+      @[spec(0, 1200), spec(0, 1200), spec(1, 1200), spec(0, 1200), spec(0, 1200)]
+    let n = run(dests, defs, groups)
 
     check n == 3
-    for g in 0 ..< n:
-      check groups[g].count == 3
-      check groups[g].segSize == 1200
-      check groups[g].useGso
-    check members(groups, order, 0) == @[0, 3, 6]
-    check members(groups, order, 1) == @[1, 4, 7]
-    check members(groups, order, 2) == @[2, 5, 8]
-    checkAscendingFirstSpec(groups, n)
+    check members(groups, 0) == @[0, 1]
+    check members(groups, 1) == @[2]
+    check members(groups, 2) == @[3, 4]
+    check groups[0].useGso
+    check not groups[1].useGso
+    check groups[2].useGso
 
   test "trailing shorter segment joins and closes the group":
     let defs = @[spec(0, 1200), spec(0, 1200), spec(0, 600), spec(0, 1200)]
-    let n = run(dests, defs, groups, order)
+    let n = run(dests, defs, groups)
 
     check n == 2
     check groups[0].count == 3
     check groups[0].totalBytes == 3000
     check groups[1].firstSpec == 3
     check groups[1].count == 1
-    check members(groups, order, 0) == @[0, 1, 2]
+    check members(groups, 0) == @[0, 1, 2]
 
   test "larger packet closes the group and starts its own":
     let defs = @[spec(0, 1200), spec(0, 1500), spec(0, 1500)]
-    let n = run(dests, defs, groups, order)
+    let n = run(dests, defs, groups)
 
     check n == 2
     check groups[0].count == 1
@@ -123,58 +151,71 @@ suite "gso grouping":
     check groups[1].firstSpec == 1
     check groups[1].count == 2
     check groups[1].segSize == 1500
-    checkAscendingFirstSpec(groups, n)
 
   test "segment count cap splits a destination":
     var defs: seq[SpecDef]
     for _ in 0 ..< MaxGsoSegments + 1:
       defs.add spec(0, 500)
-    let n = run(dests, defs, groups, order)
+    let n = run(dests, defs, groups)
 
     check n == 2
     check groups[0].count == MaxGsoSegments
     check groups[1].count == 1
 
-  test "byte cap splits a destination":
+  test "byte cap splits a destination below the kernel limit":
+    # 62 * 1040 = 64480; a 63rd segment would reach 65520, past the 65507 a
+    # single IPv4 datagram can carry - the kernel rejects the whole send with
+    # EMSGSIZE, so the group must close first.
     var defs: seq[SpecDef]
-    for _ in 0 ..< 46:
-      defs.add spec(0, 1472)
-    let n = run(dests, defs, groups, order)
+    for _ in 0 ..< 63:
+      defs.add spec(0, 1040)
+    let n = run(dests, defs, groups)
 
-    # 44 * 1472 = 64768; another full segment would exceed 65535
     check n == 2
-    check groups[0].count == 44
-    check groups[0].totalBytes == 64768
-    check groups[1].count == 2
+    check groups[0].count == 62
+    check groups[0].totalBytes == 64480
+    check groups[1].count == 1
 
   test "coalesced multi-iovec spec forms a solo group":
     let defs = @[spec(0, 1200), coalesced(0, @[500, 700]), spec(0, 1200)]
-    let n = run(dests, defs, groups, order)
+    let n = run(dests, defs, groups)
 
-    check n == 2
-    check groups[0].count == 2
-    check groups[0].useGso
-    check groups[1].firstSpec == 1
+    check n == 3
     check groups[1].count == 1
     check not groups[1].useGso
-    check members(groups, order, 0) == @[0, 2]
-    check members(groups, order, 1) == @[1]
-    checkAscendingFirstSpec(groups, n)
+    check members(groups, 1) == @[1]
 
   test "differing ecn splits groups":
-    let defs = @[spec(0, 1200, ecn = 0), spec(0, 1200, ecn = 2), spec(0, 1200, ecn = 0)]
-    let n = run(dests, defs, groups, order)
+    let defs = @[spec(0, 1200, ecn = 0), spec(0, 1200, ecn = 2), spec(0, 1200, ecn = 2)]
+    let n = run(dests, defs, groups)
 
     check n == 2
-    check groups[0].count == 2
-    check members(groups, order, 0) == @[0, 2]
-    check groups[1].count == 1
+    check groups[0].count == 1
+    check groups[1].count == 2
+    check members(groups, 1) == @[1, 2]
 
   test "ipv4 and ipv6 destinations never merge":
-    let defs = @[spec(0, 1200), spec(2, 1200), spec(0, 1200), spec(2, 1200)]
-    let n = run(dests, defs, groups, order)
+    let defs = @[spec(0, 1200), spec(0, 1200), spec(2, 1200), spec(2, 1200)]
+    let n = run(dests, defs, groups)
 
     check n == 2
-    check groups[0].count == 2
-    check groups[1].count == 2
-    check members(groups, order, 1) == @[1, 3]
+    check members(groups, 0) == @[0, 1]
+    check members(groups, 1) == @[2, 3]
+
+  test "a full MaxBatch batch groups without overflowing":
+    var defs: seq[SpecDef]
+    for _ in 0 ..< MaxBatch:
+      defs.add spec(0, 1200)
+    let n = run(dests, defs, groups)
+
+    # 54 * 1200 = 64800, and a 55th segment would exceed the byte cap
+    check n == 19
+    check groups[0].count == 54
+
+  test "a full MaxBatch batch of interleaved destinations is all solo groups":
+    var defs: seq[SpecDef]
+    for i in 0 ..< MaxBatch:
+      defs.add spec(i mod 3, 1200)
+    let n = run(dests, defs, groups)
+
+    check n == MaxBatch

--- a/tests/test_gso.nim
+++ b/tests/test_gso.nim
@@ -49,11 +49,8 @@ proc build(
 proc checkGroupInvariants(
     groups: array[MaxBatch, GsoGroup], ngroups: int, nspecs: int
 ) =
-  ## Properties every grouping must hold regardless of input. The first is what
-  ## the send path's prefix accounting rests on: groups tile specs[0 ..< nspecs]
-  ## contiguously and in order, so groups[k].firstSpec is exactly the number of
-  ## specs preceding group k. The rest keep a segmented send within what the
-  ## kernel will accept.
+  ## Checks the properties that every result must have. The send path depends
+  ## on the coverage check to report a correct prefix count.
   var next = 0
   for g in 0 ..< ngroups:
     check groups[g].firstSpec.int == next
@@ -110,8 +107,7 @@ suite "gso grouping":
         defs.add spec(d, 1200)
     let n = run(dests, defs, groups)
 
-    # Only adjacent specs are grouped, so a round-robin batch yields solo
-    # groups; the send path falls back to plain sendmmsg for them.
+    # the send path uses plain sendmmsg for solo groups
     check n == 9
     for g in 0 ..< n:
       check groups[g].count == 1
@@ -163,9 +159,9 @@ suite "gso grouping":
     check groups[1].count == 1
 
   test "byte cap splits a destination below the kernel limit":
-    # 62 * 1040 = 64480; a 63rd segment would reach 65520, past the 65507 a
-    # single IPv4 datagram can carry - the kernel rejects the whole send with
-    # EMSGSIZE, so the group must close first.
+    # 62 * 1040 = 64480 bytes. A 63rd segment gives 65520 bytes. One IPv4
+    # datagram holds 65507 bytes, so the kernel refuses the whole send with
+    # EMSGSIZE. The group must close first.
     var defs: seq[SpecDef]
     for _ in 0 ..< 63:
       defs.add spec(0, 1040)
@@ -208,7 +204,7 @@ suite "gso grouping":
       defs.add spec(0, 1200)
     let n = run(dests, defs, groups)
 
-    # 54 * 1200 = 64800, and a 55th segment would exceed the byte cap
+    # 54 * 1200 = 64800 bytes. A 55th segment is more than the byte limit.
     check n == 19
     check groups[0].count == 54
 

--- a/tests/test_gso.nim
+++ b/tests/test_gso.nim
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos, chronos/osdefs, chronos/unittest2/asynctests
+import ../lsquic/context/gso
+import ../lsquic/lsquic_ffi
+
+type SpecDef = object
+  dest: int
+  sizes: seq[int] # one iovec per entry; len > 1 means a coalesced datagram
+  ecn: int
+
+proc spec(dest: int, size: int, ecn = 0): SpecDef =
+  SpecDef(dest: dest, sizes: @[size], ecn: ecn)
+
+proc coalesced(dest: int, sizes: seq[int]): SpecDef =
+  SpecDef(dest: dest, sizes: sizes)
+
+proc makeAddr(address: string): Sockaddr_storage =
+  var length: SockLen
+  initTAddress(address).toSAddr(result, length)
+
+proc build(
+    dests: var seq[Sockaddr_storage],
+    defs: seq[SpecDef],
+    iovecs: var seq[struct_iovec],
+    specs: var seq[struct_lsquic_out_spec],
+) =
+  var total = 0
+  for d in defs:
+    total += d.sizes.len
+  iovecs = newSeq[struct_iovec](total)
+  specs = newSeq[struct_lsquic_out_spec](defs.len)
+
+  var k = 0
+  for i, d in defs:
+    specs[i] = struct_lsquic_out_spec(
+      iov: addr iovecs[k],
+      iovlen: csize_t(d.sizes.len),
+      dest_sa: cast[ptr SockAddr](addr dests[d.dest]),
+      ecn: cint(d.ecn),
+    )
+    for size in d.sizes:
+      iovecs[k] = struct_iovec(iov_base: nil, iov_len: csize_t(size))
+      inc k
+
+proc run(
+    dests: var seq[Sockaddr_storage],
+    defs: seq[SpecDef],
+    groups: var array[MaxBatch, GsoGroup],
+    order: var array[MaxBatch, uint16],
+): int =
+  var
+    iovecs: seq[struct_iovec]
+    specs: seq[struct_lsquic_out_spec]
+  build(dests, defs, iovecs, specs)
+  groupSpecs(
+    cast[ptr UncheckedArray[struct_lsquic_out_spec]](addr specs[0]),
+    specs.len,
+    groups,
+    order,
+  )
+
+proc members(
+    groups: array[MaxBatch, GsoGroup], order: array[MaxBatch, uint16], g: int
+): seq[int] =
+  var start = 0
+  for k in 0 ..< g:
+    start += groups[k].count.int
+  for j in 0 ..< groups[g].count.int:
+    result.add order[start + j].int
+
+proc checkAscendingFirstSpec(groups: array[MaxBatch, GsoGroup], ngroups: int) =
+  for g in 1 ..< ngroups:
+    check groups[g].firstSpec > groups[g - 1].firstSpec
+
+suite "gso grouping":
+  setup:
+    var
+      dests = @[
+        makeAddr("127.0.0.1:1001"), makeAddr("127.0.0.1:1002"), makeAddr("[::1]:1003")
+      ]
+      groups: array[MaxBatch, GsoGroup]
+      order: array[MaxBatch, uint16]
+
+  test "round-robin interleave collapses to one group per destination":
+    var defs: seq[SpecDef]
+    for _ in 0 ..< 3:
+      for d in 0 ..< 3:
+        defs.add spec(d, 1200)
+    let n = run(dests, defs, groups, order)
+
+    check n == 3
+    for g in 0 ..< n:
+      check groups[g].count == 3
+      check groups[g].segSize == 1200
+      check groups[g].useGso
+    check members(groups, order, 0) == @[0, 3, 6]
+    check members(groups, order, 1) == @[1, 4, 7]
+    check members(groups, order, 2) == @[2, 5, 8]
+    checkAscendingFirstSpec(groups, n)
+
+  test "trailing shorter segment joins and closes the group":
+    let defs = @[spec(0, 1200), spec(0, 1200), spec(0, 600), spec(0, 1200)]
+    let n = run(dests, defs, groups, order)
+
+    check n == 2
+    check groups[0].count == 3
+    check groups[0].totalBytes == 3000
+    check groups[1].firstSpec == 3
+    check groups[1].count == 1
+    check members(groups, order, 0) == @[0, 1, 2]
+
+  test "larger packet closes the group and starts its own":
+    let defs = @[spec(0, 1200), spec(0, 1500), spec(0, 1500)]
+    let n = run(dests, defs, groups, order)
+
+    check n == 2
+    check groups[0].count == 1
+    check not groups[0].useGso
+    check groups[1].firstSpec == 1
+    check groups[1].count == 2
+    check groups[1].segSize == 1500
+    checkAscendingFirstSpec(groups, n)
+
+  test "segment count cap splits a destination":
+    var defs: seq[SpecDef]
+    for _ in 0 ..< MaxGsoSegments + 1:
+      defs.add spec(0, 500)
+    let n = run(dests, defs, groups, order)
+
+    check n == 2
+    check groups[0].count == MaxGsoSegments
+    check groups[1].count == 1
+
+  test "byte cap splits a destination":
+    var defs: seq[SpecDef]
+    for _ in 0 ..< 46:
+      defs.add spec(0, 1472)
+    let n = run(dests, defs, groups, order)
+
+    # 44 * 1472 = 64768; another full segment would exceed 65535
+    check n == 2
+    check groups[0].count == 44
+    check groups[0].totalBytes == 64768
+    check groups[1].count == 2
+
+  test "coalesced multi-iovec spec forms a solo group":
+    let defs = @[spec(0, 1200), coalesced(0, @[500, 700]), spec(0, 1200)]
+    let n = run(dests, defs, groups, order)
+
+    check n == 2
+    check groups[0].count == 2
+    check groups[0].useGso
+    check groups[1].firstSpec == 1
+    check groups[1].count == 1
+    check not groups[1].useGso
+    check members(groups, order, 0) == @[0, 2]
+    check members(groups, order, 1) == @[1]
+    checkAscendingFirstSpec(groups, n)
+
+  test "differing ecn splits groups":
+    let defs = @[spec(0, 1200, ecn = 0), spec(0, 1200, ecn = 2), spec(0, 1200, ecn = 0)]
+    let n = run(dests, defs, groups, order)
+
+    check n == 2
+    check groups[0].count == 2
+    check members(groups, order, 0) == @[0, 2]
+    check groups[1].count == 1
+
+  test "ipv4 and ipv6 destinations never merge":
+    let defs = @[spec(0, 1200), spec(2, 1200), spec(0, 1200), spec(2, 1200)]
+    let n = run(dests, defs, groups, order)
+
+    check n == 2
+    check groups[0].count == 2
+    check groups[1].count == 2
+    check members(groups, order, 1) == @[1, 3]

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -91,6 +91,34 @@ suite "runtime":
 
     check endpoint.datagramTransport().socketReceiveBufferBytes() >= requested
 
+  asyncTest "segmentation offload probe reflects platform support":
+    cleanupLsquic()
+    initializeLsquic(true, true)
+    let endpoint = QuicEndpoint.new(makeTLSConfig(), AutoAddressIP4)
+    defer:
+      await endpoint.stop()
+      cleanupLsquic()
+
+    when defined(linux) or defined(windows):
+      check endpoint.segmentationOffloadActive()
+    else:
+      check not endpoint.segmentationOffloadActive()
+
+  asyncTest "segmentation offload can be disabled":
+    cleanupLsquic()
+    initializeLsquic(true, true)
+    let endpoint = QuicEndpoint.new(
+      makeTLSConfig(),
+      AutoAddressIP4,
+      {CanListen, CanDial},
+      QuicSocketConfig(segmentationOffload: false),
+    )
+    defer:
+      await endpoint.stop()
+      cleanupLsquic()
+
+    check not endpoint.segmentationOffloadActive()
+
   test "negative socket receive buffer is rejected":
     expect QuicConfigError:
       discard QuicEndpoint.new(


### PR DESCRIPTION
## Summary

Adds UDP segmentation offload for QUIC sends. When the socket supports it, packets that share a destination can go out as one segmented UDP datagram using Linux `UDP_SEGMENT` or Windows `UDP_SEND_MSG_SIZE`.

This reduces kernel per-packet work, not syscall count: `sendmmsg` already batches roughly 25 messages per call.

The grouping logic only combines adjacent specs with the same destination, ECN, and segment size. That keeps each group as a contiguous range, so the send path can still return a true prefix count to lsquic. With eight concurrent connections, 94% of packets were still sent segmented, with 23.1 segments per group on average.

## Measurements

100 MB over loopback, release build, three runs each unless noted:

| Scenario | GSO off | GSO on | Result |
| --- | --- | --- | --- |
| 1 connection (`test_perf`) | 1.19 / 1.20 / 1.20 s | 1.01 / 1.02 / 1.05 s | ~14% faster |
| 8 concurrent connections | 1.16 / 1.13 / 1.13 s | 0.97 / 1.05 s | ~12% faster |

## Impact on Library Users

UDP segmentation offload is enabled by default when the platform and socket support it. Users can turn it off with `QuicSocketConfig(segmentationOffload: false)`.

The gain scales with how many packets one write produces on one connection. A large write becomes a single segmented datagram, while small request/response messages produce about one packet per send call and see no change either way.

Unsupported sockets and platforms continue using normal sends. If the kernel rejects a segmented send with `EIO`, `EINVAL`, or `ENOTSUP`, offload is disabled for that socket and the batch is retried without segmentation.

## Risk Assessment

The implementation keeps lsquic's prefix-count contract by grouping only adjacent packets. Groups stop at `UDP_MAX_SEGMENTS`, 65507 bytes, or when a larger packet appears; one trailing shorter segment is allowed.

lsquic takes one packet per connection per pass when filling a batch, so connections sending at once can interleave and leave no adjacent runs to group (discussed upstream in litespeedtech/lsquic#669). That does not happen today because stream writes tick the engine synchronously, so each flush carries the packets of the one connection that just wrote: 97% of send calls in the eight-connection run had a single destination. Coalescing those ticks, the way the receive path now coalesces datagrams, would mix connections into one batch and turn every group into a solo send: offload would stop helping, nothing else would change. If that is done, gate it on write size. A write large enough to segment should keep flushing on its own, while small writes have nothing to segment and can be coalesced freely.

`EMSGSIZE` on a segmented send is handled by resending that group's packets one at a time, so lsquic can attribute the failure to a single packet and adjust MTU.

The Windows USO path is covered by `nim check --os:windows` and the Windows CI job, but the performance measurements are from Linux loopback runs.



