### PR TITLE
perf: coalesce engine ticks, gated on write size

### DIFF
--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -114,8 +114,11 @@ proc incomingStream*(
     raise newException(ConnectionClosedError, "connection closed")
 
   let stream = await incomingFut
-  stream.doProcess = proc() {.gcsafe, raises: [].} =
-    connection.quicContext.processWhenReady()
+  stream.doProcess = proc(urgent: bool) {.gcsafe, raises: [].} =
+    if urgent:
+      connection.quicContext.processWhenReady()
+    else:
+      connection.quicContext.processSoon()
   stream
 
 proc openStream*(
@@ -125,8 +128,11 @@ proc openStream*(
     raise newException(ConnectionClosedError, "connection closed")
 
   let s = Stream.new()
-  s.doProcess = proc() {.gcsafe, raises: [].} =
-    connection.quicContext.processWhenReady()
+  s.doProcess = proc(urgent: bool) {.gcsafe, raises: [].} =
+    if urgent:
+      connection.quicContext.processWhenReady()
+    else:
+      connection.quicContext.processSoon()
   let created = connection.quicConn.addPendingStream(s)
   connection.quicContext.makeStream(connection.quicConn)
   connection.quicContext.processWhenReady()

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -198,19 +198,11 @@ proc flushDeferred(udata: pointer) {.gcsafe, raises: [].} =
   let ctx = cast[QuicContext](udata)
   ctx.flushScheduled = false
   ctx.processWhenReady()
-  # Unpin last: `udata` is a raw pointer, so releasing the pin before the call
-  # could free the context out from under it.
+  # Unpin last: the callback holds only a raw pointer.
   unpin(ctx)
 
 proc processSoon*(quicContext: QuicContext) {.raises: [].} =
-  ## Asks for an engine tick at the end of the current event loop iteration
-  ## instead of right now. lsquic decides what to send once per tick, so a tick
-  ## per stream operation is a send batch per stream operation; deferring lets
-  ## operations on different connections share one batch.
-  ##
-  ## `callSoon` rather than a timer: chronos forces its poll timeout to zero
-  ## while any callback is queued, so a deferred flush cannot be left pending
-  ## by an idle loop.
+  ## Schedules one engine pass so nearby stream operations can share a tick.
   if quicContext.isNil or not quicContext.isRunning() or quicContext.flushScheduled:
     return
   quicContext.flushScheduled = true

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -39,6 +39,7 @@ type
     fd*: cint
     gso*: SegmentationOffload = SegmentationOffload()
     processing: bool
+    flushScheduled: bool
     running*: bool
     ownedCids: HashSet[CidKey]
 
@@ -192,6 +193,29 @@ proc processWhenReady*(quicContext: QuicContext) =
   if quicContext.isNil or quicContext.engine.isNil:
     return
   quicContext.engine_process()
+
+proc flushDeferred(udata: pointer) {.gcsafe, raises: [].} =
+  let ctx = cast[QuicContext](udata)
+  ctx.flushScheduled = false
+  ctx.processWhenReady()
+  # Unpin last: `udata` is a raw pointer, so releasing the pin before the call
+  # could free the context out from under it.
+  unpin(ctx)
+
+proc processSoon*(quicContext: QuicContext) {.raises: [].} =
+  ## Asks for an engine tick at the end of the current event loop iteration
+  ## instead of right now. lsquic decides what to send once per tick, so a tick
+  ## per stream operation is a send batch per stream operation; deferring lets
+  ## operations on different connections share one batch.
+  ##
+  ## `callSoon` rather than a timer: chronos forces its poll timeout to zero
+  ## while any callback is queued, so a deferred flush cannot be left pending
+  ## by an idle loop.
+  if quicContext.isNil or not quicContext.isRunning() or quicContext.flushScheduled:
+    return
+  quicContext.flushScheduled = true
+  pin(quicContext) # the dispatcher holds a raw pointer until the callback runs
+  callSoon(flushDeferred, cast[pointer](quicContext))
 
 proc incomingStream*(
     quicConn: QuicConnection

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -6,6 +6,15 @@ import chronos
 import chronicles
 import ./[lsquic_ffi, errors, tracking]
 
+const WriteFlushBytes = 16384
+  ## A write at or above this size is flushed immediately so that its packets
+  ## stay adjacent in the batch and segmentation offload can group them.
+  ## Smaller writes defer, so writes across connections coalesce into one tick.
+  ##
+  ## Measured, 8 connections, request/response at a range of message sizes:
+  ## deferring wins up to 8 KB (-25% wall at 1 KB, -8% at 8 KB) and loses from
+  ## 16 KB up (+5% at 16 KB, +14% at 64 KB).
+
 type WriteTask* = object
   data*: ptr byte
   dataLen*: int
@@ -34,7 +43,7 @@ type Stream* = ref object
   readLock*: AsyncLock
   isEof*: bool # Received a FIN from remote
   toRead*: Opt[ReadTask]
-  doProcess*: proc() {.gcsafe, raises: [].}
+  doProcess*: proc(urgent: bool) {.gcsafe, raises: [].}
 
 proc new*(T: typedesc[Stream], quicStream: ptr lsquic_stream_t = nil): T =
   let closed = newAsyncEvent()
@@ -135,7 +144,7 @@ template raiseIfWriteReset(stream: Stream) =
 
 template processWhenAvailable(stream: Stream) =
   if not isNil(stream.doProcess):
-    stream.doProcess()
+    stream.doProcess(true)
 
 proc requestClose(stream: Stream): bool {.raises: [].} =
   if stream.closedByEngine or stream.quicStream.isNil or stream.closeRequested:
@@ -184,7 +193,7 @@ proc close*(stream: Stream) {.async: (raises: [StreamError, CancelledError]).} =
       stream.abort()
       raise newException(StreamError, "could not close the stream")
     if not stream.isEof:
-      stream.doProcess()
+      stream.doProcess(true)
   else:
     raise newException(StreamError, "could not close the stream")
 
@@ -245,7 +254,9 @@ proc readOnce*(
   stream.toRead = Opt.some(ReadTask(data: dst, dataLen: dstLen, doneFut: doneFut))
 
   try:
-    stream.doProcess()
+    # Deferred: this only asks lsquic to hand over data it has already buffered,
+    # and coalescing it is what lets several connections share a tick.
+    stream.doProcess(false)
 
     let raceFut = await race(stream.closedWaiter, doneFut)
     if raceFut == stream.closedWaiter:
@@ -297,7 +308,7 @@ proc write*(
     if lsquic_stream_flush(stream.quicStream) != 0:
       stream.abort()
       raise newException(StreamError, "could not flush stream")
-    stream.doProcess()
+    stream.doProcess(data.len >= WriteFlushBytes)
     return
   elif n < 0:
     if errno == ECONNRESET:
@@ -318,7 +329,7 @@ proc write*(
   )
 
   try:
-    stream.doProcess()
+    stream.doProcess(data.len >= WriteFlushBytes)
 
     let raceFut = await race(stream.closedWaiter, doneFut)
     if raceFut == stream.closedWaiter:

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -7,13 +7,7 @@ import chronicles
 import ./[lsquic_ffi, errors, tracking]
 
 const WriteFlushBytes = 16384
-  ## A write at or above this size is flushed immediately so that its packets
-  ## stay adjacent in the batch and segmentation offload can group them.
-  ## Smaller writes defer, so writes across connections coalesce into one tick.
-  ##
-  ## Measured, 8 connections, request/response at a range of message sizes:
-  ## deferring wins up to 8 KB (-25% wall at 1 KB, -8% at 8 KB) and loses from
-  ## 16 KB up (+5% at 16 KB, +14% at 64 KB).
+  ## Large writes flush immediately; smaller writes defer to coalesce ticks.
 
 type WriteTask* = object
   data*: ptr byte
@@ -254,8 +248,6 @@ proc readOnce*(
   stream.toRead = Opt.some(ReadTask(data: dst, dataLen: dstLen, doneFut: doneFut))
 
   try:
-    # Deferred: this only asks lsquic to hand over data it has already buffered,
-    # and coalescing it is what lets several connections share a tick.
     stream.doProcess(false)
 
     let raceFut = await race(stream.closedWaiter, doneFut)


### PR DESCRIPTION
## Summary

Every stream operation used to tick the lsquic engine immediately. In request/response traffic that produced one send syscall per packet: 96,098 calls carrying 96,495 specs, or 1.00 spec per call.

This PR defers non-urgent ticks with `callSoon`, so operations across connections can share one engine batch at the end of the current event loop iteration. Writes at or above 16 KiB, `close`, and `abort` still flush immediately to preserve latency and GSO-friendly packet adjacency.

## Affected Areas

- Transports: QUIC stream scheduling and context-level engine processing

## Implementation Notes

Deferring only writes did not improve request/response traffic. The write path deferred correctly, but each following `readOnce` forced an immediate tick:

```text
ticks: write=0  writeSoon=96000  read=96000  close=8  receive=12062  deferredRan=12000
```

The read path now defers as well, because it only asks lsquic to hand over data it has already buffered. Immediate processing is still used for `close`, `abort`, and writes at or above the size gate.

`callSoon` is used instead of a timer because chronos sets the poll timeout to zero while callbacks are queued, so the dispatcher should not block while a deferred flush is pending. Dirtiness is tracked per context because client and server hold separate engines.

## Size Gate

Large writes produce adjacent same-destination packets, which is what GSO grouping depends on. Deferring them lets other connections interleave into the batch and can break those runs.

Measured on bulk:

| config | specs/call | syscalls | **segments/group** | wall |
|---|---|---|---|---|
| baseline (all immediate) | 23.53 | 3,245 | **16.64** | 0.323 s |
| this PR (gate at 16 kB) | 24.22 | 3,176 | **16.80** | 0.313 s |
| gate removed, all deferred | 39.12 | 2,035 | **12.63** | worse |

Removing the gate collapses grouping by 24% and regresses bulk wall clock.

The 16 KiB threshold comes from sweeping message size at 8 connections:

| size | immediate | deferred |
|---|---|---|
| 1 kB | 1.173 | **0.883** |
| 2 kB | 2.086 | **1.778** |
| 4 kB | 2.341 | **2.111** |
| 8 kB | 3.120 | **2.866** |
| 16 kB | **5.157** | 5.396 |
| 32 kB | **9.931** | 10.082 |
| 64 kB | **16.534** | 18.802 |

This was derived on one machine and one workload shape; re-deriving it on real traffic would be reasonable.

## Benchmarks

8 connections, release, median of 3:

| request/response, 1 kB | before | after |
|---|---|---|
| wall | 1.167 s | **0.875 s** |
| specs per call | 1.00 | **7.98** |
| send syscalls | 96,098 | **12,091** |
| GSO segments/group | 6.79 | 7.99 |

| bulk, 64 kB writes | before | after |
|---|---|---|
| wall | 0.323 s | 0.313 s |
| specs per call | 23.53 | 24.22 |
| GSO segments/group | 16.64 | 16.80 |
