### PR TITLE
experiment: drain the UDP socket with recvmmsg on Linux

### DIFF
--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -10,7 +10,7 @@ import ./[context, io, stream]
 import
   ../[
     lsquic_ffi, errors, tlsconfig, timeout, stream, certificates, certificateverifier,
-    tracking,
+    socketconfig, tracking,
   ]
 import ../helpers/sequninit
 
@@ -139,6 +139,9 @@ proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
   ctx.settings.es_base_plpmtu = 1280
   ctx.settings.es_max_plpmtu = 0
   ctx.settings.es_pace_packets = 1
+  # Left unset, no transport parameter is sent and the peer applies the RFC
+  # 9000 default of 65527, above what the receive path is sized for.
+  ctx.settings.es_max_udp_payload_size_rx = MaxReceiveDatagramSize.cushort
 
   ctx.settings.es_cfcw = 4 * 1024 * 1024
   ctx.settings.es_max_cfcw = 8 * 1024 * 1024

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -16,17 +16,9 @@ when defined(linux) or defined(windows):
   import ./gso
 
 when defined(linux):
-  {.passc: "-D_GNU_SOURCE".}
+  import ../helpers/mmsg
 
   const SendmmsgBatchSize = 64
-
-  type MMsgHdr {.importc: "struct mmsghdr", header: "<sys/socket.h>", bycopy.} = object
-    msg_hdr: Tmsghdr
-    msg_len: cuint
-
-  proc sendmmsg(
-    sockfd: SocketHandle, msgvec: ptr MMsgHdr, vlen: cuint, flags: cint
-  ): cint {.importc, header: "<sys/socket.h>".}
 
 when defined(windows):
   {.pragma: wsa, stdcall, dynlib: "ws2_32.dll".}

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -7,7 +7,7 @@ import chronicles
 import chronos
 import chronos/osdefs
 import ./[context, io, stream]
