### PR TITLE
test: routing

### DIFF
--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -315,3 +315,6 @@ proc stop*(endpoint: QuicEndpoint) {.async: (raises: [CancelledError]).} =
   if not endpoint.serverContext.isNil:
     endpoint.serverContext.destroy()
     endpoint.serverContext = nil
+
+when defined(lsquic_testing):
+  export scidLen, packetDcid, isIetfInitial

--- a/lsquic/lsquic_ffi_types.nim
+++ b/lsquic/lsquic_ffi_types.nim
@@ -88,8 +88,7 @@ type
   struct_lsquic_cid* {.
     importc: "struct lsquic_cid", header: "lsquic_types.h", bycopy, completeStruct
   .} = object
-    buf* {.importc: "buf".}: array[MAX_CID_LEN, uint8]
+    buf* {.importc: "buf", align: 8.}: array[MAX_CID_LEN, uint8]
     len* {.importc: "len".}: uint_fast8_t
-    padding: array[3, uint8]
 
   lsquic_cid_t* = struct_lsquic_cid

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,1 +1,2 @@
---path=".."
+--path = ".."
+-d:lsquic_testing

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -5,4 +5,4 @@
 
 import
   test_connection, test_perf, test_tlsconfig, test_verifier, test_lifecycle,
-  test_timeout, test_stress, test_runtime
+  test_timeout, test_stress, test_runtime, test_routing

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -4,7 +4,7 @@
 ## Tests for CID ownership and datagram header parsing - the inputs
 ## `receiveDatagram` uses to pick the context a datagram belongs to.
 ##
-## `scidLen`, `packetDcid` and `isIetfInitial` are internal; `-d:lsquic_testing`
+## `packetDcid` and `isIetfInitial` are internal; `-d:lsquic_testing`
 ## (set in tests/nim.cfg) publishes them, so they are asserted directly instead
 ## of through a handshake that would only fail as a timeout.
 
@@ -60,13 +60,11 @@ func toCidKey(bytes: openArray[byte]): CidKey =
   key
 
 func nativeCids(cids: openArray[seq[byte]]): seq[lsquic_cid_t] =
-  ## `len` is copied verbatim even when it overstates lsquic's fixed buffer -
-  ## an oversized length is exactly what the length guard has to reject.
   var native = newSeq[lsquic_cid_t](cids.len)
   for i, cid in cids:
     native[i].len = cid.len.uint8
-    for j in 0 ..< min(cid.len, MAX_CID_LEN):
-      native[i].buf[j] = cid[j]
+    for j, b in cid:
+      native[i].buf[j] = b
   native
 
 proc own(ctx: QuicContext, cids: varargs[seq[byte]]) =
