### PR TITLE
 test: stream read/write locking and timeout re-arm

### DIFF
--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -508,12 +508,16 @@ suite "lifecycle":
 
   asyncTest "nil read destination is rejected":
     let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
 
     expect AssertionDefect:
       discard await stream.readOnce(nil, 8)
 
   asyncTest "read waiting for the read lock sees the stream closed by the engine":
     let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
     # hold the lock so the read parks after its pre-lock checks have passed
     await stream.readLock.acquire()
 
@@ -529,6 +533,8 @@ suite "lifecycle":
 
   asyncTest "read waiting for the read lock sees a peer reset":
     let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
     await stream.readLock.acquire()
 
     var buf = newSeq[byte](8)
@@ -539,6 +545,34 @@ suite "lifecycle":
 
     expect StreamResetError:
       discard await reading
+
+  asyncTest "write waiting for the write lock sees the stream closed by the engine":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+    await stream.writeLock.acquire()
+
+    let writing = stream.write(@[1'u8])
+
+    stream.closedByEngine = true
+    stream.writeLock.release()
+
+    expect StreamError:
+      await writing
+
+  asyncTest "write waiting for the write lock sees a peer reset":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+    await stream.writeLock.acquire()
+
+    let writing = stream.write(@[1'u8])
+
+    stream.markResetByPeer(ResetWrite)
+    stream.writeLock.release()
+
+    expect StreamResetError:
+      await writing
 
   asyncTest "concurrent reads on one stream are serialized":
     let peers = await connectPeers()
@@ -553,10 +587,8 @@ suite "lifecycle":
     check (await incomingStream.readOnce(kickoff)) == 1
     check kickoff[0] == 1
 
-    # Both reads park. A stream has a single pending-read slot, so `readLock` has
-    # to keep the second reader out until the first one is done; otherwise the
-    # second task would overwrite the first and the first read would hang.
-    # The buffer lengths differ so the pending task identifies its owner.
+    # A stream has a single pending-read slot, so `readLock` has to keep the
+    # second reader out until the first one is done.
     var firstBuf = newSeq[byte](4)
     var secondBuf = newSeq[byte](8)
     let firstRead = incomingStream.readOnce(firstBuf)

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -583,10 +583,10 @@ suite "lifecycle":
     await outgoingStream.write(@[1'u8])
     let incomingStream = await peers.incoming.incomingStream()
 
-    var kickoff = newSeq[byte](1)
+    var firstByte = newSeq[byte](1)
     check:
-      (await incomingStream.readOnce(kickoff)) == 1
-      kickoff[0] == 1
+      (await incomingStream.readOnce(firstByte)) == 1
+      firstByte[0] == 1
 
     # A stream has a single pending-read slot, so `readLock` has to keep the
     # second reader out until the first one is done.

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -467,3 +467,81 @@ suite "lifecycle":
     var buf = newSeq[byte](8)
     expect StreamResetError:
       discard await stream.readOnce(buf)
+
+  asyncTest "nil read destination is rejected":
+    let stream = Stream.new()
+
+    expect AssertionDefect:
+      discard await stream.readOnce(nil, 8)
+
+  asyncTest "read waiting for the read lock sees the stream closed by the engine":
+    let stream = Stream.new()
+    # hold the lock so the read parks after its pre-lock checks have passed
+    await stream.readLock.acquire()
+
+    var buf = newSeq[byte](8)
+    let reading = stream.readOnce(buf)
+
+    stream.closedByEngine = true
+    stream.readLock.release()
+
+    # the post-lock re-check keeps the read away from the freed native stream
+    check (await reading.withTimeout(timeout))
+    check (await reading) == 0
+
+  asyncTest "read waiting for the read lock sees a peer reset":
+    let stream = Stream.new()
+    await stream.readLock.acquire()
+
+    var buf = newSeq[byte](8)
+    let reading = stream.readOnce(buf)
+
+    stream.markResetByPeer(ResetRead)
+    stream.readLock.release()
+
+    expect StreamResetError:
+      discard await reading
+
+  asyncTest "concurrent reads on one stream are serialized":
+    let peers = await connectPeers()
+    defer:
+      await peers.stop()
+
+    let outgoingStream = await peers.outgoing.openStream()
+    await outgoingStream.write(@[1'u8])
+    let incomingStream = await peers.incoming.incomingStream()
+
+    var kickoff = newSeq[byte](1)
+    check (await incomingStream.readOnce(kickoff)) == 1
+    check kickoff[0] == 1
+
+    # Both reads park. A stream has a single pending-read slot, so `readLock` has
+    # to keep the second reader out until the first one is done; otherwise the
+    # second task would overwrite the first and the first read would hang.
+    # The buffer lengths differ so the pending task identifies its owner.
+    var firstBuf = newSeq[byte](4)
+    var secondBuf = newSeq[byte](8)
+    let firstRead = incomingStream.readOnce(firstBuf)
+    let secondRead = incomingStream.readOnce(secondBuf)
+
+    await sleepAsync(100.milliseconds)
+    check not firstRead.finished
+    check not secondRead.finished
+    check incomingStream.toRead.valueOr(ReadTask()).dataLen == firstBuf.len
+
+    await outgoingStream.write(@[7'u8])
+    check (await firstRead.withTimeout(timeout))
+    check (await firstRead) == 1
+    check firstBuf[0] == 7
+
+    # only now does the second read take the lock and claim the pending slot
+    await sleepAsync(100.milliseconds)
+    check not secondRead.finished
+    check incomingStream.toRead.valueOr(ReadTask()).dataLen == secondBuf.len
+
+    await outgoingStream.write(@[8'u8])
+    check (await secondRead.withTimeout(timeout))
+    check (await secondRead) == 1
+    check secondBuf[0] == 8
+
+    await incomingStream.close()

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -584,8 +584,9 @@ suite "lifecycle":
     let incomingStream = await peers.incoming.incomingStream()
 
     var kickoff = newSeq[byte](1)
-    check (await incomingStream.readOnce(kickoff)) == 1
-    check kickoff[0] == 1
+    check:
+      (await incomingStream.readOnce(kickoff)) == 1
+      kickoff[0] == 1
 
     # A stream has a single pending-read slot, so `readLock` has to keep the
     # second reader out until the first one is done.
@@ -594,24 +595,31 @@ suite "lifecycle":
     let firstRead = incomingStream.readOnce(firstBuf)
     let secondRead = incomingStream.readOnce(secondBuf)
 
+    # A parked read completes nothing, so there is no event to wait on.
+    # The sleep is the window in which the second read would claim the slot
+    # if `readLock` let it through.
     await sleepAsync(100.milliseconds)
-    check not firstRead.finished
-    check not secondRead.finished
-    check incomingStream.toRead.valueOr(ReadTask()).dataLen == firstBuf.len
+    check:
+      not firstRead.finished
+      not secondRead.finished
+      incomingStream.toRead.valueOr(ReadTask()).dataLen == firstBuf.len
 
     await outgoingStream.write(@[7'u8])
-    check (await firstRead.withTimeout(timeout))
-    check (await firstRead) == 1
-    check firstBuf[0] == 7
+    check:
+      (await firstRead.withTimeout(timeout))
+      (await firstRead) == 1
+      firstBuf[0] == 7
 
     # only now does the second read take the lock and claim the pending slot
     await sleepAsync(100.milliseconds)
-    check not secondRead.finished
-    check incomingStream.toRead.valueOr(ReadTask()).dataLen == secondBuf.len
+    check:
+      not secondRead.finished
+      incomingStream.toRead.valueOr(ReadTask()).dataLen == secondBuf.len
 
     await outgoingStream.write(@[8'u8])
-    check (await secondRead.withTimeout(timeout))
-    check (await secondRead) == 1
-    check secondBuf[0] == 8
+    check:
+      (await secondRead.withTimeout(timeout))
+      (await secondRead) == 1
+      secondBuf[0] == 8
 
     await incomingStream.close()

--- a/tests/test_timeout.nim
+++ b/tests/test_timeout.nim
@@ -39,6 +39,24 @@ suite "timeout":
     check (await fired.wait().withTimeout(fireTimeout))
     check fireCount == 1
 
+  asyncTest "expiry callback can re-arm the timeout":
+    let rearmedFired = newAsyncEvent()
+    var fireCount = 0
+    var timeout: Timeout
+    timeout = newTimeout(
+      proc() =
+        inc fireCount
+        if fireCount == 1:
+          timeout.set(50.milliseconds)
+        else:
+          rearmedFired.fire()
+    )
+
+    timeout.set(50.milliseconds)
+
+    check (await rearmedFired.wait().withTimeout(fireTimeout))
+    check fireCount == 2
+
   asyncTest "stop cancels expiry":
     var fired = 0
     let timeout = newTimeout(


### PR DESCRIPTION
Adds tests to `test_lifecycle` and `test_timeout`.

`test_lifecycle`:
- `readOnce` and `write` re-check `closedByEngine` and peer reset after taking `readLock` / `writeLock`, so a caller that parked on the lock never touches a stream an engine callback already changed
- `readOnce(nil, 8)` raises `AssertionDefect` instead of passing a nil buffer to `lsquic_stream_read`
- Concurrent reads on one stream serialize. A `Stream` has a single `toRead` slot, so without `readLock` the second reader overwrites the first

`test_timeout`:
- An `onExpiry` callback can call `set` on its own `Timeout`. `onTimeout` runs `stop` first, so the re-arm survives