-import ../[lsquic_ffi, tlsconfig, timeout, stream, certificates, tracking]
+import ../[lsquic_ffi, tlsconfig, timeout, stream, certificates, socketconfig, tracking]
 import ../helpers/[sequninit, transportaddr]
 
 proc onNewConn(
@@ -69,6 +69,9 @@ proc new*(T: typedesc[ServerContext], tlsConfig: TLSConfig): Result[T, string] =
   ctx.settings.es_base_plpmtu = 1280
   ctx.settings.es_max_plpmtu = 0
   ctx.settings.es_pace_packets = 1
+  # Left unset, no transport parameter is sent and the peer applies the RFC
+  # 9000 default of 65527, above what the receive path is sized for.
+  ctx.settings.es_max_udp_payload_size_rx = MaxReceiveDatagramSize.cushort
 
   ctx.settings.es_cfcw = 1536 * 1024
   ctx.settings.es_max_cfcw = 1536 * 1024

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -5,7 +5,7 @@ import chronos, chronicles, results
 when defined(windows):
   from chronos/osdefs import SOL_SOCKET, SO_RCVBUF
 else:
-  from posix import SOL_SOCKET, SO_RCVBUF
+  from posix import SOL_SOCKET, SO_RCVBUF, Tmsghdr, IOVec, MSG_TRUNC
 import
   ./[
     errors, connection, tlsconfig, connectionmanager, lsquic_ffi, certificateverifier,
@@ -18,6 +18,26 @@ when defined(windows):
   from std/winlean import recvfrom
 else:
   from chronos/osdefs import recvfrom
+
+when defined(linux):
+  const DrainSlotBytes = 2048
+    ## Per-datagram slot in the batch buffer. recvmmsg needs the space reserved
+    ## up front, so this trades a fixed 128 KB per endpoint against being able
+    ## to read a whole burst in one syscall. Comfortably above the largest
+    ## datagram the engine negotiates, and anything longer is reported by
+    ## MSG_TRUNC rather than silently cut.
+
+  type MMsgHdr {.importc: "struct mmsghdr", header: "<sys/socket.h>", bycopy.} = object
+    msg_hdr: Tmsghdr
+    msg_len: cuint
+
+  proc recvmmsg(
+    sockfd: SocketHandle,
+    msgvec: ptr MMsgHdr,
+    vlen: cuint,
+    flags: cint,
+    timeout: pointer,
+  ): cint {.importc, header: "<sys/socket.h>".}
 
 type
   QuicEndpointCapability* = enum
@@ -40,6 +60,12 @@ type
     gso: SegmentationOffload
     stopped: bool
     drainBuf: seq[byte]
+    when defined(linux):
+      # Preallocated once: one slot, address and message header per datagram of
+      # a batch, so a drain is a single recvmmsg rather than a recvfrom each.
+      drainAddrs: seq[Sockaddr_storage]
+      drainIovs: seq[IOVec]
+      drainMsgs: seq[MMsgHdr]
 
 const
   CloseWait: Duration = 300.milliseconds
@@ -199,35 +225,97 @@ proc recvDatagram(
       addr remoteAddrLen,
     ).int
 
-proc drainDatagrams(
-    endpoint: QuicEndpoint, udp: DatagramTransport, local: TransportAddress
-): set[RouteTarget] {.raises: [].} =
-  ## Chronos hands this callback a single datagram per event-loop wakeup, so
-  ## whatever else has already arrived is read here rather than one wakeup, and
-  ## one engine tick, at a time.
-  if endpoint.drainBuf.len == 0:
-    endpoint.drainBuf = newSeq[byte](DefaultDatagramBufferSize)
+when defined(linux):
+  proc initDrainBatch(endpoint: QuicEndpoint) {.raises: [].} =
+    endpoint.drainBuf = newSeq[byte](MaxDatagramsPerWakeup * DrainSlotBytes)
+    endpoint.drainAddrs = newSeq[Sockaddr_storage](MaxDatagramsPerWakeup)
+    endpoint.drainIovs = newSeq[IOVec](MaxDatagramsPerWakeup)
+    endpoint.drainMsgs = newSeq[MMsgHdr](MaxDatagramsPerWakeup)
+    for i in 0 ..< MaxDatagramsPerWakeup:
+      endpoint.drainIovs[i] = IOVec(
+        iov_base: addr endpoint.drainBuf[i * DrainSlotBytes], iov_len: DrainSlotBytes
+      )
+      endpoint.drainMsgs[i].msg_hdr.msg_name = addr endpoint.drainAddrs[i]
+      endpoint.drainMsgs[i].msg_hdr.msg_iov = addr endpoint.drainIovs[i]
+      when defined(x86_64) and not defined(android):
+        endpoint.drainMsgs[i].msg_hdr.msg_iovlen = 1.csize_t
+      else:
+        endpoint.drainMsgs[i].msg_hdr.msg_iovlen = 1.cint
 
-  var targets: set[RouteTarget]
-  for _ in 0 ..< MaxDatagramsPerWakeup:
-    var
-      remoteAddress: Sockaddr_storage
-      remoteAddrLen = SockLen(sizeof(Sockaddr_storage))
-    let res = recvDatagram(
-      SocketHandle(udp.fd), endpoint.drainBuf, remoteAddress, remoteAddrLen
+  proc drainDatagrams(
+      endpoint: QuicEndpoint, udp: DatagramTransport, local: TransportAddress
+  ): set[RouteTarget] {.raises: [].} =
+    ## Chronos hands this callback a single datagram per event-loop wakeup, so
+    ## whatever else has already arrived is read here. recvmmsg takes the whole
+    ## burst in one syscall instead of one recvfrom per datagram plus a final
+    ## one to discover the socket is empty.
+    if endpoint.drainMsgs.len == 0:
+      endpoint.initDrainBatch()
+
+    # the kernel writes these back, so they are reset for every call
+    for i in 0 ..< MaxDatagramsPerWakeup:
+      endpoint.drainMsgs[i].msg_hdr.msg_namelen = SockLen(sizeof(Sockaddr_storage))
+      endpoint.drainMsgs[i].msg_hdr.msg_flags = 0
+
+    let received = recvmmsg(
+      SocketHandle(udp.fd),
+      addr endpoint.drainMsgs[0],
+      MaxDatagramsPerWakeup.cuint,
+      0,
+      nil,
     )
-    if res < 0:
+    if received <= 0:
       # Empty, or an error the transport will report again on the next wakeup.
-      break
+      return {}
 
-    if res > 0:
+    var targets: set[RouteTarget]
+    for i in 0 ..< received:
+      let
+        hdr = addr endpoint.drainMsgs[i]
+        length = hdr.msg_len.int
+      if length <= 0:
+        continue
+      if (hdr.msg_hdr.msg_flags and MSG_TRUNC) != 0:
+        warn "Dropping oversized datagram", bytes = length, slot = DrainSlotBytes
+        continue
       targets.incl endpoint.routeDatagram(
-        endpoint.drainBuf.toOpenArray(0, res - 1),
+        endpoint.drainBuf.toOpenArray(
+          i * DrainSlotBytes, i * DrainSlotBytes + length - 1
+        ),
         local,
-        toTransportAddress(cast[ptr SockAddr](addr remoteAddress)),
+        toTransportAddress(cast[ptr SockAddr](addr endpoint.drainAddrs[i])),
       )
 
-  targets
+    targets
+
+else:
+  proc drainDatagrams(
+      endpoint: QuicEndpoint, udp: DatagramTransport, local: TransportAddress
+  ): set[RouteTarget] {.raises: [].} =
+    ## One recvfrom per datagram, for platforms without recvmmsg.
+    if endpoint.drainBuf.len == 0:
+      endpoint.drainBuf = newSeq[byte](DefaultDatagramBufferSize)
+
+    var targets: set[RouteTarget]
+    for _ in 0 ..< MaxDatagramsPerWakeup:
+      var
+        remoteAddress: Sockaddr_storage
+        remoteAddrLen = SockLen(sizeof(Sockaddr_storage))
+      let res = recvDatagram(
+        SocketHandle(udp.fd), endpoint.drainBuf, remoteAddress, remoteAddrLen
+      )
+      if res < 0:
+        # Empty, or an error the transport will report again on the next wakeup.
+        break
+
+      if res > 0:
+        targets.incl endpoint.routeDatagram(
+          endpoint.drainBuf.toOpenArray(0, res - 1),
+          local,
+          toTransportAddress(cast[ptr SockAddr](addr remoteAddress)),
+        )
+
+    targets
 
 proc receiveFromUdp(
     endpoint: QuicEndpoint, udp: DatagramTransport, remote: TransportAddress

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -5,7 +5,7 @@ import chronos, chronicles, results
 when defined(windows):
   from chronos/osdefs import SOL_SOCKET, SO_RCVBUF
 else:
-  from posix import SOL_SOCKET, SO_RCVBUF, Tmsghdr, IOVec, MSG_TRUNC
+  from posix import SOL_SOCKET, SO_RCVBUF
 import
   ./[
     errors, connection, tlsconfig, connectionmanager, lsquic_ffi, certificateverifier,
@@ -20,24 +20,7 @@ else:
   from chronos/osdefs import recvfrom
 
 when defined(linux):
-  const DrainSlotBytes = 2048
-    ## Per-datagram slot in the batch buffer. recvmmsg needs the space reserved
-    ## up front, so this trades a fixed 128 KB per endpoint against being able
-    ## to read a whole burst in one syscall. Comfortably above the largest
-    ## datagram the engine negotiates, and anything longer is reported by
-    ## MSG_TRUNC rather than silently cut.
-
-  type MMsgHdr {.importc: "struct mmsghdr", header: "<sys/socket.h>", bycopy.} = object
-    msg_hdr: Tmsghdr
-    msg_len: cuint
-
-  proc recvmmsg(
-    sockfd: SocketHandle,
-    msgvec: ptr MMsgHdr,
-    vlen: cuint,
-    flags: cint,
-    timeout: pointer,
-  ): cint {.importc, header: "<sys/socket.h>".}
+  import ./helpers/recvbatch
 
 type
   QuicEndpointCapability* = enum
@@ -59,19 +42,12 @@ type
     udp: DatagramTransport
     gso: SegmentationOffload
     stopped: bool
-    drainBuf: seq[byte]
     when defined(linux):
-      # Preallocated once: one slot, address and message header per datagram of
-      # a batch, so a drain is a single recvmmsg rather than a recvfrom each.
-      drainAddrs: seq[Sockaddr_storage]
-      drainIovs: seq[IOVec]
-      drainMsgs: seq[MMsgHdr]
+      drain: RecvBatch
+    else:
+      drainBuf: seq[byte]
 
-const
-  CloseWait: Duration = 300.milliseconds
-
-  MaxDatagramsPerWakeup = 64
-    ## Capped so that a busy socket cannot starve the rest of the event loop.
+const CloseWait: Duration = 300.milliseconds
 
 proc socketReceiveBufferBytes(
     udp: DatagramTransport
@@ -226,22 +202,6 @@ proc recvDatagram(
     ).int
 
 when defined(linux):
-  proc initDrainBatch(endpoint: QuicEndpoint) {.raises: [].} =
-    endpoint.drainBuf = newSeq[byte](MaxDatagramsPerWakeup * DrainSlotBytes)
-    endpoint.drainAddrs = newSeq[Sockaddr_storage](MaxDatagramsPerWakeup)
-    endpoint.drainIovs = newSeq[IOVec](MaxDatagramsPerWakeup)
-    endpoint.drainMsgs = newSeq[MMsgHdr](MaxDatagramsPerWakeup)
-    for i in 0 ..< MaxDatagramsPerWakeup:
-      endpoint.drainIovs[i] = IOVec(
-        iov_base: addr endpoint.drainBuf[i * DrainSlotBytes], iov_len: DrainSlotBytes
-      )
-      endpoint.drainMsgs[i].msg_hdr.msg_name = addr endpoint.drainAddrs[i]
-      endpoint.drainMsgs[i].msg_hdr.msg_iov = addr endpoint.drainIovs[i]
-      when defined(x86_64) and not defined(android):
-        endpoint.drainMsgs[i].msg_hdr.msg_iovlen = 1.csize_t
-      else:
-        endpoint.drainMsgs[i].msg_hdr.msg_iovlen = 1.cint
-
   proc drainDatagrams(
       endpoint: QuicEndpoint, udp: DatagramTransport, local: TransportAddress
   ): set[RouteTarget] {.raises: [].} =
@@ -249,41 +209,27 @@ when defined(linux):
     ## whatever else has already arrived is read here. recvmmsg takes the whole
     ## burst in one syscall instead of one recvfrom per datagram plus a final
     ## one to discover the socket is empty.
-    if endpoint.drainMsgs.len == 0:
-      endpoint.initDrainBatch()
+    if not endpoint.drain.initialized:
+      endpoint.drain.init()
 
-    # the kernel writes these back, so they are reset for every call
-    for i in 0 ..< MaxDatagramsPerWakeup:
-      endpoint.drainMsgs[i].msg_hdr.msg_namelen = SockLen(sizeof(Sockaddr_storage))
-      endpoint.drainMsgs[i].msg_hdr.msg_flags = 0
-
-    let received = recvmmsg(
-      SocketHandle(udp.fd),
-      addr endpoint.drainMsgs[0],
-      MaxDatagramsPerWakeup.cuint,
-      0,
-      nil,
-    )
+    let received = endpoint.drain.receive(SocketHandle(udp.fd))
     if received <= 0:
       # Empty, or an error the transport will report again on the next wakeup.
       return {}
 
     var targets: set[RouteTarget]
     for i in 0 ..< received:
-      let
-        hdr = addr endpoint.drainMsgs[i]
-        length = hdr.msg_len.int
+      let length = endpoint.drain.datagramLen(i)
       if length <= 0:
         continue
-      if (hdr.msg_hdr.msg_flags and MSG_TRUNC) != 0:
-        warn "Dropping oversized datagram", bytes = length, slot = DrainSlotBytes
+      if endpoint.drain.truncated(i):
+        warn "Dropping datagram larger than the advertised receive maximum",
+          bytes = length, maximum = MaxReceiveDatagramSize
         continue
       targets.incl endpoint.routeDatagram(
-        endpoint.drainBuf.toOpenArray(
-          i * DrainSlotBytes, i * DrainSlotBytes + length - 1
-        ),
+        endpoint.drain.payload(i, length),
         local,
-        toTransportAddress(cast[ptr SockAddr](addr endpoint.drainAddrs[i])),
+        toTransportAddress(endpoint.drain.sender(i)),
       )
 
     targets

--- a/lsquic/helpers/mmsg.nim
+++ b/lsquic/helpers/mmsg.nim
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Shared `struct mmsghdr` wiring for the batched send and receive paths.
+##
+## glibc hides both calls behind `__USE_GNU`, so `_GNU_SOURCE` belongs next to
+## the declarations rather than being inherited from whichever module happens
+## to be in the import graph.
+
+when defined(linux):
+  import std/posix
+
+  {.passc: "-D_GNU_SOURCE".}
+
+  type MMsgHdr* {.importc: "struct mmsghdr", header: "<sys/socket.h>", bycopy.} = object
+    msg_hdr*: Tmsghdr
+    msg_len*: cuint
+
+  proc sendmmsg*(
+    sockfd: SocketHandle, msgvec: ptr MMsgHdr, vlen: cuint, flags: cint
+  ): cint {.importc, header: "<sys/socket.h>".}
+
+  proc recvmmsg*(
+    sockfd: SocketHandle,
+    msgvec: ptr MMsgHdr,
+    vlen: cuint,
+    flags: cint,
+    timeout: pointer,
+  ): cint {.importc, header: "<sys/socket.h>".}

--- a/lsquic/helpers/recvbatch.nim
+++ b/lsquic/helpers/recvbatch.nim
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## A reusable recvmmsg batch: one syscall drains a whole burst, where a
+## recvfrom loop needs one syscall per datagram plus a final one to discover
+## the socket is empty.
+##
+## recvmmsg wants its buffers reserved up front, so a slot has to hold any
+## datagram the peer may legally send. Slots are `MaxReceiveDatagramSize`, the
+## same value the engine advertises as `max_udp_payload_size`. Anything longer
+## is reported by MSG_TRUNC rather than silently cut, and the caller drops it.
+
+when defined(linux):
+  import std/posix
+  import ./mmsg
+  import ../socketconfig
+
+  type RecvBatch* = object
+    buf*: seq[byte]
+    addrs: seq[Sockaddr_storage]
+    iovs: seq[IOVec]
+    msgs: seq[MMsgHdr]
+    dirty: int ## slots the kernel filled on the previous call
+
+  func initialized*(batch: RecvBatch): bool {.raises: [].} =
+    batch.msgs.len > 0
+
+  proc init*(batch: var RecvBatch) {.raises: [].} =
+    batch.buf = newSeq[byte](MaxDatagramsPerWakeup * MaxReceiveDatagramSize)
+    batch.addrs = newSeq[Sockaddr_storage](MaxDatagramsPerWakeup)
+    batch.iovs = newSeq[IOVec](MaxDatagramsPerWakeup)
+    batch.msgs = newSeq[MMsgHdr](MaxDatagramsPerWakeup)
+    batch.dirty = 0
+    for i in 0 ..< MaxDatagramsPerWakeup:
+      batch.iovs[i] = IOVec(
+        iov_base: addr batch.buf[i * MaxReceiveDatagramSize],
+        iov_len: MaxReceiveDatagramSize.csize_t,
+      )
+      batch.msgs[i].msg_hdr.msg_name = addr batch.addrs[i]
+      batch.msgs[i].msg_hdr.msg_namelen = SockLen(sizeof(Sockaddr_storage))
+      batch.msgs[i].msg_hdr.msg_iov = addr batch.iovs[i]
+      when defined(x86_64) and not defined(android):
+        batch.msgs[i].msg_hdr.msg_iovlen = 1.csize_t
+      else:
+        batch.msgs[i].msg_hdr.msg_iovlen = 1.cint
+
+  proc receive*(batch: var RecvBatch, fd: SocketHandle): int {.raises: [].} =
+    ## Reads a whole burst. Returns the number of datagrams, or a negative
+    ## value when the socket is empty or the read failed.
+    ##
+    ## MSG_TRUNC makes the kernel report the true length of a datagram that did
+    ## not fit, so an oversized one can be logged with the size it actually was
+    ## rather than the size that was copied.
+    for i in 0 ..< batch.dirty:
+      # msg_namelen is in/out: the kernel writes back the length of the address
+      # it stored, and that value is the capacity on the next call, so only the
+      # slots it filled last time need restoring. msg_flags needs no reset, the
+      # kernel writes it on every slot it fills.
+      batch.msgs[i].msg_hdr.msg_namelen = SockLen(sizeof(Sockaddr_storage))
+
+    let received =
+      recvmmsg(fd, addr batch.msgs[0], MaxDatagramsPerWakeup.cuint, MSG_TRUNC, nil).int
+    batch.dirty = max(received, 0)
+    received
+
+  func datagramLen*(batch: RecvBatch, i: int): int {.raises: [].} =
+    ## The length the datagram had on the wire, which for a truncated one is
+    ## more than was copied into the slot.
+    batch.msgs[i].msg_len.int
+
+  func truncated*(batch: RecvBatch, i: int): bool {.raises: [].} =
+    (batch.msgs[i].msg_hdr.msg_flags and MSG_TRUNC) != 0
+
+  proc sender*(batch: var RecvBatch, i: int): ptr SockAddr {.raises: [].} =
+    cast[ptr SockAddr](addr batch.addrs[i])
+
+  template payload*(batch: RecvBatch, i, length: int): openArray[byte] =
+    batch.buf.toOpenArray(
+      i * MaxReceiveDatagramSize, i * MaxReceiveDatagramSize + length - 1
+    )

--- a/lsquic/socketconfig.nim
+++ b/lsquic/socketconfig.nim
@@ -3,7 +3,19 @@
 
 import ./errors
 
-const DefaultQuicReceiveBufferBytes* = 8 * 1024 * 1024
+const
+  DefaultQuicReceiveBufferBytes* = 8 * 1024 * 1024
+
+  MaxReceiveDatagramSize* = 2048
+    ## Largest UDP payload the receive path accepts, advertised to the peer as
+    ## `max_udp_payload_size`. The batched drain reserves a slot of this size
+    ## per datagram up front, so what it is able to accept has to be what the
+    ## peer was told to stay under: with no transport parameter sent, the peer
+    ## applies the RFC 9000 default of 65527 and may legally send what the
+    ## batch would then have to drop.
+
+  MaxDatagramsPerWakeup* = 64
+    ## Capped so that a busy socket cannot starve the rest of the event loop.
 
 type QuicSocketConfig* = object
   receiveBufferBytes*: int = DefaultQuicReceiveBufferBytes

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -5,7 +5,7 @@
 
 import
   test_connection, test_perf, test_tlsconfig, test_verifier, test_lifecycle,
-  test_timeout, test_stress, test_runtime, test_gso
+  test_timeout, test_stress, test_runtime, test_gso, test_recvbatch
 
 from ./helpers/trackers import finalCheckTrackers
 finalCheckTrackers()

--- a/tests/test_recvbatch.nim
+++ b/tests/test_recvbatch.nim
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+when defined(linux):
+  import std/posix
+  import unittest2
+  import ../lsquic/helpers/recvbatch
+  import ../lsquic/socketconfig
+
+  proc makeSocket(): SocketHandle =
+    let fd = socket(AF_INET, SOCK_DGRAM, 0)
+    doAssert fd.int >= 0
+    fd
+
+  proc bindLoopback(fd: SocketHandle): Sockaddr_in =
+    var address = Sockaddr_in(sin_family: AF_INET.uint16, sin_port: 0)
+    address.sin_addr.s_addr = 0x0100007F'u32 # 127.0.0.1, network order
+    doAssert bindSocket(fd, cast[ptr SockAddr](addr address), SockLen(sizeof(address))) ==
+      0
+    var length = SockLen(sizeof(result))
+    doAssert getsockname(fd, cast[ptr SockAddr](addr result), addr length) == 0
+    doAssert fcntl(fd.cint, F_SETFL, O_NONBLOCK) == 0
+    # a burst has to survive in the socket buffer until one recvmmsg takes it
+    var size = 4 * 1024 * 1024
+    discard setsockopt(fd, SOL_SOCKET, SO_RCVBUF, addr size, SockLen(sizeof(size)))
+
+  proc send(fd: SocketHandle, dest: Sockaddr_in, payload: openArray[byte]) =
+    let sent = sendto(
+      fd,
+      unsafeAddr payload[0],
+      payload.len,
+      0,
+      cast[ptr SockAddr](unsafeAddr dest),
+      SockLen(sizeof(dest)),
+    )
+    doAssert sent == payload.len, "sendto sent " & $sent & " of " & $payload.len
+
+  proc datagram(length: int, tag: byte): seq[byte] =
+    ## Distinct content per datagram, so a slot read at the wrong offset or
+    ## with the wrong length cannot pass.
+    result = newSeq[byte](length)
+    for i in 0 ..< length:
+      result[i] = byte((i + tag.int) and 0xFF)
+
+  proc port(address: Sockaddr_in): uint16 =
+    address.sin_port.uint16
+
+  proc senderPort(batch: var RecvBatch, i: int): uint16 =
+    cast[ptr Sockaddr_in](batch.sender(i)).sin_port.uint16
+
+  suite "recvmmsg drain batch":
+    setup:
+      var
+        batch: RecvBatch
+        receiver = makeSocket()
+        sender = makeSocket()
+      let
+        destination = receiver.bindLoopback()
+        source = sender.bindLoopback()
+      batch.init()
+
+    teardown:
+      discard close(receiver.cint)
+      discard close(sender.cint)
+
+    test "an empty socket reports no datagrams":
+      check batch.receive(receiver) < 0
+
+    test "a burst is drained by one call, each slot holding its own datagram":
+      let lengths = [1, 64, 1200, MaxReceiveDatagramSize, 300, 1500]
+      for i, length in lengths:
+        sender.send(destination, datagram(length, byte(i)))
+
+      check batch.receive(receiver) == lengths.len
+      for i, length in lengths:
+        check batch.datagramLen(i) == length
+        check not batch.truncated(i)
+        check @(batch.payload(i, length)) == datagram(length, byte(i))
+
+      # and the socket is now empty
+      check batch.receive(receiver) < 0
+
+    test "an oversized datagram is flagged without disturbing its neighbours":
+      let oversized = MaxReceiveDatagramSize + 1
+      sender.send(destination, datagram(1200, 1))
+      sender.send(destination, datagram(oversized, 2))
+      sender.send(destination, datagram(60000, 3))
+      sender.send(destination, datagram(900, 4))
+
+      check batch.receive(receiver) == 4
+
+      check not batch.truncated(0)
+      check @(batch.payload(0, 1200)) == datagram(1200, 1)
+
+      # MSG_TRUNC reports the length the datagram had on the wire, not the
+      # length that fit in the slot
+      check batch.truncated(1)
+      check batch.datagramLen(1) == oversized
+      check batch.truncated(2)
+      check batch.datagramLen(2) == 60000
+
+      check not batch.truncated(3)
+      check @(batch.payload(3, 900)) == datagram(900, 4)
+
+    test "a zero-length datagram occupies a slot without a payload":
+      sender.send(destination, datagram(1200, 1))
+      var nothing: byte
+      doAssert sendto(
+        sender,
+        addr nothing,
+        0,
+        0,
+        cast[ptr SockAddr](unsafeAddr destination),
+        SockLen(sizeof(destination)),
+      ) == 0
+      sender.send(destination, datagram(700, 3))
+
+      check batch.receive(receiver) == 3
+      check batch.datagramLen(1) == 0
+      check @(batch.payload(2, 700)) == datagram(700, 3)
+
+    test "each slot carries the address of its own sender":
+      var second = makeSocket()
+      let secondSource = second.bindLoopback()
+
+      sender.send(destination, datagram(100, 1))
+      second.send(destination, datagram(200, 2))
+      sender.send(destination, datagram(300, 3))
+
+      check batch.receive(receiver) == 3
+      check batch.senderPort(0) == source.port
+      check batch.senderPort(1) == secondSource.port
+      check batch.senderPort(2) == source.port
+
+      discard close(second.cint)
+
+    test "state does not leak from one call into the next":
+      # `receive` only resets the slots the previous call filled, so a shorter
+      # burst after a longer one must not inherit its flags or addresses.
+      var second = makeSocket()
+      let secondSource = second.bindLoopback()
+
+      # the truncated datagram has to land in a slot the shorter second burst
+      # will reuse, or nothing is being tested
+      second.send(destination, datagram(MaxReceiveDatagramSize + 1, 9))
+      for i in 0 ..< 5:
+        sender.send(destination, datagram(1200, byte(i)))
+      check batch.receive(receiver) == 6
+      check batch.truncated(0)
+
+      second.send(destination, datagram(400, 7))
+      sender.send(destination, datagram(500, 8))
+      check batch.receive(receiver) == 2
+
+      for i in 0 ..< 2:
+        check not batch.truncated(i)
+      check batch.datagramLen(0) == 400
+      check batch.senderPort(0) == secondSource.port
+      check batch.senderPort(1) == source.port
+      check @(batch.payload(1, 500)) == datagram(500, 8)
+
+      discard close(second.cint)


### PR DESCRIPTION
## What

The drain loop issued one `recvfrom` per datagram plus a final one to discover the socket was empty. This is the receive-side counterpart of the `sendmmsg` batching the send path already does: `recvmmsg` takes the whole burst in one syscall.

Message headers, address storage and slot buffers are allocated once per endpoint and reused. Other platforms keep the `recvfrom` loop.

## Measured with strace

8 connections, release:

| | receive syscalls before | after |
|---|---|---|
| request/response | 108,855 `recvfrom` | 12,170 `recvmmsg` + 12,170 `recvfrom` (**-78%**) |
| bulk | 75,990 `recvfrom` | 1,688 `recvmmsg` + 1,688 `recvfrom` (**-96%**) |

Total syscalls in request/response: 205,095 -> 120,570 (-41%). The remaining `recvfrom` is chronos' own read, one per wakeup.

## It does not show in wall clock, and that is the honest headline

| | before | after |
|---|---|---|
| request/response | 1.1676 s | 1.1495 s (-1.5%) |
| bulk | 0.3255 s | 0.3263 s (-0.3%) |

Both inside this machine's noise. A loopback `recvfrom` is cheap. The reduction is worth more where a syscall costs more — a real NIC, higher packet rates, speculative-execution mitigations enabled — none of which is measured here.

Working backwards from the numbers: 96,685 syscalls saved over a 1.1676 s run means the measured -1.5% is consistent with a `recvfrom` costing roughly 180 ns. At 1.5 µs, which is not unusual on a cloud guest with full mitigations, the same syscall delta would be worth about 12%. Which of those a deployment sits in is decided by `/sys/devices/system/cpu/vulnerabilities` on the target, not by anything in this diff.

**So this is a judgement call for someone with deployment context, not a slam dunk.** I would not merge it on the numbers above alone.

## Memory is the remaining tradeoff

`recvmmsg` needs its buffers reserved up front, so an endpoint now holds 64 slots rather than one 64 KB buffer:

| | bytes |
|---|---|
| slots (64 x 2048) | 131,072 |
| address storage | 8,192 |
| message headers | 4,096 |
| iovecs | 1,024 |
| **total** | **144,384 (141 KB)** |

against 64 KB before, and chronos' own 64 KB transport buffer is unchanged on top of both.

## Oversized datagrams: now advertised rather than silently dropped

A slot is 2048 bytes, so the receive path cannot accept more than that per datagram. Previously nothing told the peer. `es_max_udp_payload_size_rx` was never set, so lsquic sent no `max_udp_payload_size` transport parameter, the peer applied the RFC 9000 default of 65527, and a datagram it was entitled to send would have been dropped with no signal in either direction.

The slot size is now advertised as `max_udp_payload_size` on both contexts and on every platform. lsquic caps its MTU ceiling to the peer's advertised value (`lsquic_full_conn_ietf.c:7887`), and RFC 9000 requires the same of any other implementation, so the limit the receive path enforces is the limit the peer was given. 2048 is well above the RFC minimum of 1200 and above any real path MTU, so nothing is given up.

Advertising it on all platforms also removes an order dependency that would otherwise have been Linux-only: the first datagram of a wakeup goes through chronos' 64 KB buffer and the rest go through 2048-byte slots, so without a common advertised limit the same datagram would be accepted or dropped depending on where it landed in a burst.

This would still need raising before enabling any receive-side offload such as GRO.

## Diagnostics

`recvmmsg` is called with `MSG_TRUNC`, which makes the kernel report the true length of a datagram that did not fit. Without it `msg_len` is the length that was copied, always exactly the slot size, so the warning read `bytes=2048, slot=2048` whether the datagram was 4 KB or 64 KB.

## Sequencing

**Conflicts with the drain hardening PR (#126), in a way that loses work silently.** This branch rewrites `drainDatagrams` into a Linux/other split, and its Linux path does not carry those fixes — no address-family guard, no `EINTR` retry, `newSeq` rather than `newSeqUninit`. The missing family guard is the one that matters: `toTransportAddress` reaches `sockAddrLen`, which raises a Defect on an unrecognised family, inside a `{.raises: [].}` receive callback. Land #126 first; this then needs rebasing with the fixes applied to *both* branches of the split.

Also behind `main` by #118, #120, #121, #123 and #128. No conflict with #120's `readIncoming`.

## Structure

The batch lives in `helpers/recvbatch.nim` rather than inline in `endpoint.nim`, following the `gso.nim` precedent, so a test can drive it directly against a real socket. `endpoint.nim` loses 47 lines. The `mmsghdr` wiring shared with the send path moves to `helpers/mmsg.nim` together with the `_GNU_SOURCE` define, which was previously declared in `io.nim` only and reached `endpoint.nim` because `passC` happens to be global — glibc hides both calls behind `__USE_GNU`, so a future import change would have turned that into an implicit declaration.

The per-wakeup reset covers only the slots the kernel filled, and only `msg_namelen`. `msg_flags` needs no reset; the kernel writes it on every slot it fills, confirmed by disabling the reset and watching the truncation tests still pass.

## Checks

- 101 tests green on `--mm:orc` and `--mm:refc`, including 6 new ones in `tests/test_recvbatch.nim` covering slot arithmetic, per-slot sender addresses, zero-length datagrams, truncation reporting and reuse across calls
- Mutation-checked: removing `MSG_TRUNC` from the flags fails the truncation test
- `nph --check` clean
- `nim check --os:macosx` clean, which exercises the non-Linux drain branch
- `nim check --os:windows` at the same two pre-existing boringssl errors as baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