@@ -143,45 +141,23 @@ suite "cid ownership":
       # a longer cid sharing that prefix is a different connection
       not ctx.ownsCid(toCidKey([0xA0'u8, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7]))
 
-  test "cid lengths outside 1..MAX_CID_LEN are rejected":
-    for cidLen in [0, 1, MAX_CID_LEN, MAX_CID_LEN + 1]:
+  test "cids at both ends of the length range are tracked":
+    for cidLen in [1, MAX_CID_LEN]:
       checkpoint("cidLen=" & $cidLen)
       let
         ctx = newTrackingContext(ClientContext)
         cid = filledCid(cidLen)
       ctx.own(cid)
 
-      if cidLen == 0 or cidLen > MAX_CID_LEN:
-        # nothing was registered, not even a truncated key
-        check not ctx.ownsCid(toCidKey(filledCid(min(cidLen, MAX_CID_LEN))))
-      else:
-        check ctx.ownsCid(toCidKey(cid))
-
-  test "nil contexts and nil cid arrays are ignored":
-    # these run as callbacks from C: a missing guard is a crash, not an error
-    let
-      ctx = newTrackingContext(ClientContext)
-      missing: ClientContext = nil
-
-    addCids(nil, nil, nil, 1)
-    removeCids(nil, nil, nil, 1)
-    addCids(cast[pointer](ctx), nil, nil, 1)
-    removeCids(cast[pointer](ctx), nil, nil, 1)
-    missing.trackConnectionCid(nil)
-    ctx.trackConnectionCid(nil)
-
-    check:
-      not missing.ownsCid(toCidKey(ClientCid))
-      not ctx.ownsCid(toCidKey(ClientCid))
+      check ctx.ownsCid(toCidKey(cid))
 
 suite "datagram header parsing":
   test "the short header cid is read at the engine's cid width":
     # a short header carries no length byte, so this width is the only thing
     # that tells the endpoint where the routing cid ends
     let endpoint = QuicEndpoint()
-    check endpoint.scidLen() == LSQUIC_DF_SCID_LEN.cuint
-
     var cid = CidKey()
+
     check endpoint.packetDcid(shortHeaderPacket(ClientCid), cid)
     check cid == toCidKey(ClientCid)
 

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -16,6 +16,100 @@ import lsquic/[endpoint, lsquic_ffi]
 import lsquic/context/context
 
 const
+  ClientCid = @[0xC1'u8, 1, 2, 3, 4, 5, 6, 7]
+  ServerCid = @[0x5E'u8, 1, 2, 3, 4, 5, 6, 7]
+  UnknownCid = @[0xFF'u8, 1, 2, 3, 4, 5, 6, 7]
+
+func filledCid(cidLen: int, fill: byte = 0xAB): seq[byte] =
+  newSeqWith(cidLen, fill)
+
+func toCidKey(bytes: openArray[byte]): CidKey =
+  var key = CidKey(len: bytes.len.uint8)
+  for i, b in bytes:
+    key.bytes[i] = b
+  key
+
+func toCidKey(cid: string): CidKey =
+  toCidKey(cid.toOpenArrayByte(0, cid.high))
+
+func nativeCids(cids: openArray[seq[byte]]): seq[lsquic_cid_t] =
+  var native = newSeq[lsquic_cid_t](cids.len)
+  for i, cid in cids:
+    native[i].len = cid.len.uint8
+    for j, b in cid:
+      native[i].buf[j] = b
+  native
+
+proc own(ctx: QuicContext, cids: varargs[seq[byte]]) =
+  ## Register CIDs the way lsquic's `ea_new_scids` callback does.
+  var native = nativeCids(cids)
+  addCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
+
+proc disown(ctx: QuicContext, cids: varargs[seq[byte]]) =
+  ## Retire CIDs the way lsquic's `ea_old_scids` callback does.
+  var native = nativeCids(cids)
+  removeCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
+
+proc newTrackingContext(T: typedesc): T =
+  let ctx = T()
+  ctx.initCidTracking()
+  ctx
+
+suite "cid ownership":
+  test "registered cids are owned, unknown ones are not":
+    let ctx = newTrackingContext(ClientContext)
+
+    check not ctx.ownsCid(toCidKey(ClientCid))
+
+    ctx.own(ClientCid, ServerCid)
+
+    check:
+      ctx.ownsCid(toCidKey(ClientCid))
+      ctx.ownsCid(toCidKey(ServerCid))
+      not ctx.ownsCid(toCidKey(UnknownCid))
+
+  test "retired cids are dropped, the rest are kept":
+    let ctx = newTrackingContext(ClientContext)
+    ctx.own(ClientCid, ServerCid)
+
+    ctx.disown(ClientCid)
+
+    check:
+      not ctx.ownsCid(toCidKey(ClientCid))
+      ctx.ownsCid(toCidKey(ServerCid))
+
+  test "cid identity ignores the bytes past the cid length":
+    # lsquic hands us a fixed-size buffer and a length, only the first `len`
+    # bytes identify the connection. A key that carried the buffer tail would
+    # never match the key `packetDcid` builds from the wire.
+    const
+      Cid = "peer"
+      Buffer = Cid & "-leftover-buffer" # the whole fixed buffer, tail included
+      LongerCid = Cid & "-two"
+
+    let ctx = newTrackingContext(ClientContext)
+    var native = lsquic_cid_t(len: Cid.len.uint8)
+    for i in 0 ..< MAX_CID_LEN:
+      native.buf[i] = Buffer[i].byte
+
+    addCids(cast[pointer](ctx), nil, addr native, 1)
+
+    check:
+      ctx.ownsCid(toCidKey(Cid))
+      # a longer cid sharing that prefix is a different connection
+      not ctx.ownsCid(toCidKey(LongerCid))
+
+  test "cids at both ends of the length range are tracked":
+    for cidLen in [1, MAX_CID_LEN]:
+      checkpoint("cidLen=" & $cidLen)
+      let
+        ctx = newTrackingContext(ClientContext)
+        cid = filledCid(cidLen)
+      ctx.own(cid)
+
+      check ctx.ownsCid(toCidKey(cid))
+
+const
   ## The first byte of a QUIC packet, bit by bit (RFC 9000 17.2/17.3):
   ##
   ##   long header:  1 F T T  R R P P
@@ -46,47 +140,16 @@ const
   ShortFirstByte = FixedBit # header form bit clear
 
 const
-  ClientCid = @[0xC1'u8, 1, 2, 3, 4, 5, 6, 7]
-  ServerCid = @[0x5E'u8, 1, 2, 3, 4, 5, 6, 7]
-  UnknownCid = @[0xFF'u8, 1, 2, 3, 4, 5, 6, 7]
-
-func filledCid(cidLen: int, fill: byte = 0xAB): seq[byte] =
-  newSeqWith(cidLen, fill)
-
-func toCidKey(bytes: openArray[byte]): CidKey =
-  var key = CidKey(len: bytes.len.uint8)
-  for i, b in bytes:
-    key.bytes[i] = b
-  key
-
-func nativeCids(cids: openArray[seq[byte]]): seq[lsquic_cid_t] =
-  var native = newSeq[lsquic_cid_t](cids.len)
-  for i, cid in cids:
-    native[i].len = cid.len.uint8
-    for j, b in cid:
-      native[i].buf[j] = b
-  native
-
-proc own(ctx: QuicContext, cids: varargs[seq[byte]]) =
-  ## Register CIDs the way lsquic's `ea_new_scids` callback does.
-  var native = nativeCids(cids)
-  addCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
-
-proc disown(ctx: QuicContext, cids: varargs[seq[byte]]) =
-  ## Retire CIDs the way lsquic's `ea_old_scids` callback does.
-  var native = nativeCids(cids)
-  removeCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
-
-proc newTrackingContext(T: typedesc): T =
-  let ctx = T()
-  ctx.initCidTracking()
-  ctx
+  QuicVersion1 = [0x00'u8, 0x00, 0x00, 0x01]
+  LongHeaderPrefixLen = 1 + QuicVersion1.len + 1 # first byte, version, dcid length
+  ShortHeaderPrefixLen = 1 # first byte
 
 func longHeaderPacket(
     dcid: openArray[byte], firstByte: byte = InitialFirstByte
 ): seq[byte] =
   ## first byte, 4-byte version, DCID length, DCID, SCID length, then payload.
-  var packet = @[firstByte, 0x00'u8, 0x00, 0x00, 0x01] # QUIC v1
+  var packet = @[firstByte]
+  packet.add(QuicVersion1)
   packet.add(dcid.len.byte)
   packet.add(dcid)
   packet.add(0'u8) # zero-length SCID
@@ -101,55 +164,6 @@ func shortHeaderPacket(
   packet.add(dcid)
   packet.add(newSeq[byte](8))
   packet
-
-suite "cid ownership":
-  test "registered cids are owned, unknown ones are not":
-    let ctx = newTrackingContext(ClientContext)
-
-    check not ctx.ownsCid(toCidKey(ClientCid))
-
-    ctx.own(ClientCid, ServerCid)
-
-    check:
-      ctx.ownsCid(toCidKey(ClientCid))
-      ctx.ownsCid(toCidKey(ServerCid))
-      not ctx.ownsCid(toCidKey(UnknownCid))
-
-  test "retired cids are dropped, the rest are kept":
-    let ctx = newTrackingContext(ClientContext)
-    ctx.own(ClientCid, ServerCid)
-
-    ctx.disown(ClientCid)
-
-    check:
-      not ctx.ownsCid(toCidKey(ClientCid))
-      ctx.ownsCid(toCidKey(ServerCid))
-
-  test "cid identity ignores the bytes past the cid length":
-    # lsquic hands us a fixed-size buffer and a length, only the first `len`
-    # bytes identify the connection. A key that carried the buffer tail would
-    # never match the key `packetDcid` builds from the wire.
-    let ctx = newTrackingContext(ClientContext)
-    var native = lsquic_cid_t(len: 4)
-    for i in 0 ..< MAX_CID_LEN:
-      native.buf[i] = byte(0xA0 + i)
-
-    addCids(cast[pointer](ctx), nil, addr native, 1)
-
-    check:
-      ctx.ownsCid(toCidKey([0xA0'u8, 0xA1, 0xA2, 0xA3]))
-      # a longer cid sharing that prefix is a different connection
-      not ctx.ownsCid(toCidKey([0xA0'u8, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7]))
-
-  test "cids at both ends of the length range are tracked":
-    for cidLen in [1, MAX_CID_LEN]:
-      checkpoint("cidLen=" & $cidLen)
-      let
-        ctx = newTrackingContext(ClientContext)
-        cid = filledCid(cidLen)
-      ctx.own(cid)
-
-      check ctx.ownsCid(toCidKey(cid))
 
 suite "datagram header parsing":
   test "the short header cid is read at the engine's cid width":
@@ -177,8 +191,10 @@ suite "datagram header parsing":
       "empty datagram": newSeq[byte](),
       "zero length dcid": longHeaderPacket(newSeq[byte]()),
       "dcid longer than the maximum": longHeaderPacket(filledCid(MAX_CID_LEN + 1)),
-      "long header cut inside the dcid": longHeaderPacket(ClientCid)[0 ..< 8],
-      "short header cut inside the dcid": @[ShortFirstByte, 1, 2, 3],
+      "long header cut inside the dcid":
+        longHeaderPacket(ClientCid)[0 ..< LongHeaderPrefixLen + 2],
+      "short header cut inside the dcid":
+        shortHeaderPacket(ClientCid)[0 ..< ShortHeaderPrefixLen + 3],
     }
 
     for (name, packet) in cases:

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Tests for CID ownership and datagram header parsing - the inputs
+## `receiveDatagram` uses to pick the context a datagram belongs to.
+##
+## `scidLen`, `packetDcid` and `isIetfInitial` are internal; `-d:lsquic_testing`
+## (set in tests/nim.cfg) publishes them, so they are asserted directly instead
+## of through a handshake that would only fail as a timeout.
+
+{.used.}
+
+import std/sequtils
+import chronos, chronos/unittest2/asynctests
+import lsquic/[endpoint, lsquic_ffi]
+import lsquic/context/context
+
+const
+  ## The first byte of a QUIC packet, bit by bit (RFC 9000 17.2/17.3):
+  ##
+  ##   long header:  1 F T T  R R P P
+  ##   short header: 0 F S    R R K P P
+  ##
+  ## Routing looks at the header form (bit 7), the fixed bit F and, on a long
+  ## header, the two packet type bits T. Everything below them is payload
+  ## framing the endpoint never reads.
+  LongHeaderForm = 0b1000_0000'u8
+  FixedBit = 0b0100_0000'u8
+
+  LongTypeInitial = 0b0000_0000'u8 # type bits 00
+  LongTypeZeroRtt = 0b0001_0000'u8 # type bits 01
+  LongTypeHandshake = 0b0010_0000'u8 # type bits 10
+  LongTypeRetry = 0b0011_0000'u8 # type bits 11
+
+  # reserved and packet number bits, below the type - set them all to prove
+  # they are not part of the classification
+  LowBits = 0b0000_1111'u8
+
+  InitialFirstByte = LongHeaderForm or FixedBit or LongTypeInitial
+  InitialWithLowBitsSet = InitialFirstByte or LowBits
+  InitialWithoutFixedBit = LongHeaderForm or LongTypeInitial
+  ZeroRttFirstByte = LongHeaderForm or FixedBit or LongTypeZeroRtt
+  HandshakeFirstByte = LongHeaderForm or FixedBit or LongTypeHandshake
+  RetryFirstByte = LongHeaderForm or FixedBit or LongTypeRetry
+
+  ShortFirstByte = FixedBit # header form bit clear
+
+const
+  ClientCid = @[0xC1'u8, 1, 2, 3, 4, 5, 6, 7]
+  ServerCid = @[0x5E'u8, 1, 2, 3, 4, 5, 6, 7]
+  UnknownCid = @[0xFF'u8, 1, 2, 3, 4, 5, 6, 7]
+
+func filledCid(cidLen: int, fill: byte = 0xAB): seq[byte] =
+  newSeqWith(cidLen, fill)
+
+func toCidKey(bytes: openArray[byte]): CidKey =
+  var key = CidKey(len: bytes.len.uint8)
+  for i, b in bytes:
+    key.bytes[i] = b
+  key
+
+func nativeCids(cids: openArray[seq[byte]]): seq[lsquic_cid_t] =
+  ## `len` is copied verbatim even when it overstates lsquic's fixed buffer -
+  ## an oversized length is exactly what the length guard has to reject.
+  var native = newSeq[lsquic_cid_t](cids.len)
+  for i, cid in cids:
+    native[i].len = cid.len.uint8
+    for j in 0 ..< min(cid.len, MAX_CID_LEN):
+      native[i].buf[j] = cid[j]
+  native
+
+proc own(ctx: QuicContext, cids: varargs[seq[byte]]) =
+  ## Register CIDs the way lsquic's `ea_new_scids` callback does.
+  var native = nativeCids(cids)
+  addCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
+
+proc disown(ctx: QuicContext, cids: varargs[seq[byte]]) =
+  ## Retire CIDs the way lsquic's `ea_old_scids` callback does.
+  var native = nativeCids(cids)
+  removeCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
+
+proc newTrackingContext(T: typedesc): T =
+  let ctx = T()
+  ctx.initCidTracking()
+  ctx
+
+func longHeaderPacket(
+    dcid: openArray[byte], firstByte: byte = InitialFirstByte
+): seq[byte] =
+  ## first byte, 4-byte version, DCID length, DCID, SCID length, then payload.
+  var packet = @[firstByte, 0x00'u8, 0x00, 0x00, 0x01] # QUIC v1
+  packet.add(dcid.len.byte)
+  packet.add(dcid)
+  packet.add(0'u8) # zero-length SCID
+  packet.add(newSeq[byte](8))
+  packet
+
+func shortHeaderPacket(
+    dcid: openArray[byte], firstByte: byte = ShortFirstByte
+): seq[byte] =
+  ## A short header has no length byte: the DCID is `scidLen()` bytes wide.
+  var packet = @[firstByte]
+  packet.add(dcid)
+  packet.add(newSeq[byte](8))
+  packet
+
+suite "cid ownership":
+  test "registered cids are owned, unknown ones are not":
+    let ctx = newTrackingContext(ClientContext)
+
+    check not ctx.ownsCid(toCidKey(ClientCid))
+
+    ctx.own(ClientCid, ServerCid)
+
+    check:
+      ctx.ownsCid(toCidKey(ClientCid))
+      ctx.ownsCid(toCidKey(ServerCid))
+      not ctx.ownsCid(toCidKey(UnknownCid))
+
+  test "retired cids are dropped, the rest are kept":
+    let ctx = newTrackingContext(ClientContext)
+    ctx.own(ClientCid, ServerCid)
+
+    ctx.disown(ClientCid)
+
+    check:
+      not ctx.ownsCid(toCidKey(ClientCid))
+      ctx.ownsCid(toCidKey(ServerCid))
+
+  test "cid identity ignores the bytes past the cid length":
+    # lsquic hands us a fixed-size buffer and a length, only the first `len`
+    # bytes identify the connection. A key that carried the buffer tail would
+    # never match the key `packetDcid` builds from the wire.
+    let ctx = newTrackingContext(ClientContext)
+    var native = lsquic_cid_t(len: 4)
+    for i in 0 ..< MAX_CID_LEN:
+      native.buf[i] = byte(0xA0 + i)
+
+    addCids(cast[pointer](ctx), nil, addr native, 1)
+
+    check:
+      ctx.ownsCid(toCidKey([0xA0'u8, 0xA1, 0xA2, 0xA3]))
+      # a longer cid sharing that prefix is a different connection
+      not ctx.ownsCid(toCidKey([0xA0'u8, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7]))
+
+  test "cid lengths outside 1..MAX_CID_LEN are rejected":
+    for cidLen in [0, 1, MAX_CID_LEN, MAX_CID_LEN + 1]:
+      checkpoint("cidLen=" & $cidLen)
+      let
+        ctx = newTrackingContext(ClientContext)
+        cid = filledCid(cidLen)
+      ctx.own(cid)
+
+      if cidLen == 0 or cidLen > MAX_CID_LEN:
+        # nothing was registered, not even a truncated key
+        check not ctx.ownsCid(toCidKey(filledCid(min(cidLen, MAX_CID_LEN))))
+      else:
+        check ctx.ownsCid(toCidKey(cid))
+
+  test "nil contexts and nil cid arrays are ignored":
+    # these run as callbacks from C: a missing guard is a crash, not an error
+    let
+      ctx = newTrackingContext(ClientContext)
+      missing: ClientContext = nil
+
+    addCids(nil, nil, nil, 1)
+    removeCids(nil, nil, nil, 1)
+    addCids(cast[pointer](ctx), nil, nil, 1)
+    removeCids(cast[pointer](ctx), nil, nil, 1)
+    missing.trackConnectionCid(nil)
+    ctx.trackConnectionCid(nil)
+
+    check:
+      not missing.ownsCid(toCidKey(ClientCid))
+      not ctx.ownsCid(toCidKey(ClientCid))
+
+suite "datagram header parsing":
+  test "the short header cid is read at the engine's cid width":
+    # a short header carries no length byte, so this width is the only thing
+    # that tells the endpoint where the routing cid ends
+    let endpoint = QuicEndpoint()
+    check endpoint.scidLen() == LSQUIC_DF_SCID_LEN.cuint
+
+    var cid = CidKey()
+    check endpoint.packetDcid(shortHeaderPacket(ClientCid), cid)
+    check cid == toCidKey(ClientCid)
+
+  test "the long header cid is read at its declared length":
+    let endpoint = QuicEndpoint()
+    var cid = CidKey()
+
+    for cidLen in [1, 4, 8, MAX_CID_LEN]:
+      checkpoint("long header dcid length=" & $cidLen)
+      let dcid = filledCid(cidLen, byte(cidLen))
+      check endpoint.packetDcid(longHeaderPacket(dcid), cid)
+      check cid == toCidKey(dcid)
+
+  test "malformed datagrams carry no routing cid":
+    let endpoint = QuicEndpoint()
+    let cases = {
+      "empty datagram": newSeq[byte](),
+      "zero length dcid": longHeaderPacket(newSeq[byte]()),
+      "dcid longer than the maximum": longHeaderPacket(filledCid(MAX_CID_LEN + 1)),
+      "long header cut inside the dcid": longHeaderPacket(ClientCid)[0 ..< 8],
+      "short header cut inside the dcid": @[ShortFirstByte, 1, 2, 3],
+    }
+
+    for (name, packet) in cases:
+      checkpoint(name)
+      var cid = CidKey()
+      check not endpoint.packetDcid(packet, cid)
+
+  test "only long header initial packets count as initial":
+    # this is the rung that hands an unknown cid to the server context; every
+    # other long header type has to fall through to the drop
+    check:
+      isIetfInitial(longHeaderPacket(ClientCid))
+      isIetfInitial(longHeaderPacket(ClientCid, firstByte = InitialWithLowBitsSet))
+      not isIetfInitial(longHeaderPacket(ClientCid, firstByte = ZeroRttFirstByte))
+      not isIetfInitial(longHeaderPacket(ClientCid, firstByte = HandshakeFirstByte))
+      not isIetfInitial(longHeaderPacket(ClientCid, firstByte = RetryFirstByte))
+      not isIetfInitial(longHeaderPacket(ClientCid, firstByte = InitialWithoutFixedBit))
+      not isIetfInitial(shortHeaderPacket(ClientCid))
+      not isIetfInitial(newSeq[byte]())

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -10,42 +10,39 @@
 
 {.used.}
 
-import std/sequtils
 import chronos, chronos/unittest2/asynctests
 import lsquic/[endpoint, lsquic_ffi]
 import lsquic/context/context
 
-const
-  ClientCid = @[0xC1'u8, 1, 2, 3, 4, 5, 6, 7]
-  ServerCid = @[0x5E'u8, 1, 2, 3, 4, 5, 6, 7]
-  UnknownCid = @[0xFF'u8, 1, 2, 3, 4, 5, 6, 7]
-
-func filledCid(cidLen: int, fill: byte = 0xAB): seq[byte] =
-  newSeqWith(cidLen, fill)
-
-func toCidKey(bytes: openArray[byte]): CidKey =
-  var key = CidKey(len: bytes.len.uint8)
+func makeCid(bytes: openArray[byte]): CidKey =
+  var cid = CidKey(len: bytes.len.uint8)
   for i, b in bytes:
-    key.bytes[i] = b
-  key
+    cid.bytes[i] = b
+  cid
 
-func toCidKey(cid: string): CidKey =
-  toCidKey(cid.toOpenArrayByte(0, cid.high))
+func makeCid(cidLen: int, fill: byte = 0xAB): CidKey =
+  var cid = CidKey(len: cidLen.uint8)
+  for i in 0 ..< cidLen:
+    cid.bytes[i] = fill
+  cid
 
-func nativeCids(cids: openArray[seq[byte]]): seq[lsquic_cid_t] =
+const
+  ClientCid = makeCid([0xC1'u8, 1, 2, 3, 4, 5, 6, 7])
+  ServerCid = makeCid([0x5E'u8, 1, 2, 3, 4, 5, 6, 7])
+  UnknownCid = makeCid([0xFF'u8, 1, 2, 3, 4, 5, 6, 7])
+
+func nativeCids(cids: openArray[CidKey]): seq[lsquic_cid_t] =
   var native = newSeq[lsquic_cid_t](cids.len)
   for i, cid in cids:
-    native[i].len = cid.len.uint8
-    for j, b in cid:
-      native[i].buf[j] = b
+    native[i] = lsquic_cid_t(len: cid.len, buf: cid.bytes)
   native
 
-proc own(ctx: QuicContext, cids: varargs[seq[byte]]) =
+proc own(ctx: QuicContext, cids: varargs[CidKey]) =
   ## Register CIDs the way lsquic's `ea_new_scids` callback does.
   var native = nativeCids(cids)
   addCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
 
-proc disown(ctx: QuicContext, cids: varargs[seq[byte]]) =
+proc disown(ctx: QuicContext, cids: varargs[CidKey]) =
   ## Retire CIDs the way lsquic's `ea_old_scids` callback does.
   var native = nativeCids(cids)
   removeCids(cast[pointer](ctx), nil, addr native[0], native.len.cuint)
@@ -59,14 +56,14 @@ suite "cid ownership":
   test "registered cids are owned, unknown ones are not":
     let ctx = newTrackingContext(ClientContext)
 
-    check not ctx.ownsCid(toCidKey(ClientCid))
+    check not ctx.ownsCid(ClientCid)
 
     ctx.own(ClientCid, ServerCid)
 
     check:
-      ctx.ownsCid(toCidKey(ClientCid))
-      ctx.ownsCid(toCidKey(ServerCid))
-      not ctx.ownsCid(toCidKey(UnknownCid))
+      ctx.ownsCid(ClientCid)
+      ctx.ownsCid(ServerCid)
+      not ctx.ownsCid(UnknownCid)
 
   test "retired cids are dropped, the rest are kept":
     let ctx = newTrackingContext(ClientContext)
@@ -75,39 +72,37 @@ suite "cid ownership":
     ctx.disown(ClientCid)
 
     check:
-      not ctx.ownsCid(toCidKey(ClientCid))
-      ctx.ownsCid(toCidKey(ServerCid))
+      not ctx.ownsCid(ClientCid)
+      ctx.ownsCid(ServerCid)
 
   test "cid identity ignores the bytes past the cid length":
     # lsquic hands us a fixed-size buffer and a length, only the first `len`
     # bytes identify the connection. A key that carried the buffer tail would
     # never match the key `packetDcid` builds from the wire.
     const
-      Cid = "peer"
-      Buffer = Cid & "-leftover-buffer" # the whole fixed buffer, tail included
-      LongerCid = Cid & "-two"
+      Cid = makeCid(4)
+      LongerCid = makeCid(6)
+      Buffer = makeCid(MAX_CID_LEN) # the whole fixed buffer, tail included
 
     let ctx = newTrackingContext(ClientContext)
-    var native = lsquic_cid_t(len: Cid.len.uint8)
-    for i in 0 ..< MAX_CID_LEN:
-      native.buf[i] = Buffer[i].byte
+    var native = lsquic_cid_t(len: Cid.len, buf: Buffer.bytes)
 
     addCids(cast[pointer](ctx), nil, addr native, 1)
 
     check:
-      ctx.ownsCid(toCidKey(Cid))
+      ctx.ownsCid(Cid)
       # a longer cid sharing that prefix is a different connection
-      not ctx.ownsCid(toCidKey(LongerCid))
+      not ctx.ownsCid(LongerCid)
 
   test "cids at both ends of the length range are tracked":
     for cidLen in [1, MAX_CID_LEN]:
       checkpoint("cidLen=" & $cidLen)
       let
         ctx = newTrackingContext(ClientContext)
-        cid = filledCid(cidLen)
+        cid = makeCid(cidLen)
       ctx.own(cid)
 
-      check ctx.ownsCid(toCidKey(cid))
+      check ctx.ownsCid(cid)
 
 const
   ## The first byte of a QUIC packet, bit by bit (RFC 9000 17.2/17.3):
@@ -145,23 +140,24 @@ const
   ShortHeaderPrefixLen = 1 # first byte
 
 func longHeaderPacket(
-    dcid: openArray[byte], firstByte: byte = InitialFirstByte
+    dcid: CidKey, firstByte: byte = InitialFirstByte, declaredLen: uint8 = dcid.len
 ): seq[byte] =
   ## first byte, 4-byte version, DCID length, DCID, SCID length, then payload.
+  ## `declaredLen` overrides the DCID length byte to build a malformed header.
   var packet = @[firstByte]
   packet.add(QuicVersion1)
-  packet.add(dcid.len.byte)
-  packet.add(dcid)
+  packet.add(declaredLen)
+  for i in 0 ..< dcid.len.int:
+    packet.add(dcid.bytes[i])
   packet.add(0'u8) # zero-length SCID
   packet.add(newSeq[byte](8))
   packet
 
-func shortHeaderPacket(
-    dcid: openArray[byte], firstByte: byte = ShortFirstByte
-): seq[byte] =
+func shortHeaderPacket(dcid: CidKey, firstByte: byte = ShortFirstByte): seq[byte] =
   ## A short header has no length byte: the DCID is `scidLen()` bytes wide.
   var packet = @[firstByte]
-  packet.add(dcid)
+  for i in 0 ..< dcid.len.int:
+    packet.add(dcid.bytes[i])
   packet.add(newSeq[byte](8))
   packet
 
@@ -173,7 +169,7 @@ suite "datagram header parsing":
     var cid = CidKey()
 
     check endpoint.packetDcid(shortHeaderPacket(ClientCid), cid)
-    check cid == toCidKey(ClientCid)
+    check cid == ClientCid
 
   test "the long header cid is read at its declared length":
     let endpoint = QuicEndpoint()
@@ -181,16 +177,17 @@ suite "datagram header parsing":
 
     for cidLen in [1, 4, 8, MAX_CID_LEN]:
       checkpoint("long header dcid length=" & $cidLen)
-      let dcid = filledCid(cidLen, byte(cidLen))
+      let dcid = makeCid(cidLen, byte(cidLen))
       check endpoint.packetDcid(longHeaderPacket(dcid), cid)
-      check cid == toCidKey(dcid)
+      check cid == dcid
 
   test "malformed datagrams carry no routing cid":
     let endpoint = QuicEndpoint()
     let cases = {
       "empty datagram": newSeq[byte](),
-      "zero length dcid": longHeaderPacket(newSeq[byte]()),
-      "dcid longer than the maximum": longHeaderPacket(filledCid(MAX_CID_LEN + 1)),
+      "zero length dcid": longHeaderPacket(makeCid(0)),
+      "dcid longer than the maximum":
+        longHeaderPacket(makeCid(MAX_CID_LEN), declaredLen = uint8(MAX_CID_LEN + 1)),
       "long header cut inside the dcid":
         longHeaderPacket(ClientCid)[0 ..< LongHeaderPrefixLen + 2],
       "short header cut inside the dcid":


### PR DESCRIPTION
## Changes

Adds `tests/test_routing.nim`, covering the inputs `receiveDatagram` uses to pick which context an inbound datagram belongs to.

`suite "cid ownership"` drives `addCids` and `removeCids` the way lsquic's `ea_new_scids` and `ea_old_scids` callbacks do: registration and retirement, `CidKey` identity ignoring the bytes past the declared length, and CIDs at 1 and at `MAX_CID_LEN` bytes.

`suite "datagram header parsing"` asserts `packetDcid` and `isIetfInitial` directly: short header DCID read at `scidLen()`, long header DCID read at its declared length, malformed datagrams producing no routing CID, and Initial classification against 0-RTT, Handshake, Retry, a cleared fixed bit and short headers.

Publishes `scidLen`, `packetDcid` and `isIetfInitial` under `lsquic_testing`, and registers the new file in `test_all.nim`.

> [!NOTE]
>  Also, replaces the `padding` member on `struct_lsquic_cid` with `align: 8` on `buf`, fixing the refc build. Same 24 byte, 8 aligned layout.

## Risk

 Test only, plus one export behind a compile time define and an FFI layout declaration that leaves `sizeof` and `alignof` unchanged.