### PR TITLE
perf: drain the UDP socket per wakeup instead of ticking per datagram

### DIFF
--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -94,15 +94,17 @@ when not defined(windows):
         msg_flags: 0,
       )
 
-proc receive*(
+proc packetIn*(
     ctx: QuicContext,
     data: openArray[byte],
     local: TransportAddress,
     remote: TransportAddress,
     ecn: cint = 0,
-) =
+): bool {.discardable.} =
+  ## Returns false when the engine did not take the datagram, so that a caller
+  ## draining a burst knows whether it has to tick at all.
   if data.len == 0 or not ctx.isRunning():
-    return
+    return false
 
   var
     localAddress: Sockaddr_storage
@@ -123,7 +125,20 @@ proc receive*(
     ecn,
   )
 
-  ctx.processWhenReady()
+  true
+
+proc receive*(
+    ctx: QuicContext,
+    data: openArray[byte],
+    local: TransportAddress,
+    remote: TransportAddress,
+    ecn: cint = 0,
+) =
+  ## With several datagrams in hand, prefer `packetIn` and one
+  ## `processWhenReady`: lsquic picks what to send once per tick, so a tick per
+  ## datagram is a send batch per datagram.
+  if ctx.packetIn(data, local, remote, ecn):
+    ctx.processWhenReady()
 
 proc receive*(
     ctx: QuicContext,

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -12,6 +12,12 @@ import
     socketconfig,
   ]
 import ./context/[server, client, context, io]
+import ./helpers/transportaddr
+from chronos/osdefs import Sockaddr_storage, SockAddr, SockLen, SocketHandle
+when defined(windows):
+  from std/winlean import recvfrom
+else:
+  from chronos/osdefs import recvfrom
 
 type
   QuicEndpointCapability* = enum
@@ -19,6 +25,10 @@ type
     CanDial
 
   QuicEndpointCapabilities* = set[QuicEndpointCapability]
+
+  RouteTarget = enum
+    rtClient
+    rtServer
 
   QuicEndpoint* = ref object of RootObj
     tlsConfig: TLSConfig
@@ -28,8 +38,13 @@ type
     connman: ConnectionManager
     udp: DatagramTransport
     stopped: bool
+    drainBuf: seq[byte]
 
