### PR TITLE
fix: harden the UDP drain loop

### DIFF
--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -3,13 +3,13 @@
 
 import chronos
 import chronos/osdefs
+import chronicles
 import ./context
 import ../[lsquic_ffi, datagram]
 import ../helpers/[sequninit, transportaddr]
 import std/[nativesockets, net]
 
 when not defined(windows):
-  import chronicles
   import posix
 
 when defined(linux):
@@ -59,12 +59,19 @@ proc prepareDestAddr(
   let
     localAddress = localSa.toTransportAddress()
     destAddress = destSa.toTransportAddress()
-  if localAddress.family == AddressFamily.IPv6 and
-      destAddress.family == AddressFamily.IPv4:
-    let mappedDest = destAddress.toIPv6()
+  if localAddress.isSome() and destAddress.isSome() and
+      localAddress[].family == AddressFamily.IPv6 and
+      destAddress[].family == AddressFamily.IPv4:
+    let mappedDest = destAddress[].toIPv6()
     mappedDest.toSAddr(destStorage, destAddrLen)
   else:
-    destAddrLen = sockAddrLen(destSa.sa_family.int)
+    # lsquic hands back the addresses we gave it, so an unsupported family here
+    # should be unreachable; a zero-length destination fails the send rather
+    # than aborting the process from a `{.cdecl.}` callback.
+    destAddrLen = sockAddrLen(destSa.sa_family.int).valueOr:
+      trace "Unsupported destination address family; send will fail",
+        family = destSa.sa_family.int
+      SockLen(0)
     copyMem(addr destStorage, destSa, destAddrLen)
 
 when not defined(windows):

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -16,7 +16,19 @@ proc onNewConn(
   debug "New connection established: server"
   var local: ptr SockAddr
   var remote: ptr SockAddr
-  discard lsquic_conn_get_sockaddr(conn, addr local, addr remote)
+  if lsquic_conn_get_sockaddr(conn, addr local, addr remote) != 0:
+    error "Could not read connection addresses; dropping incoming connection"
+    return nil
+
+  let
+    localAddress = local.toTransportAddress().valueOr:
+      error "Unsupported local address family; dropping incoming connection",
+        family = local.sa_family.int
+      return nil
+    remoteAddress = remote.toTransportAddress().valueOr:
+      error "Unsupported remote address family; dropping incoming connection",
+        family = remote.sa_family.int
+      return nil
 
   let x509chain = lsquic_conn_get_full_cert_chain(conn)
   let certChain = x509chain.getCertChain()
@@ -26,8 +38,8 @@ proc onNewConn(
   let quicConn = QuicConnection(
     isOutgoing: false,
     incoming: newAsyncQueue[Stream](),
-    local: local.toTransportAddress(),
-    remote: remote.toTransportAddress(),
+    local: localAddress,
+    remote: remoteAddress,
     lsquicConn: conn,
     certChain: certChain,
     onClose: proc() =

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -221,11 +221,17 @@ proc drainDatagrams(
       # Empty, or an error the transport will report again on the next wakeup.
       break
 
-    let remoteSa = cast[ptr SockAddr](addr remoteAddress)
-    if res > 0 and remoteSa.hasKnownFamily():
-      targets.incl endpoint.routeDatagram(
-        endpoint.drainBuf.toOpenArray(0, res - 1), local, remoteSa.toTransportAddress()
-      )
+    if res == 0:
+      continue
+
+    let remote = cast[ptr SockAddr](addr remoteAddress).toTransportAddress().valueOr:
+      trace "Dropping datagram from unsupported address family",
+        family = remoteAddress.ss_family.int, bytes = res
+      continue
+
+    targets.incl endpoint.routeDatagram(
+      endpoint.drainBuf.toOpenArray(0, res - 1), local, remote
+    )
 
   targets
 

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -5,14 +5,14 @@ import chronos, chronicles, results
 when defined(windows):
   from chronos/osdefs import SOL_SOCKET, SO_RCVBUF
 else:
-  from posix import SOL_SOCKET, SO_RCVBUF
+  from posix import SOL_SOCKET, SO_RCVBUF, EINTR, errno
 import
   ./[
     errors, connection, tlsconfig, connectionmanager, lsquic_ffi, certificateverifier,
     socketconfig,
   ]
 import ./context/[server, client, context, io]
-import ./helpers/transportaddr
+import ./helpers/[transportaddr, sequninit]
 from chronos/osdefs import Sockaddr_storage, SockAddr, SockLen, SocketHandle
 when defined(windows):
   from std/winlean import recvfrom
@@ -203,7 +203,7 @@ proc drainDatagrams(
   ## whatever else has already arrived is read here rather than one wakeup, and
   ## one engine tick, at a time.
   if endpoint.drainBuf.len == 0:
-    endpoint.drainBuf = newSeq[byte](DefaultDatagramBufferSize)
+    endpoint.drainBuf = newSeqUninit[byte](DefaultDatagramBufferSize)
 
   var targets: set[RouteTarget]
   for _ in 0 ..< MaxDatagramsPerWakeup:
@@ -214,14 +214,17 @@ proc drainDatagrams(
       SocketHandle(udp.fd), endpoint.drainBuf, remoteAddress, remoteAddrLen
     )
     if res < 0:
+      when not defined(windows):
+        # A signal is not "socket empty"; chronos' own read loop retries too.
+        if errno == EINTR:
+          continue
       # Empty, or an error the transport will report again on the next wakeup.
       break
 
-    if res > 0:
+    let remoteSa = cast[ptr SockAddr](addr remoteAddress)
+    if res > 0 and remoteSa.hasKnownFamily():
       targets.incl endpoint.routeDatagram(
-        endpoint.drainBuf.toOpenArray(0, res - 1),
-        local,
-        toTransportAddress(cast[ptr SockAddr](addr remoteAddress)),
+        endpoint.drainBuf.toOpenArray(0, res - 1), local, remoteSa.toTransportAddress()
       )
 
   targets
@@ -241,6 +244,11 @@ proc readIncoming(
 proc receiveFromUdp(
     endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress
 ) {.raises: [].} =
+  if endpoint.isNil or endpoint.stopped:
+    # routeDatagram would drop everything anyway, so do not spend a drain loop
+    # of recvfrom calls per wakeup on it.
+    return
+
   var
     targets: set[RouteTarget]
     local: TransportAddress

--- a/lsquic/helpers/transportaddr.nim
+++ b/lsquic/helpers/transportaddr.nim
@@ -1,39 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright (c) Status Research & Development GmbH 
+# Copyright (c) Status Research & Development GmbH
 
 import chronos
 import chronos/osdefs
+import results
 import ../lsquic_ffi
 
-# up until nim 2.2.6, AF_INET6 const had wrong value. 
-# that's why this const is defiend here to have backwards compatability with older versions of nim.
-# commit fix: https://github.com/nim-lang/Nim/commit/248850a0ce869c15fea16a35e248850d2df47c8d
-const fixed_AF_INET6 =
-  when defined(macosx):
-    30
-  elif defined(windows):
-    23
-  else:
-    10
-
-proc sockAddrLen*(family: int): SockLen {.inline.} =
+proc sockAddrLen*(family: int): Opt[SockLen] {.inline.} =
+  ## `none` for any family other than AF_INET/AF_INET6. Every caller runs in a
+  ## `{.raises: [].}` receive callback or a `{.cdecl.}` callback invoked by
+  ## lsquic, so a Defect here would abort the process rather than be handled.
   case family
   of AF_INET.int:
-    sizeof(Sockaddr_in).uint32
-  of fixed_AF_INET6.int: # use fixed const
-    sizeof(Sockaddr_in6).uint32
+    Opt.some(sizeof(Sockaddr_in).SockLen)
+  of AF_INET6.int:
+    Opt.some(sizeof(Sockaddr_in6).SockLen)
   else:
-    raiseAssert "invalid socket address family"
+    Opt.none(SockLen)
 
-proc hasKnownFamily*(sock: ptr SockAddr): bool {.inline.} =
-  ## `sockAddrLen` raises a Defect on anything else, which would abort the
-  ## process if it ever reached a `{.raises: [].}` receive callback.
-  sock.sa_family.int in [AF_INET.int, fixed_AF_INET6]
-
-proc toTransportAddress*(sock: ptr SockAddr): TransportAddress =
+proc toTransportAddress*(sock: ptr SockAddr): Opt[TransportAddress] =
+  let destAddrLen = ?sockAddrLen(sock.sa_family.int)
   var destAddress: Sockaddr_storage
-  let destAddrLen: SockLen = sockAddrLen(sock.sa_family.int)
   copyMem(addr destAddress, sock, destAddrLen)
   var taddr: TransportAddress
   fromSAddr(addr destAddress, destAddrLen, taddr)
-  taddr
+  Opt.some(taddr)

--- a/lsquic/helpers/transportaddr.nim
+++ b/lsquic/helpers/transportaddr.nim
@@ -25,6 +25,11 @@ proc sockAddrLen*(family: int): SockLen {.inline.} =
   else:
     raiseAssert "invalid socket address family"
 
+proc hasKnownFamily*(sock: ptr SockAddr): bool {.inline.} =
+  ## `sockAddrLen` raises a Defect on anything else, which would abort the
+  ## process if it ever reached a `{.raises: [].}` receive callback.
+  sock.sa_family.int in [AF_INET.int, fixed_AF_INET6]
+
 proc toTransportAddress*(sock: ptr SockAddr): TransportAddress =
   var destAddress: Sockaddr_storage
   let destAddrLen: SockLen = sockAddrLen(sock.sa_family.int)

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -5,7 +5,7 @@
 
 import
   test_connection, test_perf, test_tlsconfig, test_verifier, test_lifecycle,
-  test_timeout, test_stress, test_runtime, test_routing
+  test_timeout, test_stress, test_runtime, test_routing, test_transportaddr
 
 from ./helpers/trackers import finalCheckTrackers
 finalCheckTrackers()

--- a/tests/test_transportaddr.nim
+++ b/tests/test_transportaddr.nim
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import results
+import unittest2
+import chronos
+import chronos/osdefs
+import lsquic/helpers/transportaddr
+
+proc storageFor(address: TransportAddress): Sockaddr_storage =
+  var
+    storage: Sockaddr_storage
+    length: SockLen
+  address.toSAddr(storage, length)
+  storage
+
+proc asSockAddr(storage: var Sockaddr_storage): ptr SockAddr =
+  cast[ptr SockAddr](addr storage)
+
+suite "Transport address conversion":
+  test "sockAddrLen accepts the two supported families":
+    check:
+      sockAddrLen(AF_INET.int) == Opt.some(sizeof(Sockaddr_in).SockLen)
+      sockAddrLen(AF_INET6.int) == Opt.some(sizeof(Sockaddr_in6).SockLen)
+
+  test "sockAddrLen rejects every other family":
+    # AF_UNSPEC is what a zeroed `Sockaddr_storage` holds when the kernel never
+    # filled it in; the rest stand in for a family this build does not expect,
+    # including the AF_INET6 values used by platforms other than this one.
+    for family in [0, 1, 23, 24, 26, 28, 30, 4242]:
+      if family == AF_INET6.int:
+        continue
+      check sockAddrLen(family).isNone()
+
+  test "toTransportAddress round-trips IPv4":
+    let expected = initTAddress("127.0.0.1:4433")
+    var storage = storageFor(expected)
+    check storage.asSockAddr().toTransportAddress() == Opt.some(expected)
+
+  test "toTransportAddress round-trips IPv6":
+    let expected = initTAddress("[::1]:4433")
+    var storage = storageFor(expected)
+    check storage.asSockAddr().toTransportAddress() == Opt.some(expected)
+
+  test "toTransportAddress rejects an unsupported family":
+    # The drain loop and the lsquic `{.cdecl.}` callbacks are all `raises: []`,
+    # so this must stay a `none` rather than a Defect that aborts the process.
+    var storage = storageFor(initTAddress("127.0.0.1:4433"))
+    storage.ss_family = type(storage.ss_family)(4242)
+    check storage.asSockAddr().toTransportAddress().isNone()


### PR DESCRIPTION
## What

This hardens the UDP drain loop and the socket-address conversion paths it depends on. The change is about correctness and robustness, not throughput.

### Socket-address conversion is now fallible

`sockAddrLen` used to `raiseAssert` on any family other than AF_INET or AF_INET6. That becomes a process abort in the production call sites here: the drain loop is `{.raises: [].}`, and `onNewConn` / `prepareDestAddr` are `{.cdecl.}` callbacks invoked by lsquic.

The conversion helpers now return `Opt`:

- `sockAddrLen` returns `Opt[SockLen]`
- `toTransportAddress` returns `Opt[TransportAddress]`

Each caller handles the unsupported-family case at the boundary where it has enough context:

- the drain loop traces and skips that datagram
- `onNewConn` drops the incoming connection
- `prepareDestAddr` traces and leaves a zero-length destination so the send fails instead of aborting

`onNewConn` also now checks `lsquic_conn_get_sockaddr`; previously a failure there left `local` and `remote` as uninitialized pointers that were dereferenced.

### IPv6 family handling uses Chronos' platform constant

The old `fixed_AF_INET6` workaround is removed. This helper deals with socket address families from `chronos/osdefs`, so it now uses `AF_INET6` from that module instead of a local 30/23/10 table. That also avoids the old Linux-specific fallback value on BSD-family targets.

### The drain loop is hardened

The drain loop now:

- retries POSIX `EINTR` instead of treating it as "socket empty"
- returns early when the endpoint is nil or stopped
- allocates the receive buffer with `newSeqUninit`, since `recvfrom` overwrites the bytes before they are read

### Test coverage

Adds `tests/test_transportaddr.nim` for supported and unsupported socket families, plus IPv4/IPv6 round trips through `toTransportAddress`.

## Sequencing

**This conflicts with #127 (`recvmmsg`), and the conflict loses work silently.** #127 rewrites `drainDatagrams` into a Linux/other split whose Linux path has none of these fixes. Land this one first, then #127 needs rebasing with the fixes carried into *both* branches of the split.
