### PR TITLE
perf: settle pending stream operations on close instead of racing

### DIFF
--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -234,6 +234,8 @@ proc cancelPending*(quicConn: QuicConnection) =
     if not pending.created.finished:
       pending.created.fail(newException(ConnectionError, "can't open new streams"))
 
+    # Nothing to settle: the stream is not handed to the caller until `created`
+    # completes, so no read or write can be in flight on it.
     pending.stream.closedByEngine = true
     pending.stream.closeWrite = true
     pending.stream.isEof = true

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -234,8 +234,6 @@ proc cancelPending*(quicConn: QuicConnection) =
     if not pending.created.finished:
       pending.created.fail(newException(ConnectionError, "can't open new streams"))
 
-    # Nothing to settle: the stream is not handed to the caller until `created`
-    # completes, so no read or write can be in flight on it.
     pending.stream.closedByEngine = true
     pending.stream.closeWrite = true
     pending.stream.isEof = true

--- a/lsquic/context/stream.nim
+++ b/lsquic/context/stream.nim
@@ -42,8 +42,6 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
 
   streamCtx.closedByEngine = true
 
-  # Unconditionally: a write still pending when the engine closes can never
-  # complete, and nothing else will settle its future.
   streamCtx.abortPendingWrites("stream closed")
 
   if not streamCtx.readResetByPeer():
@@ -57,8 +55,7 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
   if streamCtx.readResetByPeer():
     streamCtx.failPendingRead(streamCtx.newStreamResetError("stream read"))
   else:
-    # A clean close is end of stream, so a pending read reports 0 rather than
-    # failing. readOnce used to derive this by racing the closed event.
+    # A clean close is end of stream: report 0 rather than failing.
     streamCtx.completePendingRead()
 
   unpin(streamCtx)
@@ -101,14 +98,16 @@ proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.
       streamCtx.abort()
       return
 
-  if lsquic_stream_wantread(stream, 0) == -1:
-    trace "could not set stream wantread", streamId = lsquic_stream_id(stream)
-    streamCtx.abort() # settles the pending read, so it may already be finished
-
+  # abort settles a pending read with 0, so report the bytes first or they are
+  # lost. The guard covers closeIfDone above having re-entered onClose.
   if not task.doneFut.finished:
     task.doneFut.complete(int(n))
 
   streamCtx.toRead = Opt.none(ReadTask)
+
+  if lsquic_stream_wantread(stream, 0) == -1:
+    trace "could not set stream wantread", streamId = lsquic_stream_id(stream)
+    streamCtx.abort()
 
 proc onWrite*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.} =
   trace "onWrite"

--- a/lsquic/context/stream.nim
+++ b/lsquic/context/stream.nim
@@ -42,8 +42,9 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
 
   streamCtx.closedByEngine = true
 
-  if not streamCtx.closeWrite:
-    streamCtx.abortPendingWrites("stream closed")
+  # Unconditionally: a write still pending when the engine closes can never
+  # complete, and nothing else will settle its future.
+  streamCtx.abortPendingWrites("stream closed")
 
   if not streamCtx.readResetByPeer():
     streamCtx.isEof = true
@@ -55,11 +56,10 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
 
   if streamCtx.readResetByPeer():
     streamCtx.failPendingRead(streamCtx.newStreamResetError("stream read"))
-  elif streamCtx.toRead.isSome:
-    let doneFut = streamCtx.toRead.unsafeGet().doneFut
-    if not doneFut.finished:
-      doneFut.fail(newException(StreamError, "stream closed"))
-    streamCtx.toRead = Opt.none(ReadTask)
+  else:
+    # A clean close is end of stream, so a pending read reports 0 rather than
+    # failing. readOnce used to derive this by racing the closed event.
+    streamCtx.completePendingRead()
 
   unpin(streamCtx)
 
@@ -103,9 +103,10 @@ proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.
 
   if lsquic_stream_wantread(stream, 0) == -1:
     trace "could not set stream wantread", streamId = lsquic_stream_id(stream)
-    streamCtx.abort()
+    streamCtx.abort() # settles the pending read, so it may already be finished
 
-  task.doneFut.complete(int(n))
+  if not task.doneFut.finished:
+    task.doneFut.complete(int(n))
 
   streamCtx.toRead = Opt.none(ReadTask)
 

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -27,25 +27,22 @@ type Stream* = ref object
   closeRequested: bool
   # This is called when on_close callback is executed
   closed*: AsyncEvent
-  # Reuse a single closed-event waiter to minimize allocations on hot paths.
-  # (no per call allocation)
-  closedWaiter*: Future[void].Raising([CancelledError])
   resetByPeer*: bool
   resetHow*: StreamResetHow
   writeLock*: AsyncLock
   toWrite*: Opt[WriteTask]
   readLock*: AsyncLock
   isEof*: bool # Received a FIN from remote
