### PR TITLE
perf: take stream write payloads as sink

### DIFF
--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -267,8 +267,11 @@ template readOnce*(stream: Stream, dst: var openArray[byte]): untyped =
   else: stream.readOnce(dst[0].addr, dst.len))
 
 proc write*(
-    stream: Stream, data: seq[byte]
+    stream: Stream, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, StreamError]).} =
+  ## `sink` so that handing over a temporary - `write(@[header])`, or a freshly
+  ## built buffer - moves into the async environment instead of being copied
+  ## into it. A caller that keeps its own buffer still pays one copy.
   if data.len == 0:
     return
 

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -269,9 +269,6 @@ template readOnce*(stream: Stream, dst: var openArray[byte]): untyped =
 proc write*(
     stream: Stream, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, StreamError]).} =
-  ## `sink` so that handing over a temporary - `write(@[header])`, or a freshly
-  ## built buffer - moves into the async environment instead of being copied
-  ## into it. A caller that keeps its own buffer still pays one copy.
   if data.len == 0:
     return
 


### PR DESCRIPTION
## Summary

`Stream.write` now takes `data: sink seq[byte]` so freshly built payloads can move into the async environment instead of being copied into it.

Async procs store parameters in a heap environment across `await` points. With a by-value `seq[byte]`, that store deep-copies the sequence payload. For callers that hand off a temporary buffer and do not keep using it, `sink` removes that extra payload-sized copy.

## Impact

- Existing `seq[byte]` call sites should not need changes.
- Temporaries such as `write(@[header])`, `write(toSeq(...))`, or freshly built buffers can avoid one copy.
- Callers that keep and reuse their own buffer are unaffected; those still need a pointer-based write path such as #124.
- The write operation keeps the same lifetime model: the async proc owns the payload it writes.

## Benchmarks

`malloc` counter, bulk mode, 99.6 MB in 64 kB writes from a fresh buffer per write, allocations of >= 32 KB:

| | calls | bytes |
|---|---|---|
| before | 4751 | 297.0 MB |
| after | **3227** | **201.7 MB** |

That removes one payload copy in this workload. 