### PR TITLE
perf: stop copying 64KB per receive wakeup under arc/orc

### DIFF
--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -232,11 +232,9 @@ proc drainDatagrams(
 proc readIncoming(
     udp: DatagramTransport, msg: var seq[byte], msgLen: var int
 ) {.raises: [TransportError].} =
-  ## `peekMessage` only avoids a copy where `shallowCopy` exists, which is refc
-  ## only - Nim does not declare it under arc/orc. There chronos falls back to
-  ## `msg = transp.buffer`, which copies `bufSize` bytes (65536 by default)
-  ## rather than the bytes received, through a byte-at-a-time loop.
-  ## `getMessage` copies `buflen` instead.
+  ## Avoid `peekMessage` under ARC/ORC: without `shallowCopy`, Chronos copies the
+  ## full receive buffer instead of only the datagram. `getMessage` copies only the
+  ## received bytes.
   when declared(shallowCopy):
     udp.peekMessage(msg, msgLen)
   else:

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -229,6 +229,20 @@ proc drainDatagrams(
 
   targets
 
+proc readIncoming(
+    udp: DatagramTransport, msg: var seq[byte], msgLen: var int
+) {.raises: [TransportError].} =
+  ## `peekMessage` only avoids a copy where `shallowCopy` exists, which is refc
+  ## only - Nim does not declare it under arc/orc. There chronos falls back to
+  ## `msg = transp.buffer`, which copies `bufSize` bytes (65536 by default)
+  ## rather than the bytes received, through a byte-at-a-time loop.
+  ## `getMessage` copies `buflen` instead.
+  when declared(shallowCopy):
+    udp.peekMessage(msg, msgLen)
+  else:
+    msg = udp.getMessage()
+    msgLen = msg.len
+
 proc receiveFromUdp(
     endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress
 ) {.raises: [].} =
@@ -241,7 +255,7 @@ proc receiveFromUdp(
       msg: seq[byte]
       msgLen: int
     local = udp.localAddress()
-    udp.peekMessage(msg, msgLen)
+    readIncoming(udp, msg, msgLen)
     if msgLen > 0:
       targets = endpoint.routeDatagram(msg.toOpenArray(0, msgLen - 1), local, remote)
   except TransportError as e:


### PR DESCRIPTION
## What

`peekMessage` is only zero-copy where `shallowCopy` is declared, and Nim restricts that to refc:

```nim
when not defined(gcArc) and not defined(gcOrc) and not defined(gcAtomicArc):
  proc shallowCopy*[T](x: var T, y: T) {.magic: "ShallowCopy".}
```

Under arc/orc chronos falls through to `msg = transp.buffer`, which copies the transport's whole `bufSize` buffer — 65536 bytes by default, not the ~1.4 kB received — through the byte-at-a-time loop the compiler generates for `seq` `=copy`.

This keeps `peekMessage` on refc so #109 still holds there, and uses `getMessage` on arc/orc.

## Why now

#109 was a real ~33x win on refc and, at the same time, a ~1500x pessimization on arc/orc. On the default memory manager, `main` has been slower than it was *before* that PR:

| `--mm` | before #109 (`getMessage`) | after #109 (`peekMessage`) | this PR |
|---|---|---|---|
| refc | 297 ns | **9 ns** | **9 ns** |
| orc | **31 ns** | 46,709 ns | **31 ns** |
| arc | **32 ns** | 42,012 ns | **32 ns** |

Measured on a real `DatagramTransport`, 20k iterations per cell.

## Measured

In-process, 8 connections, release, `--mm:orc`, median of 3:

| | before | after |
|---|---|---|
| request/response | 1.358 s | **0.809 s** |
| bulk | 0.366 s | **0.296 s** |
| receive accessor, reqresp | **506.2 ms** (36% of the run) | 1.3 ms |

Allocation, same runs, via a `malloc` counter:

| | total allocated | allocations >= 32 KB |
|---|---|---|
| reqresp before | 953.0 MB | 12,114 calls / 757.2 MB |
| reqresp after | **208.3 MB** | **5 calls** |

The 12,114 large allocations match the 12,068 receive wakeups — one 64 KB allocation per wakeup, gone.

`--mm:refc` is unchanged (0.829 s -> 0.810 s, median of 7), as the generated code there is identical.

## Not fixed by this

Allocation *count* on orc is essentially unchanged (313k -> 311k). `getMessage` still allocates one seq per wakeup, just 1.4 kB instead of 64 kB. #107's original complaint was about allocation rate, and on orc that stays open — it would need something like `peekMessageInto(dst: var seq[byte])` upstream in chronos, since `transp.buffer` is private and `getMessage` always allocates.