+  # Every path that sets closedByEngine or fires `closed` must settle these;
+  # missing one hangs the parked operation instead of failing it.
   toRead*: Opt[ReadTask]
   doProcess*: proc(urgent: bool) {.gcsafe, raises: [].}
 
 proc new*(T: typedesc[Stream], quicStream: ptr lsquic_stream_t = nil): T =
   let closed = newAsyncEvent()
-  let closedWaiter = closed.wait()
   let s = Stream(
     quicStream: quicStream,
     closed: closed,
-    closedWaiter: closedWaiter,
     readLock: newAsyncLock(),
     writeLock: newAsyncLock(),
   )
@@ -85,8 +82,7 @@ proc failPendingRead*(stream: Stream, error: ref StreamError) {.raises: [].} =
   stream.toRead = Opt.none(ReadTask)
 
 proc completePendingRead*(stream: Stream) {.raises: [].} =
-  ## Ends a pending read at end of stream. Reporting 0 rather than failing is
-  ## what readOnce did when the closed event won its race.
+  ## Ends a pending read at end of stream, reporting 0 rather than failing.
   let task = stream.toRead.valueOr:
     return
   if not task.doneFut.finished:
@@ -259,8 +255,6 @@ proc readOnce*(
 
   try:
     stream.doProcess(false)
-    # onClose completes this with 0 on a clean close and fails it on a reset,
-    # and abort completes it too, so there is nothing to race against.
     return await doneFut
   finally:
     stream.clearPendingRead(doneFut)
@@ -334,7 +328,6 @@ proc write*(
 
   try:
     stream.doProcess(srcLen >= WriteFlushBytes)
-    # abortPendingWrites on the close and reset paths settles this future.
     await doneFut
   finally:
     stream.clearPendingWrite(doneFut)

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -84,6 +84,15 @@ proc failPendingRead*(stream: Stream, error: ref StreamError) {.raises: [].} =
     task.doneFut.fail(error)
   stream.toRead = Opt.none(ReadTask)
 
+proc completePendingRead*(stream: Stream) {.raises: [].} =
+  ## Ends a pending read at end of stream. Reporting 0 rather than failing is
+  ## what readOnce did when the closed event won its race.
+  let task = stream.toRead.valueOr:
+    return
+  if not task.doneFut.finished:
+    task.doneFut.complete(0)
+  stream.toRead = Opt.none(ReadTask)
+
 proc abortPendingWrites*(stream: Stream, error: ref StreamError) {.raises: [].} =
   let task = stream.toWrite.valueOr:
     return
@@ -170,6 +179,7 @@ proc abort*(stream: Stream) =
   stream.closeWrite = true
   stream.isEof = true
   stream.abortPendingWrites("stream aborted")
+  stream.completePendingRead()
   discard stream.requestClose()
   if not stream.closed.isSet():
     stream.closed.fire()
@@ -249,17 +259,8 @@ proc readOnce*(
 
   try:
     stream.doProcess(false)
-
-    let raceFut = await race(stream.closedWaiter, doneFut)
-    if raceFut == stream.closedWaiter:
-      if not doneFut.finished:
-        await doneFut.cancelAndWait()
-      raiseIfReadReset(stream)
-      stream.isEof = true
-      stream.closeWrite = true
-      discard stream.closeIfDone()
-      return 0
-
+    # onClose completes this with 0 on a clean close and fails it on a reset,
+    # and abort completes it too, so there is nothing to race against.
     return await doneFut
   finally:
     stream.clearPendingRead(doneFut)
@@ -333,14 +334,7 @@ proc write*(
 
   try:
     stream.doProcess(srcLen >= WriteFlushBytes)
-
-    let raceFut = await race(stream.closedWaiter, doneFut)
-    if raceFut == stream.closedWaiter:
-      raiseIfWriteReset(stream)
-      if not doneFut.finished:
-        doneFut.fail(newException(StreamError, "stream closed"))
-      stream.closeWrite = true
-
+    # abortPendingWrites on the close and reset paths settles this future.
     await doneFut
   finally:
     stream.clearPendingWrite(doneFut)

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -614,6 +614,89 @@ suite "lifecycle":
     expect StreamResetError:
       await writing
 
+  # One test per close path, pinning the rule that each settles the parked
+  # operation itself.
+
+  asyncTest "engine close completes a parked read with eof":
+    let stream = Stream.new()
+    var buf = newSeq[byte](8)
+    let doneFut =
+      Future[int].Raising([CancelledError, StreamError]).init("test parked read")
+    stream.toRead =
+      Opt.some(ReadTask(data: buf[0].addr, dataLen: buf.len, doneFut: doneFut))
+
+    onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # also releases the pin
+
+    check stream.toRead.isNone()
+    # guarded so a regression fails this test instead of parking the suite
+    check doneFut.finished
+    if doneFut.finished:
+      check (await doneFut) == 0
+
+  asyncTest "engine close fails a parked read after a peer read reset":
+    let stream = Stream.new()
+    stream.markResetByPeer(ResetRead)
+
+    var buf = newSeq[byte](8)
+    let doneFut =
+      Future[int].Raising([CancelledError, StreamError]).init("test parked read")
+    stream.toRead =
+      Opt.some(ReadTask(data: buf[0].addr, dataLen: buf.len, doneFut: doneFut))
+
+    onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # also releases the pin
+
+    check stream.toRead.isNone()
+    check doneFut.finished
+    if doneFut.finished:
+      expect StreamResetError:
+        discard await doneFut
+
+  asyncTest "engine close fails a parked write after a local write shutdown":
+    let stream = Stream.new()
+    var data = @[1'u8, 2, 3]
+    let doneFut =
+      Future[void].Raising([CancelledError, StreamError]).init("test parked write")
+    stream.toWrite =
+      Opt.some(WriteTask(data: data[0].addr, dataLen: data.len, doneFut: doneFut))
+    stream.closeWrite = true # pins the removed `if not closeWrite` guard
+
+    onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # also releases the pin
+
+    check stream.toWrite.isNone()
+    check doneFut.finished
+    if doneFut.finished:
+      expect StreamError:
+        await doneFut
+
+  asyncTest "abort settles a parked read and a parked write":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+
+    var buf = newSeq[byte](8)
+    let readFut =
+      Future[int].Raising([CancelledError, StreamError]).init("test parked read")
+    stream.toRead =
+      Opt.some(ReadTask(data: buf[0].addr, dataLen: buf.len, doneFut: readFut))
+
+    var data = @[1'u8, 2, 3]
+    let writeFut =
+      Future[void].Raising([CancelledError, StreamError]).init("test parked write")
+    stream.toWrite =
+      Opt.some(WriteTask(data: data[0].addr, dataLen: data.len, doneFut: writeFut))
+
+    stream.abort()
+
+    check stream.toRead.isNone()
+    check stream.toWrite.isNone()
+    check readFut.finished
+    check writeFut.finished
+    if readFut.finished:
+      check (await readFut) == 0
+    if writeFut.finished:
+      expect StreamError:
+        await writeFut
+
   asyncTest "concurrent reads on one stream are serialized":
     let peers = await connectPeers()
     defer:


### PR DESCRIPTION
## What

`readOnce` and `write` each waited with `race(closedWaiter, doneFut)`, so every blocking operation built a race future, a seq of the two futures and two closure environments, then tore them down again.

The race existed because the close paths did not fully settle pending operations:

- `onClose` failed a pending read with `StreamError`, while `readOnce`'s close branch turned that into a clean `0`
- `abort` did not touch a pending read at all

So the close outcome was emergent from which future won the race, rather than stated in the close paths. This makes those paths settle pending work directly: `onClose` completes a pending read with `0` on clean close and fails it on reset, `abort` completes pending reads and writes, and `abortPendingWrites` runs unconditionally when the engine closes the stream.

With the race gone, `readOnce` and `write` can await their own operation futures directly, and `Stream.closedWaiter` is removed because nothing consumes it anymore.

## The invariant this creates

The race used to double as a safety net: any path that fired `closed` released the awaiter even if it did not settle the pending operation. That net is gone, so every path that sets `closedByEngine` or fires `closed` must now settle `toRead`/`toWrite` itself. A missed path hangs the operation instead of failing it.

The relevant paths are `onClose`, `abort`, `onReset`, and `cancelPending`. `cancelPending` has nothing to settle because a pending stream is not handed to the caller until `created` completes. This invariant is now documented on the `Stream` type.

## Measured

Workload: 8 connections, one stream each, 1000 request/response round trips of 64 bytes per stream. This is 8,000 round trips total, and every round trip parks a read on both peers, so it is close to a worst case for the per-operation overhead. Allocations are counted with `getAllocStats()` over the round-trip region only; connection setup and teardown are excluded.

32 measured rounds per side, from two independent alternating runs:

| | before | after |
|---|---|---|
| allocations | 334,801 | **286,717** (-48,084, **-14.4%**) |
| wall clock, mean | 80.03 ms | 73.48 ms (-8.2%) |
| wall clock, minimum | 70.28 ms | 61.65 ms (-12.3%) |

The allocation count is the reliable figure: it reproduced to within 0.01% across both runs and works out to about 6 allocations saved per round trip, matching the removed race future, seq, and closure environments.

The wall-clock result is directionally consistent but noisier. The mean delta was -11.6% in the first run and -6.1% in the second, while the minimum-to-minimum delta held at -10.8% and -12.3%. Read it as roughly 5-10% on this workload, not as a precise figure.

## Latent bugs fixed on the way

`onRead` called `abort()` on a `wantread` failure and then unconditionally completed the same future. That only worked because `abort` did not settle reads; making it do so surfaced a double-complete.

Guarding the completion was not enough: `abort` settles a pending read with `0`, so aborting first made the guard swallow the byte count and report EOF while `n` bytes sat unread in the caller's buffer. The order is now "report the bytes, then abort", with the guard kept for the case where `closeIfDone` above has re-entered `onClose`.