-const CloseWait: Duration = 300.milliseconds
+const
+  CloseWait: Duration = 300.milliseconds
+
+  MaxDatagramsPerWakeup = 64
+    ## Capped so that a busy socket cannot starve the rest of the event loop.
 
 proc socketReceiveBufferBytes(
     udp: DatagramTransport
@@ -117,11 +132,11 @@ func isIetfInitial(packet: openArray[byte]): bool {.raises: [].} =
     return false
   (packet[0] and 0xC0'u8) == 0xC0'u8 and (packet[0] and 0x30'u8) == 0
 
-proc receiveDatagram(
+proc routeDatagram(
     endpoint: QuicEndpoint, data: openArray[byte], local, remote: TransportAddress
-) {.raises: [].} =
+): set[RouteTarget] {.raises: [].} =
   if endpoint.isNil or endpoint.stopped:
-    return
+    return {}
 
   let
     hasClientContext = not endpoint.clientContext.isNil
@@ -131,44 +146,112 @@ proc receiveDatagram(
   if endpoint.packetDcid(data, cid):
     if hasClientContext and endpoint.clientContext.ownsCid(cid):
       trace "Routing datagram to client context", cid
-      endpoint.clientContext.receive(data, local, remote)
-      return
+      endpoint.clientContext.packetIn(data, local, remote)
+      return {rtClient}
 
     if hasServerContext and endpoint.serverContext.ownsCid(cid):
       trace "Routing datagram to server context", cid
-      endpoint.serverContext.receive(data, local, remote)
-      return
+      endpoint.serverContext.packetIn(data, local, remote)
+      return {rtServer}
 
   if hasClientContext and not hasServerContext:
-    endpoint.clientContext.receive(data, local, remote)
-    return
+    endpoint.clientContext.packetIn(data, local, remote)
+    return {rtClient}
 
   if hasServerContext and not hasClientContext:
-    endpoint.serverContext.receive(data, local, remote)
-    return
+    endpoint.serverContext.packetIn(data, local, remote)
+    return {rtServer}
 
   if hasServerContext and data.isIetfInitial():
     trace "Routing initial datagram with unknown CID to server context",
       bytes = data.len, local, remote
-    endpoint.serverContext.receive(data, local, remote)
-    return
+    endpoint.serverContext.packetIn(data, local, remote)
+    return {rtServer}
 
   trace "Dropping datagram with unknown CID", bytes = data.len, local, remote
+  {}
+
+proc recvDatagram(
+    fd: SocketHandle,
+    buf: var seq[byte],
+    remoteAddress: var Sockaddr_storage,
+    remoteAddrLen: var SockLen,
+): int {.raises: [].} =
+  when defined(windows):
+    recvfrom(
+      fd,
+      cast[cstring](addr buf[0]),
+      cint(buf.len),
+      cint(0),
+      cast[ptr SockAddr](addr remoteAddress),
+      addr remoteAddrLen,
+    ).int
+  else:
+    recvfrom(
+      fd,
+      addr buf[0],
+      buf.len,
+      cint(0),
+      cast[ptr SockAddr](addr remoteAddress),
+      addr remoteAddrLen,
+    ).int
+
+proc drainDatagrams(
+    endpoint: QuicEndpoint, udp: DatagramTransport, local: TransportAddress
+): set[RouteTarget] {.raises: [].} =
+  ## Chronos hands this callback a single datagram per event-loop wakeup, so
+  ## whatever else has already arrived is read here rather than one wakeup, and
+  ## one engine tick, at a time.
+  if endpoint.drainBuf.len == 0:
+    endpoint.drainBuf = newSeq[byte](DefaultDatagramBufferSize)
+
+  var count = 0
+  while count < MaxDatagramsPerWakeup:
+    var
+      remoteAddress: Sockaddr_storage
+      remoteAddrLen = SockLen(sizeof(Sockaddr_storage))
+    let res = recvDatagram(
+      SocketHandle(udp.fd), endpoint.drainBuf, remoteAddress, remoteAddrLen
+    )
+    if res < 0:
+      # Empty, or an error the transport will report again on the next wakeup.
+      break
+
+    inc count
+    if res > 0:
+      result =
+        result +
+        endpoint.routeDatagram(
+          endpoint.drainBuf.toOpenArray(0, res - 1),
+          local,
+          toTransportAddress(cast[ptr SockAddr](addr remoteAddress)),
+        )
 
 proc receiveFromUdp(
     endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress
 ) {.raises: [].} =
+  var
+    targets: set[RouteTarget]
+    local: TransportAddress
+
   try:
     var
       msg: seq[byte]
       msgLen: int
+    local = udp.localAddress()
     udp.peekMessage(msg, msgLen)
     if msgLen > 0:
-      endpoint.receiveDatagram(
-        msg.toOpenArray(0, msgLen - 1), udp.localAddress(), remote
-      )
+      targets = endpoint.routeDatagram(msg.toOpenArray(0, msgLen - 1), local, remote)
   except TransportError as e:
     warn "Could not read received datagram", errorMsg = e.msg
+    return
+
+  targets = targets + endpoint.drainDatagrams(udp, local)
+
+  if rtClient in targets:
+    endpoint.clientContext.processWhenReady()
+  if rtServer in targets:
+    endpoint.serverContext.processWhenReady()
 
 proc createUdp(
     endpoint: QuicEndpoint, address: TransportAddress, socketConfig: QuicSocketConfig

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -205,8 +205,8 @@ proc drainDatagrams(
   if endpoint.drainBuf.len == 0:
     endpoint.drainBuf = newSeq[byte](DefaultDatagramBufferSize)
 
-  var count = 0
-  while count < MaxDatagramsPerWakeup:
+  var targets: set[RouteTarget]
+  for _ in 0 ..< MaxDatagramsPerWakeup:
     var
       remoteAddress: Sockaddr_storage
       remoteAddrLen = SockLen(sizeof(Sockaddr_storage))
@@ -217,15 +217,14 @@ proc drainDatagrams(
       # Empty, or an error the transport will report again on the next wakeup.
       break
 
-    inc count
     if res > 0:
-      result =
-        result +
-        endpoint.routeDatagram(
-          endpoint.drainBuf.toOpenArray(0, res - 1),
-          local,
-          toTransportAddress(cast[ptr SockAddr](addr remoteAddress)),
-        )
+      targets.incl endpoint.routeDatagram(
+        endpoint.drainBuf.toOpenArray(0, res - 1),
+        local,
+        toTransportAddress(cast[ptr SockAddr](addr remoteAddress)),
+      )
+
+  targets
 
 proc receiveFromUdp(
     endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress


### PR DESCRIPTION
## Problem

Chronos delivers **one datagram per event-loop wakeup**: its POSIX `readDatagramLoop` does a single `recvfrom` and returns (the `while true` breaks unconditionally; `continue` only on `EINTR`). Our receive path then called `lsquic_engine_process_conns()` for that one datagram.

lsquic decides what to send once per tick, so `ea_packets_out()` was being handed two or three packets at a time no matter how much traffic was queued — which is also why GSO has had nothing to coalesce. Confirmed by upstream in litespeedtech/lsquic#669:

> The normal pattern is to drain all currently available datagrams, pass each to `lsquic_engine_packet_in()`, and then call `lsquic_engine_process_conns()` once. […] If your read handler reads only one datagram before processing, changing it to drain several datagrams first may improve batching.

Note that deferring the tick alone would not have helped: with one datagram per wakeup there is a full poll cycle between datagrams, so the read loop itself has to drain.

## Change

- `packetIn()` is split out of `receive()`: it hands a datagram to the engine without ticking it. `receive()` keeps its previous behaviour (feed + tick) for callers that only have one datagram.
- `receiveFromUdp` takes the datagram chronos handed it, drains whatever else is already on the socket, and then ticks each context **once**.
- `receiveDatagram` becomes `routeDatagram` and returns which context took the datagram, since the client and server contexts share the socket but have separate engines.

## Measurements

Over the 100 MB transfer in `tests/test_perf`, release build. A/B'd on one build by setting the drain cap to 0, which reproduces the old path exactly; two runs each, variance ±0.1 s:

|                        | before  | after |
| ---------------------- | ------- | ----- |
| wakeups                | 107,596 | 1,641 |
| datagrams per wakeup   | 1.0     | 43.6  |
| `ea_packets_out` calls | 40,045  | 2,823 |
| **packets per call**   | **2.69**| **25.4** |
| wall clock             | 5.5 s   | 1.0 s |

Debug build shows the same shape (17.1 s → 1.6 s).

## Notes

- The drain is capped at 64 datagrams per wakeup so a busy socket cannot starve the rest of the event loop. Stopping early loses nothing: the reader stays level-triggered, so anything left is reported on the next wakeup. That is also why reading behind chronos's back is safe — we do not touch its state, and it re-checks readability.
- The buffer is 64 KB (`DefaultDatagramBufferSize`), so truncation behaviour is unchanged. It is allocated on first use rather than in the constructors, because `addr buf[0]` on an empty seq would be silent UB in a release build if a future constructor forgot the field.
- `chronos/osdefs` does not export `recvfrom` on Windows, so there is a small `recvDatagram` wrapper over winlean's variant (`cstring` buffer, `cint` length). 
- Latency: the first datagram of a burst now waits for the rest to be read, but the drain is synchronous with no I/O wait, so that is microseconds.
- `es_pace_packets = 1` is still hardcoded in `client.nim`/`server.nim`. Upstream notes that disabling pacing changes transport behaviour and should be tested carefully, so that stays a separate discussion — with 25-packet batches it may not be needed.

