### PR TITLE
feat(benchmarks): error handling, resource-usage capture, refreshed docs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -97,14 +97,14 @@ time.
 Example output (100MB download over WAN with 25ms latency, 100 Mbit cap):
 
 ```
-Stream #1 [ramp-up] (20 windows, 50ms each):
+Stream #1 [ramp-up] (192 windows, 50ms each):
   Time to 90% peak: 150.000ms
-  Peak throughput:  83.48 Mbit/s
+  Peak throughput:  95.77 Mbit/s
   Timeline:
-       50ms |    12.3 Mbit/s | ######
-      100ms |    68.7 Mbit/s | #################################
-      150ms |    83.5 Mbit/s | ########################################
-      200ms |    82.9 Mbit/s | #######################################
+       50ms |     7.2 Mbit/s | ###
+      100ms |    51.0 Mbit/s | #####################
+      150ms |    94.6 Mbit/s | ########################################
+      200ms |    94.9 Mbit/s | ########################################
       ...
 ```
 
@@ -260,48 +260,71 @@ kill %1
 
 ### Sample Run
 
-Full matrix run (`./benchmarks/run.sh`) across all 6 scenarios and 6 modes:
+Full matrix run (`./benchmarks/run.sh`) across all 6 scenarios and 6 modes.
+
+Measured on an Intel Core Ultra 7 155H (22 threads), 62 GB RAM, Docker bridge
+networking. Absolute numbers are host-dependent — especially the LAN row, which
+measures loopback-class bandwidth rather than a real network — so compare
+relative movements between modes rather than treating these as targets.
 
 ```
-Scenario        Mode           Conns  Strms  Upload          Download        Lat p50      Lat p95      Duration
-========================================================================================================================
-lan             throughput     1      1      10.99 Mbit/s    1.10 Gbit/s     -            -            363.907ms
-lan             latency        1      1      -               -               57.966us     173.932us    7.530ms
-lan             multistream    1      4      11.15 Mbit/s    1.11 Gbit/s     1.277ms      10.798ms     430.670ms
-lan             multiconn      4      1      11.82 Mbit/s    1.18 Gbit/s     293.599us    15.731ms     406.153ms
-lan             stress         4      4      13.90 Mbit/s    1.39 Gbit/s     8.207ms      37.689ms     690.415ms
-lan             rampup         1      1      -               1.09 Gbit/s     150.000ms    p90          736.432ms
-wan             throughput     1      1      900.16 Kbit/s   90.02 Mbit/s    -            -            4.444s
-wan             latency        1      1      -               -               25.660ms     25.761ms     2.565s
-wan             multistream    1      4      703.95 Kbit/s   70.39 Mbit/s    25.697ms     220.947ms    6.819s
-wan             multiconn      4      1      750.57 Kbit/s   75.06 Mbit/s    36.330ms     36.402ms     6.395s
-wan             stress         4      4      573.97 Kbit/s   57.40 Mbit/s    25.731ms     1.029s       16.726s
-wan             rampup         1      1      -               94.22 Mbit/s    150.000ms    p90          8.491s
-constrained     throughput     1      1      92.32 Kbit/s    9.23 Mbit/s     -            -            43.327s
-constrained     latency        1      1      -               -               50.792ms     50.977ms     5.082s
-constrained     multistream    1      4      94.25 Kbit/s    9.43 Mbit/s     94.594ms     163.685ms    50.928s
-constrained     multiconn      4      1      93.94 Kbit/s    9.39 Mbit/s     96.019ms     100.841ms    51.096s
-constrained     stress         4      4      92.25 Kbit/s    9.22 Mbit/s     50.928ms     122.342ms    104.068s
-constrained     rampup         1      1      -               9.49 Mbit/s     900.000ms    p90          84.324s
-lossy           throughput     1      1      405.86 Kbit/s   40.59 Mbit/s    -            -            9.856s
-lossy           latency        1      1      -               -               25.695ms     25.902ms     2.571s
-lossy           multistream    1      4      346.40 Kbit/s   34.64 Mbit/s    25.724ms     824.939ms    13.857s
-lossy           multiconn      4      1      339.58 Kbit/s   33.96 Mbit/s    47.512ms     47.747ms     14.135s
-lossy           stress         4      4      320.42 Kbit/s   32.04 Mbit/s    25.762ms     995.620ms    29.961s
-lossy           rampup         1      1      -               41.33 Mbit/s    150.000ms    p90          19.356s
-mobile          throughput     1      1      45.32 Kbit/s    4.53 Mbit/s     -            -            88.260s
-mobile          latency        1      1      -               -               75.919ms     76.187ms     7.902s
-mobile          multistream    1      4      46.90 Kbit/s    4.69 Mbit/s     123.369ms    614.949ms    102.349s
-mobile          multiconn      4      1      46.61 Kbit/s    4.66 Mbit/s     119.147ms    351.425ms    102.988s
-mobile          stress         4      4      46.42 Kbit/s    4.64 Mbit/s     121.724ms    453.206ms    206.803s
-mobile          rampup         1      1      -               4.74 Mbit/s     3.350s       p90          168.757s
-reorder         throughput     1      1      672.33 Kbit/s   67.23 Mbit/s    -            -            5.949s
-reorder         latency        1      1      -               -               25.690ms     25.896ms     2.417s
-reorder         multistream    1      4      636.49 Kbit/s   63.65 Mbit/s    25.677ms     441.939ms    7.541s
-reorder         multiconn      4      1      664.28 Kbit/s   66.43 Mbit/s    36.302ms     36.407ms     7.226s
-reorder         stress         4      4      746.94 Kbit/s   74.69 Mbit/s    25.704ms     934.372ms    12.852s
-reorder         rampup         1      1      -               90.96 Mbit/s    100.000ms    p90          8.795s
+Scenario        Mode           Conns  Strms  Upload          Download        Lat p50      Lat p95      Duration     CPU cli     CPU srv     Peak RSS
+===========================================================================================================================================================
+lan             throughput     1      1      22.49 Mbit/s    2.25 Gbit/s     -            -            177.895ms    144.961ms   289.813ms   11.8 MiB
+lan             latency        1      1      -               -               55.313us     87.729us     6.566ms      33.146ms    111.565ms   11.7 MiB
+lan             multistream    1      4      18.82 Mbit/s    1.88 Gbit/s     40.992us     17.191ms     255.111ms    189.392ms   380.229ms   21.7 MiB
+lan             multiconn      4      1      20.15 Mbit/s    2.01 Gbit/s     39.526us     16.246ms     238.226ms    186.240ms   384.302ms   21.4 MiB
+lan             stress         4      4      21.47 Mbit/s    2.15 Gbit/s     51.891us     53.027ms     447.053ms    309.429ms   613.795ms   59.3 MiB
+lan             rampup         1      1      -               2.40 Gbit/s     150.000ms    p90          333.699ms    252.956ms   461.795ms   11.8 MiB
+wan             throughput     1      1      902.85 Kbit/s   90.28 Mbit/s    -            -            4.430s       746.879ms   4.393s      12.3 MiB
+wan             latency        1      1      -               -               25.352ms     25.475ms     2.535s       49.213ms    203.719ms   11.9 MiB
+wan             multistream    1      4      637.13 Kbit/s   63.71 Mbit/s    25.376ms     220.711ms    7.534s       818.990ms   5.326s      15.5 MiB
+wan             multiconn      4      1      919.43 Kbit/s   91.94 Mbit/s    36.339ms     36.378ms     5.221s       828.930ms   5.299s      16.0 MiB
+wan             stress         4      4      591.71 Kbit/s   59.17 Mbit/s    25.770ms     1.172s       16.224s      1.401s      10.593s     30.5 MiB
+wan             rampup         1      1      -               83.57 Mbit/s    150.000ms    p90          9.573s       1.137s      8.688s      16.5 MiB
+constrained     throughput     1      1      93.39 Kbit/s    9.34 Mbit/s     -            -            42.833s      1.077s      1.987s      11.8 MiB
+constrained     latency        1      1      -               -               50.466ms     50.669ms     5.050s       60.147ms    274.517ms   11.7 MiB
+constrained     multistream    1      4      94.29 Kbit/s    9.43 Mbit/s     96.614ms     428.695ms    50.905s      1.718s      2.646s      11.7 MiB
+constrained     multiconn      4      1      93.59 Kbit/s    9.36 Mbit/s     95.801ms     100.843ms    51.288s      1.722s      2.911s      11.8 MiB
+constrained     stress         4      4      92.38 Kbit/s    9.24 Mbit/s     50.383ms     109.086ms    103.914s     3.364s      5.666s      12.3 MiB
+constrained     rampup         1      1      -               9.49 Mbit/s     700.000ms    p90          84.307s      2.549s      3.914s      11.6 MiB
+lossy           throughput     1      1      406.78 Kbit/s   40.68 Mbit/s    -            -            9.833s       718.467ms   8.570s      11.7 MiB
+lossy           latency        1      1      -               -               25.364ms     25.630ms     2.672s       57.357ms    174.575ms   11.6 MiB
+lossy           multistream    1      4      361.71 Kbit/s   36.17 Mbit/s    25.374ms     565.669ms    13.270s      804.105ms   10.357s     13.4 MiB
+lossy           multiconn      4      1      343.65 Kbit/s   34.36 Mbit/s    47.499ms     47.627ms     13.968s      862.115ms   10.488s     15.8 MiB
+lossy           stress         4      4      301.73 Kbit/s   30.17 Mbit/s    25.336ms     1.648s       31.816s      1.405s      21.058s     26.4 MiB
+lossy           rampup         1      1      -               38.98 Mbit/s    150.000ms    p90          20.523s      1.198s      17.174s     12.9 MiB
+mobile          throughput     1      1      45.32 Kbit/s    4.53 Mbit/s     -            -            88.264s      1.361s      3.604s      11.9 MiB
+mobile          latency        1      1      -               -               75.613ms     75.801ms     7.567s       56.898ms    316.761ms   11.6 MiB
+mobile          multistream    1      4      46.86 Kbit/s    4.69 Mbit/s     121.086ms    770.688ms    102.422s     1.757s      4.297s      11.7 MiB
+mobile          multiconn      4      1      46.53 Kbit/s    4.65 Mbit/s     118.931ms    126.222ms    103.161s     1.800s      4.324s      11.9 MiB
+mobile          stress         4      4      46.34 Kbit/s    4.63 Mbit/s     75.551ms     239.780ms    207.150s     3.922s      8.926s      13.0 MiB
+mobile          rampup         1      1      -               4.75 Mbit/s     8.250s       p90          168.595s     2.640s      6.899s      11.7 MiB
+reorder         throughput     1      1      782.97 Kbit/s   78.30 Mbit/s    -            -            5.109s       610.448ms   4.411s      13.0 MiB
+reorder         latency        1      1      -               -               25.332ms     25.439ms     2.057s       47.919ms    209.847ms   11.5 MiB
+reorder         multistream    1      4      617.32 Kbit/s   61.73 Mbit/s    25.360ms     620.952ms    7.776s       622.010ms   5.293s      15.1 MiB
+reorder         multiconn      4      1      677.75 Kbit/s   67.77 Mbit/s    36.279ms     36.373ms     7.082s       660.459ms   5.290s      14.8 MiB
+reorder         stress         4      4      573.57 Kbit/s   57.36 Mbit/s    31.518ms     727.092ms    16.737s      1.284s      10.614s     24.6 MiB
+reorder         rampup         1      1      -               94.26 Mbit/s    150.000ms    p90          8.487s       971.235ms   8.753s      12.0 MiB
 ```
+
+The three trailing columns are:
+
+- **CPU cli** — user + system CPU consumed by the client process, from
+  `getrusage(RUSAGE_SELF)`. This is wall-clock time across all cores, not
+  fraction of one core: 1 s here on a run that took 500 ms wall-clock means the
+  process kept roughly two cores busy for the duration.
+- **CPU srv** — total CPU consumed by the server container, read from
+  `/sys/fs/cgroup/cpu.stat` (cgroup v2) while the container is still alive.
+  Covers the whole cgroup, so it is not strictly comparable to `getrusage`, but
+  the delta between two runs of the same server binary is meaningful.
+- **Peak RSS** — larger of the two containers' peak resident set. Includes the
+  Nim runtime and lsquic engine state.
+
+`CPU srv` matters because much of the QUIC send path (engine tick coalescing,
+packet-out scheduling, retransmission) runs on the server side of a benchmark
+that measures download throughput, so client CPU alone would miss most of the
+send-path cost.
 
 #### Reading the results
 
@@ -332,68 +355,84 @@ reorder         rampup         1      1      -               90.96 Mbit/s    100
 
 #### Analysis by scenario
 
-**LAN** (no shaping) — establishes the upper bound. Single-stream download reaches
-1.10 Gbit/s on the Docker bridge. With parallel streams and connections, aggregate
-throughput climbs to 1.1-1.4 Gbit/s as multiplexing improves pipeline utilization.
-Latency starts at 58us but grows to 8.2ms p50 / 37.7ms p95 under stress, showing
-the cost of engine processing contention when handling 16 concurrent streams across
-4 connections.
+**LAN** (no shaping) — establishes the upper bound, and it is the only scenario
+where nim-lsquic itself, rather than the emulated link, is the bottleneck.
+Single-stream download reaches 2.25 Gbit/s on the Docker bridge. Parallel streams
+and connections stay in the same 1.9-2.4 Gbit/s band; extra streams and
+connections do not increase aggregate throughput here, indicating that a single
+stream already saturates the engine at LAN speeds. Latency starts at 55 µs p50
+and stays at microsecond-scale medians across all modes; p95 grows from 88 µs
+(baseline) to 53 ms under stress, showing the cost of engine processing
+contention across 16 concurrent streams.
 
-**WAN** (25ms, 100 Mbit) — throughput reaches 90 Mbit/s, below the 100 Mbit cap
-because CUBIC needs multiple RTTs to grow the congestion window, and each of the 5
-sequential runs starts cold. Latency baseline is 25.7ms, matching the netem delay
-exactly. Under multiconn the probe latency rises to 36ms (+11ms), pointing to
-engine-level contention across connections. Stress p95 hits 1.03s from head-of-line
-blocking cascades across 16 concurrent streams. Rampup takes 150ms (6 RTTs) to
-reach 90% of peak.
+**WAN** (25 ms, 100 Mbit) — throughput reaches 90.3 Mbit/s, ~90% of the 100 Mbit
+cap. CUBIC needs multiple RTTs to grow the congestion window and each of the 5
+sequential runs starts cold. Latency baseline is 25.4 ms, matching the netem
+delay exactly. Under `multiconn` the probe latency rises to 36.3 ms (+11 ms),
+pointing to engine-level contention across connections. `stress` p95 hits 1.17 s
+from head-of-line blocking cascades across 16 concurrent streams. Rampup takes
+150 ms (6 RTTs) to reach 90% of peak.
 
-**Constrained** (50ms, 10 Mbit, 0.1% loss) — all modes saturate at ~9.2 Mbit/s,
-confirming the 10 Mbit link is the bottleneck rather than the engine. Contention
-modes show nearly identical throughput because there simply isn't more bandwidth
-to fight over. The main effect of contention is on latency: multistream p95 reaches
-164ms and stress p95 hits 122ms. Rampup takes 900ms (18 RTTs at 50ms) to reach
-steady state, consistent with CUBIC slow-start behavior.
+**Constrained** (50 ms, 10 Mbit, 0.1% loss) — all modes saturate at ~9.2-9.4
+Mbit/s, confirming the 10 Mbit link is the bottleneck rather than the engine.
+Contention modes show nearly identical throughput because there is no bandwidth
+left to fight over. The main effect of contention is on latency: `multistream`
+p95 reaches 429 ms, while `stress` p95 sits lower at 109 ms. Rampup takes 700 ms
+(14 RTTs at 50 ms) to reach steady state, consistent with CUBIC slow-start
+behavior.
 
-**Lossy** (25ms, 50 Mbit, 2% loss) — the most punishing scenario for throughput.
-Single-stream reaches only 40.6 Mbit/s (81% of cap) because 2% loss causes frequent
-congestion window reductions. Baseline latency p50 is 25.7ms, matching the netem
-delay, with p95 at 25.9ms. Stress p95 reaches 996ms as loss and congestion combine
-into retransmission cascades across 16 concurrent streams.
+**Lossy** (25 ms, 50 Mbit, 2% loss) — the most punishing scenario for tail
+latency. Single-stream throughput reaches 40.7 Mbit/s (81% of cap) because 2%
+loss causes frequent congestion-window reductions. Baseline latency p50 is 25.4
+ms, matching the netem delay, with p95 at 25.6 ms. `stress` p95 reaches 1.65 s
+as loss and congestion combine into retransmission cascades across 16 concurrent
+streams — the worst tail in the matrix.
 
-**Mobile** (75ms, 5 Mbit, 1% loss) — throughput settles at 4.5 Mbit/s (90% of
-cap). The tight bandwidth means contention modes show nearly identical throughput
-(~4.6 Mbit/s) since the link is fully saturated regardless. The contention effect
-shows up in latency instead: multistream p95 reaches 615ms from within-connection
-scheduling pressure under the narrow pipe. Rampup takes 3.35s to converge — longer
-than expected from RTT alone, likely due to a loss event during slow-start forcing
-a window reduction on this narrow, lossy link.
+**Mobile** (75 ms, 5 Mbit, 1% loss) — throughput settles at 4.53 Mbit/s (91% of
+cap). The tight bandwidth means contention modes show nearly identical
+throughput (~4.6-4.7 Mbit/s) since the link is fully saturated regardless. The
+contention effect shows up in latency instead: `multistream` p95 reaches 771 ms
+from within-connection scheduling pressure under the narrow pipe. Rampup takes
+8.25 s to converge — much longer than expected from RTT alone, because loss
+events during slow-start force repeated window reductions on this narrow, lossy
+link.
 
-**Reorder** (25ms, 100 Mbit, 25% reorder) — throughput drops to 67.2 Mbit/s, 25%
-lower than WAN (90 Mbit/s) despite the same bandwidth cap. Reordered packets
-trigger duplicate ACKs that CUBIC interprets as loss, shrinking the congestion
-window unnecessarily. This is a known weakness of loss-based congestion control.
-However, reordering is less damaging than actual loss: 25% reorder yields 67.2
-Mbit/s while 2% real loss (lossy scenario) yields only 40.6 Mbit/s, because
-reordered packets eventually arrive and don't require retransmission.
+**Reorder** (25 ms, 100 Mbit, 25% reorder) — single-stream throughput reaches
+78.3 Mbit/s, below the 100 Mbit cap but above the `lossy` figure despite
+carrying 25% reordering. Reordered packets trigger duplicate ACKs that CUBIC
+interprets as loss and shrink the congestion window, but the packets themselves
+eventually arrive, so there is no retransmission cost. Rampup fully recovers to
+the 100 Mbit cap (peak 94.3 Mbit/s), unlike the sequential-run cold-start
+average.
 
 #### Key takeaways
 
-- **Bandwidth caps are enforced bidirectionally** — download throughput stays below
-  the configured cap in all scenarios (shaping is applied on both client and server
-  egress via `tc netem`).
-- **Latency baselines match netem delays exactly** — 25.7ms for WAN/lossy/reorder
-  (25ms configured), 50.8ms for constrained (50ms), 75.9ms for mobile (75ms).
-- **Contention degrades latency more than throughput** — under constrained/mobile
-  scenarios the link is fully saturated regardless of mode, but p95 latency grows
-  2-6x from baseline under stress.
-- **Packet loss is more damaging than reordering** — 2% loss (lossy) reduces
-  throughput to 81% of cap and drives stress p95 to 996ms, while 25% reorder
-  reduces throughput to only 67% and stress p95 to 934ms. Lost packets require
-  actual retransmission and RTO backoff; reordered packets just trigger spurious
-  duplicate ACKs.
-- **CUBIC ramp-up scales with RTT** — time-to-90% grows from 150ms (LAN/WAN)
-  to 900ms (50ms RTT) to 3.35s (75ms RTT + 1% loss), with loss events during
-  slow-start significantly extending convergence on narrow, lossy links.
+- **Bandwidth caps are enforced bidirectionally** — download throughput stays
+  below the configured cap in all scenarios (shaping is applied on both client
+  and server egress via `tc netem`).
+- **Latency baselines match netem delays exactly** — 25.3-25.4 ms for
+  WAN/lossy/reorder (25 ms configured), 50.5 ms for constrained (50 ms), 75.6 ms
+  for mobile (75 ms). p50 latency is unchanged across all contention modes; the
+  cost of contention appears entirely in the tail.
+- **Contention degrades latency, not throughput** — under
+  constrained/mobile/lossy the link is fully saturated regardless of mode, but
+  p95 latency grows 2-20x from the baseline latency once other streams share
+  the connection.
+- **Loss and reordering hurt in different places** — 2% loss (`lossy`) drops
+  single-stream throughput to 81% of cap and drives `stress` p95 to 1.65 s,
+  while 25% reorder yields 78% of cap and a `stress` p95 of 727 ms. Lost packets
+  need real retransmission and RTO backoff; reordered packets just trigger
+  spurious duplicate ACKs. The two scenarios have different caps (50 vs 100
+  Mbit), so compare percentages rather than absolute Mbit/s.
+- **`multiconn` beats `multistream` for latency-sensitive workloads** — putting
+  the latency probe on its own connection (`multiconn`, p95 36-127 ms across
+  scenarios) instead of sharing one with bulk streams (`multistream`, p95
+  221-771 ms) reduces the p95 tail by 3-10x. Independent congestion state per
+  connection isolates the probe from bulk head-of-line blocking.
+- **CUBIC ramp-up scales with RTT and loss** — time-to-90% grows from 150 ms
+  (LAN/WAN) to 700 ms (50 ms RTT, 0.1% loss) to 8.25 s (75 ms RTT + 1% loss),
+  with loss events during slow-start significantly extending convergence on
+  narrow, lossy links.
 
 ### Human-Readable Output
 
@@ -423,6 +462,11 @@ Total duration: 11.079ms
       Max:   3.967ms
   Connection #2:
     ...
+
+  Client resource usage:
+    CPU user: 16.461ms
+    CPU sys:  3.713ms
+    Peak RSS: 8.4 MiB
 ```
 
 ### JSON Output
@@ -435,22 +479,35 @@ samples (in nanoseconds) for further analysis:
   "mode": "latency",
   "connections": 1,
   "streams_per_conn": 1,
-  "duration_ns": 253988269,
+  "duration_ns": 2535000000,
   "connections_results": [
     {
       "streams": [
         {
           "upload_bytes": 0,
           "download_bytes": 0,
-          "duration_ns": 253906378,
-          "latency_samples_ns": [25814400, 25296524, 25294871, ...]
+          "duration_ns": 2534900000,
+          "latency_samples_ns": [25352000, 25401000, 25311000, ...]
         }
       ],
-      "duration_ns": 253988269
+      "duration_ns": 2535000000
     }
-  ]
+  ],
+  "errors": [],
+  "client_cpu_user_ns": 33502000,
+  "client_cpu_sys_ns": 15711000,
+  "client_max_rss_bytes": 12443648,
+  "server_cpu_ns": 203719000,
+  "server_cpu_user_ns": 150710000,
+  "server_cpu_sys_ns": 53008000,
+  "server_max_rss_bytes": 5595136
 }
 ```
+
+The `errors` array lists any streams that failed transport-level (`StreamError`,
+`ConnectionError`, etc.) during the run - the benchmark records them and keeps
+going rather than aborting. Server-side CPU is read from the container's cgroup;
+client-side CPU and RSS come from `getrusage(RUSAGE_SELF)`.
 
 ## How It Works
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -267,45 +267,50 @@ networking. Absolute numbers are host-dependent — especially the LAN row, whic
 measures loopback-class bandwidth rather than a real network — so compare
 relative movements between modes rather than treating these as targets.
 
+The `Lat p95` values below are a **single draw from a wide distribution**, not
+repeatable figures: re-running an unchanged build moves them by up to 3x. See
+[Reading the tail](#reading-the-tail) before comparing any of them against a run
+of your own.
+
 ```
-Scenario        Mode           Conns  Strms  Upload          Download        Lat p50      Lat p95      Duration     CPU cli     CPU srv     Peak RSS
-===========================================================================================================================================================
-lan             throughput     1      1      22.49 Mbit/s    2.25 Gbit/s     -            -            177.895ms    144.961ms   289.813ms   11.8 MiB
-lan             latency        1      1      -               -               55.313us     87.729us     6.566ms      33.146ms    111.565ms   11.7 MiB
-lan             multistream    1      4      18.82 Mbit/s    1.88 Gbit/s     40.992us     17.191ms     255.111ms    189.392ms   380.229ms   21.7 MiB
-lan             multiconn      4      1      20.15 Mbit/s    2.01 Gbit/s     39.526us     16.246ms     238.226ms    186.240ms   384.302ms   21.4 MiB
-lan             stress         4      4      21.47 Mbit/s    2.15 Gbit/s     51.891us     53.027ms     447.053ms    309.429ms   613.795ms   59.3 MiB
-lan             rampup         1      1      -               2.40 Gbit/s     150.000ms    p90          333.699ms    252.956ms   461.795ms   11.8 MiB
-wan             throughput     1      1      902.85 Kbit/s   90.28 Mbit/s    -            -            4.430s       746.879ms   4.393s      12.3 MiB
-wan             latency        1      1      -               -               25.352ms     25.475ms     2.535s       49.213ms    203.719ms   11.9 MiB
-wan             multistream    1      4      637.13 Kbit/s   63.71 Mbit/s    25.376ms     220.711ms    7.534s       818.990ms   5.326s      15.5 MiB
-wan             multiconn      4      1      919.43 Kbit/s   91.94 Mbit/s    36.339ms     36.378ms     5.221s       828.930ms   5.299s      16.0 MiB
-wan             stress         4      4      591.71 Kbit/s   59.17 Mbit/s    25.770ms     1.172s       16.224s      1.401s      10.593s     30.5 MiB
-wan             rampup         1      1      -               83.57 Mbit/s    150.000ms    p90          9.573s       1.137s      8.688s      16.5 MiB
-constrained     throughput     1      1      93.39 Kbit/s    9.34 Mbit/s     -            -            42.833s      1.077s      1.987s      11.8 MiB
-constrained     latency        1      1      -               -               50.466ms     50.669ms     5.050s       60.147ms    274.517ms   11.7 MiB
-constrained     multistream    1      4      94.29 Kbit/s    9.43 Mbit/s     96.614ms     428.695ms    50.905s      1.718s      2.646s      11.7 MiB
-constrained     multiconn      4      1      93.59 Kbit/s    9.36 Mbit/s     95.801ms     100.843ms    51.288s      1.722s      2.911s      11.8 MiB
-constrained     stress         4      4      92.38 Kbit/s    9.24 Mbit/s     50.383ms     109.086ms    103.914s     3.364s      5.666s      12.3 MiB
-constrained     rampup         1      1      -               9.49 Mbit/s     700.000ms    p90          84.307s      2.549s      3.914s      11.6 MiB
-lossy           throughput     1      1      406.78 Kbit/s   40.68 Mbit/s    -            -            9.833s       718.467ms   8.570s      11.7 MiB
-lossy           latency        1      1      -               -               25.364ms     25.630ms     2.672s       57.357ms    174.575ms   11.6 MiB
-lossy           multistream    1      4      361.71 Kbit/s   36.17 Mbit/s    25.374ms     565.669ms    13.270s      804.105ms   10.357s     13.4 MiB
-lossy           multiconn      4      1      343.65 Kbit/s   34.36 Mbit/s    47.499ms     47.627ms     13.968s      862.115ms   10.488s     15.8 MiB
-lossy           stress         4      4      301.73 Kbit/s   30.17 Mbit/s    25.336ms     1.648s       31.816s      1.405s      21.058s     26.4 MiB
-lossy           rampup         1      1      -               38.98 Mbit/s    150.000ms    p90          20.523s      1.198s      17.174s     12.9 MiB
-mobile          throughput     1      1      45.32 Kbit/s    4.53 Mbit/s     -            -            88.264s      1.361s      3.604s      11.9 MiB
-mobile          latency        1      1      -               -               75.613ms     75.801ms     7.567s       56.898ms    316.761ms   11.6 MiB
-mobile          multistream    1      4      46.86 Kbit/s    4.69 Mbit/s     121.086ms    770.688ms    102.422s     1.757s      4.297s      11.7 MiB
-mobile          multiconn      4      1      46.53 Kbit/s    4.65 Mbit/s     118.931ms    126.222ms    103.161s     1.800s      4.324s      11.9 MiB
-mobile          stress         4      4      46.34 Kbit/s    4.63 Mbit/s     75.551ms     239.780ms    207.150s     3.922s      8.926s      13.0 MiB
-mobile          rampup         1      1      -               4.75 Mbit/s     8.250s       p90          168.595s     2.640s      6.899s      11.7 MiB
-reorder         throughput     1      1      782.97 Kbit/s   78.30 Mbit/s    -            -            5.109s       610.448ms   4.411s      13.0 MiB
-reorder         latency        1      1      -               -               25.332ms     25.439ms     2.057s       47.919ms    209.847ms   11.5 MiB
-reorder         multistream    1      4      617.32 Kbit/s   61.73 Mbit/s    25.360ms     620.952ms    7.776s       622.010ms   5.293s      15.1 MiB
-reorder         multiconn      4      1      677.75 Kbit/s   67.77 Mbit/s    36.279ms     36.373ms     7.082s       660.459ms   5.290s      14.8 MiB
-reorder         stress         4      4      573.57 Kbit/s   57.36 Mbit/s    31.518ms     727.092ms    16.737s      1.284s      10.614s     24.6 MiB
-reorder         rampup         1      1      -               94.26 Mbit/s    150.000ms    p90          8.487s       971.235ms   8.753s      12.0 MiB
+Scenario        Mode           Conns  Strms  Upload          Download        Lat p50      Lat p95      Stalls       Duration     CPU cli     CPU srv     Peak RSS
+========================================================================================================================================================================
+lan             throughput     1      1      22.49 Mbit/s    2.25 Gbit/s     -            -            -            177.895ms    144.961ms   289.813ms   11.8 MiB
+lan             latency        1      1      -               -               55.313us     87.729us     0/0/0        6.566ms      33.146ms    111.565ms   11.7 MiB
+lan             multistream    1      4      18.82 Mbit/s    1.88 Gbit/s     40.992us     17.191ms     0/0/0        255.111ms    189.392ms   380.229ms   21.7 MiB
+lan             multiconn      4      1      20.15 Mbit/s    2.01 Gbit/s     39.526us     16.246ms     0/0/0        238.226ms    186.240ms   384.302ms   21.4 MiB
+lan             stress         4      4      21.47 Mbit/s    2.15 Gbit/s     51.891us     53.027ms     0/0/0        447.053ms    309.429ms   613.795ms   59.3 MiB
+lan             rampup         1      1      -               2.40 Gbit/s     150.000ms    p90          -            333.699ms    252.956ms   461.795ms   11.8 MiB
+wan             throughput     1      1      902.85 Kbit/s   90.28 Mbit/s    -            -            -            4.430s       746.879ms   4.393s      12.3 MiB
+wan             latency        1      1      -               -               25.352ms     25.475ms     0/0/0        2.535s       49.213ms    203.719ms   11.9 MiB
+wan             multistream    1      4      637.13 Kbit/s   63.71 Mbit/s    25.376ms     220.711ms    20/0/0       7.534s       818.990ms   5.326s      15.5 MiB
+wan             multiconn      4      1      919.43 Kbit/s   91.94 Mbit/s    36.339ms     36.378ms     0/0/0        5.221s       828.930ms   5.299s      16.0 MiB
+wan             stress         4      4      591.71 Kbit/s   59.17 Mbit/s    25.770ms     1.172s       40/11/0      16.224s      1.401s      10.593s     30.5 MiB
+wan             rampup         1      1      -               83.57 Mbit/s    150.000ms    p90          -            9.573s       1.137s      8.688s      16.5 MiB
+constrained     throughput     1      1      93.39 Kbit/s    9.34 Mbit/s     -            -            -            42.833s      1.077s      1.987s      11.8 MiB
+constrained     latency        1      1      -               -               50.466ms     50.669ms     0/0/0        5.050s       60.147ms    274.517ms   11.7 MiB
+constrained     multistream    1      4      94.29 Kbit/s    9.43 Mbit/s     96.614ms     428.695ms    34/2/2       50.905s      1.718s      2.646s      11.7 MiB
+constrained     multiconn      4      1      93.59 Kbit/s    9.36 Mbit/s     95.801ms     100.843ms    15/0/0       51.288s      1.722s      2.911s      11.8 MiB
+constrained     stress         4      4      92.38 Kbit/s    9.24 Mbit/s     50.383ms     109.086ms    11/5/4       103.914s     3.364s      5.666s      12.3 MiB
+constrained     rampup         1      1      -               9.49 Mbit/s     700.000ms    p90          -            84.307s      2.549s      3.914s      11.6 MiB
+lossy           throughput     1      1      406.78 Kbit/s   40.68 Mbit/s    -            -            -            9.833s       718.467ms   8.570s      11.7 MiB
+lossy           latency        1      1      -               -               25.364ms     25.630ms     1/0/0        2.672s       57.357ms    174.575ms   11.6 MiB
+lossy           multistream    1      4      361.71 Kbit/s   36.17 Mbit/s    25.374ms     565.669ms    17/3/0       13.270s      804.105ms   10.357s     13.4 MiB
+lossy           multiconn      4      1      343.65 Kbit/s   34.36 Mbit/s    47.499ms     47.627ms     1/0/0        13.968s      862.115ms   10.488s     15.8 MiB
+lossy           stress         4      4      301.73 Kbit/s   30.17 Mbit/s    25.336ms     1.648s       34/11/3      31.816s      1.405s      21.058s     26.4 MiB
+lossy           rampup         1      1      -               38.98 Mbit/s    150.000ms    p90          -            20.523s      1.198s      17.174s     12.9 MiB
+mobile          throughput     1      1      45.32 Kbit/s    4.53 Mbit/s     -            -            -            88.264s      1.361s      3.604s      11.9 MiB
+mobile          latency        1      1      -               -               75.613ms     75.801ms     0/0/0        7.567s       56.898ms    316.761ms   11.6 MiB
+mobile          multistream    1      4      46.86 Kbit/s    4.69 Mbit/s     121.086ms    770.688ms    95/3/2       102.422s     1.757s      4.297s      11.7 MiB
+mobile          multiconn      4      1      46.53 Kbit/s    4.65 Mbit/s     118.931ms    126.222ms    88/0/0       103.161s     1.800s      4.324s      11.9 MiB
+mobile          stress         4      4      46.34 Kbit/s    4.63 Mbit/s     75.551ms     239.780ms    21/6/4       207.150s     3.922s      8.926s      13.0 MiB
+mobile          rampup         1      1      -               4.75 Mbit/s     8.250s       p90          -            168.595s     2.640s      6.899s      11.7 MiB
+reorder         throughput     1      1      782.97 Kbit/s   78.30 Mbit/s    -            -            -            5.109s       610.448ms   4.411s      13.0 MiB
+reorder         latency        1      1      -               -               25.332ms     25.439ms     0/0/0        2.057s       47.919ms    209.847ms   11.5 MiB
+reorder         multistream    1      4      617.32 Kbit/s   61.73 Mbit/s    25.360ms     620.952ms    13/2/0       7.776s       622.010ms   5.293s      15.1 MiB
+reorder         multiconn      4      1      677.75 Kbit/s   67.77 Mbit/s    36.279ms     36.373ms     0/0/0        7.082s       660.459ms   5.290s      14.8 MiB
+reorder         stress         4      4      573.57 Kbit/s   57.36 Mbit/s    31.518ms     727.092ms    37/6/1       16.737s      1.284s      10.614s     24.6 MiB
+reorder         rampup         1      1      -               94.26 Mbit/s    150.000ms    p90          -            8.487s       971.235ms   8.753s      12.0 MiB
 ```
 
 The three trailing columns are:
@@ -347,11 +352,73 @@ send-path cost.
   transfers. Shows `-` for pure throughput mode which has no latency probe.
   For `rampup` mode, this column shows the **time to 90% of peak throughput**
   instead (labeled `p90` in the Lat p95 column).
-- **Lat p95** — 95th percentile RTT. Useful for spotting tail latency spikes
-  caused by contention or packet loss. Shows `p90` for `rampup` mode to indicate
-  the Lat p50 column contains the time-to-90%-peak metric.
+- **Lat p95** — 95th percentile RTT. Shows `p90` for `rampup` mode to indicate
+  the Lat p50 column contains the time-to-90%-peak metric. **Not stable enough to
+  compare between runs on shaped scenarios** — see [Reading the
+  tail](#reading-the-tail) below, and use the Stalls column instead.
+- **Stalls** — how many latency samples exceeded 100 ms / 1 s / 10 s, e.g.
+  `34/11/3`. This is the tail metric to compare across runs. Shows `-` for modes
+  with no latency probe.
 - **Duration** — total wall-clock time for the entire benchmark run (all
   iterations, all streams)
+
+#### Reading the tail
+
+**Do not compare p95 or p99 between runs on shaped scenarios.** They are not
+stable enough to carry a regression signal, and reading them as if they were has
+produced wrong verdicts on real PRs.
+
+The numbers below are 8 consecutive runs of the *same cell* on *unchanged code*,
+back to back on an idle machine:
+
+| cell | metric | 8 runs on identical code | spread |
+|---|---|---|---|
+| `wan_multistream` | p50 | 25.20 – 25.33 ms | 1.01x |
+| `wan_multistream` | p95 | 220.8 – 649.7 ms | **2.94x** |
+| `wan_multistream` | p99 | 764 – 4263 ms | **5.58x** |
+| `lossy_stress` | p95 | 896 – 1972 ms | **2.20x** |
+| `lossy_stress` | p99 | 10.1 – 25.0 s | **2.46x** |
+
+Two things cause this:
+
+1. **Sample count.** `multistream` and `multiconn` collect 100 latency samples
+   per cell, `stress` 200. At n=100, p95 is the 5th-worst observation and p99 is
+   essentially the single worst.
+2. **The tail is quantized.** Under loss, samples pile up on the rungs of
+   lsquic's exponential retransmission backoff — roughly 1 s, 6 s, 12 s, 25 s,
+   50 s. A percentile reports *which rung one sample happened to land on*, so it
+   jumps between discrete values rather than moving smoothly. Raising the sample
+   count does not fix this; it only changes which sample gets indexed.
+
+The **Stalls** column exists because of this. Counting samples above fixed
+thresholds aggregates the whole tail instead of indexing into it, and it is
+stable across the same runs at no extra wall time:
+
+| cell | metric | 8 runs on identical code | stdev |
+|---|---|---|---|
+| `lossy_stress` | stalls > 1 s | 9, 10, 9, 10, 11, 10, 11, 13 | **1.3** |
+| `lossy_stress` | stalls > 10 s | 3, 3, 2, 2, 3, 2, 4, 2 | **0.7** |
+| `wan_multistream` | stalls > 100 ms | 17, 14, 16, 16, 16, 14, 15, 13 | **1.4** |
+
+Which threshold carries the signal depends on the shaping: `wan_multistream`
+never stalls past 1 s, so only the first bucket is informative there, while
+`lossy_stress` routinely stalls past 10 s and its first bucket is the noisy one.
+Read the bucket that is non-zero and not saturated for the cell in question.
+
+**What to trust when comparing two builds:**
+
+- **Reliable** — `errors` (categorical, and the signal that caught the GSO/USO
+  regression in #115), Lat p50, Stalls, CPU, Peak RSS.
+- **Use with care** — Download/Upload. Stable on LAN and bandwidth-capped
+  scenarios, but on `lossy_stress` throughput itself has a 25% coefficient of
+  variation, so a sub-30% throughput move there means nothing on its own.
+- **Do not use** — Lat p95, and p99 computed from the JSON. Also `rampup`
+  entirely: it is `runs=1`, a single sub-second transfer with no repetition, and
+  it has been observed to span 1546 – 2832 Mbit/s on the same commit.
+
+If a percentile move is the only evidence you have for a regression, it is not
+evidence. Re-run the cell 8 times on the unmodified base commit and compare the
+distributions before drawing a conclusion.
 
 #### Analysis by scenario
 

--- a/benchmarks/bench_client.nim
+++ b/benchmarks/bench_client.nim
@@ -11,6 +11,25 @@
 
 import ./bench_common
 
+# -- Error handling --
+#
+# Transport-level failures are expected on the lossy and mobile scenarios: a
+# peer can reset a stream or drop a connection mid-transfer, and the library
+# reports that as a StreamError/ConnectionError. Losing one stream must not
+# abort the whole benchmark, so failures are recorded and the remaining streams
+# carry on. Defects are deliberately not caught - those are bugs, not network
+# conditions, and should still crash loudly.
+
+proc tryStream(
+    f: Future[StreamResult]
+): Future[Result[StreamResult, string]] {.async.} =
+  try:
+    return ok(await f)
+  except CancelledError as e:
+    raise e
+  except IOError, QuicError, TransportError:
+    return err(getCurrentExceptionMsg())
+
 # -- Throughput on a single stream --
 
 proc runThroughputStream(
@@ -124,8 +143,12 @@ proc modeThroughput(
 
   var connRes = ConnectionResult()
   for i in 0 ..< runs:
-    let sr = await runThroughputStream(conn, uploadSize, downloadSize, chunkSize)
-    connRes.streamResults.add(sr)
+    let sr =
+      await tryStream(runThroughputStream(conn, uploadSize, downloadSize, chunkSize))
+    if sr.isOk:
+      connRes.streamResults.add(sr.get())
+    else:
+      runResult.errors.add("run " & $(i + 1) & ": " & sr.error())
 
   connRes.durationNs = (Moment.now() - start).nanoseconds
   runResult.connResults.add(connRes)
@@ -145,8 +168,11 @@ proc modeLatency(serverAddr: TransportAddress, runs: int): Future[RunResult] {.a
   let start = Moment.now()
 
   var connRes = ConnectionResult()
-  let sr = await runLatencyStream(conn, runs)
-  connRes.streamResults.add(sr)
+  let sr = await tryStream(runLatencyStream(conn, runs))
+  if sr.isOk:
+    connRes.streamResults.add(sr.get())
+  else:
+    runResult.errors.add(sr.error())
   connRes.durationNs = (Moment.now() - start).nanoseconds
   runResult.connResults.add(connRes)
   runResult.durationNs = connRes.durationNs
@@ -187,8 +213,11 @@ proc modeMultiStream(
 
     # Wait for all streams to complete
     for f in futs:
-      let sr = await f
-      connRes.streamResults.add(sr)
+      let sr = await tryStream(f)
+      if sr.isOk:
+        connRes.streamResults.add(sr.get())
+      else:
+        runResult.errors.add(sr.error())
 
   connRes.durationNs = (Moment.now() - start).nanoseconds
   runResult.connResults.add(connRes)
@@ -234,11 +263,14 @@ proc modeMultiConn(
     futs.add(runLatencyStream(conns[numConns - 1], 50))
 
     for i, f in futs:
-      let sr = await f
+      let sr = await tryStream(f)
       # Associate with the right connection metrics
       while runResult.connResults.len <= i:
         runResult.connResults.add(ConnectionResult())
-      runResult.connResults[i].streamResults.add(sr)
+      if sr.isOk:
+        runResult.connResults[i].streamResults.add(sr.get())
+      else:
+        runResult.errors.add("conn " & $(i + 1) & ": " & sr.error())
 
   let totalDur = (Moment.now() - start).nanoseconds
   for cr in runResult.connResults.mitems:
@@ -297,8 +329,11 @@ proc modeStress(
       runResult.connResults.add(ConnectionResult())
 
     for i, f in allFuts:
-      let sr = await f
-      runResult.connResults[futConnIdx[i]].streamResults.add(sr)
+      let sr = await tryStream(f)
+      if sr.isOk:
+        runResult.connResults[futConnIdx[i]].streamResults.add(sr.get())
+      else:
+        runResult.errors.add("conn " & $(futConnIdx[i] + 1) & ": " & sr.error())
 
   let totalDur = (Moment.now() - start).nanoseconds
   for cr in runResult.connResults.mitems:
@@ -351,13 +386,20 @@ proc modeRampUp(
 
   let start = Moment.now()
 
-  while totalDown < downloadSize:
-    let n = await stream.readOnce(buf[0].addr, buf.len)
-    if n == 0:
-      break
-    totalDown += n
-    let elapsed = Moment.now() - start
-    points.add(DataPoint(elapsedNs: elapsed.nanoseconds, cumulativeBytes: totalDown))
+  try:
+    while totalDown < downloadSize:
+      let n = await stream.readOnce(buf[0].addr, buf.len)
+      if n == 0:
+        break
+      totalDown += n
+      let elapsed = Moment.now() - start
+      points.add(DataPoint(elapsedNs: elapsed.nanoseconds, cumulativeBytes: totalDown))
+  except CancelledError as e:
+    raise e
+  except IOError, QuicError, TransportError:
+    # Keep the samples collected so far - a truncated ramp-up curve is still
+    # informative about slow-start behaviour.
+    runResult.errors.add("download: " & getCurrentExceptionMsg())
 
   let totalDuration = Moment.now() - start
 
@@ -478,6 +520,19 @@ proc printResults(runResult: RunResult) =
             " | ",
             bar
 
+  if runResult.errors.len > 0:
+    echo ""
+    echo "  Failed streams (", runResult.errors.len, "):"
+    for e in runResult.errors:
+      echo "    ", e
+
+  echo ""
+  echo "  Client resource usage:"
+  echo "    CPU user: ", formatDuration(runResult.usage.cpuUserNs)
+  echo "    CPU sys:  ", formatDuration(runResult.usage.cpuSysNs)
+  echo "    Peak RSS: ",
+    (runResult.usage.maxRssBytes.float / 1024.0 / 1024.0).formatFloat(ffDecimal, 1),
+    " MiB"
   echo ""
 
 # -- Main --
@@ -577,26 +632,55 @@ when isMainModule:
 
   echo "Connecting to ", serverHost, ":", port, " mode=", mode
 
-  let benchResult =
-    case mode
-    of Throughput:
-      waitFor modeThroughput(serverAddr, uploadSize, downloadSize, chunkSize, runs)
-    of Latency:
-      waitFor modeLatency(serverAddr, runs)
-    of MultiStream:
-      waitFor modeMultiStream(
-        serverAddr, numStreams, uploadSize, downloadSize, chunkSize, runs
-      )
-    of MultiConn:
-      waitFor modeMultiConn(
-        serverAddr, numConns, uploadSize, downloadSize, chunkSize, runs
-      )
-    of Stress:
-      waitFor modeStress(
-        serverAddr, numConns, numStreams, uploadSize, downloadSize, chunkSize, runs
-      )
-    of RampUp:
-      waitFor modeRampUp(serverAddr, downloadSize, chunkSize)
+  # Setup failures (dial, opening the first stream) leave nothing to report, so
+  # they are fatal - but they must produce a readable message on stdout rather
+  # than an unhandled-exception traceback on stderr, which the matrix runner
+  # would discard.
+  var benchResult: RunResult
+  try:
+    benchResult =
+      case mode
+      of Throughput:
+        waitFor modeThroughput(serverAddr, uploadSize, downloadSize, chunkSize, runs)
+      of Latency:
+        waitFor modeLatency(serverAddr, runs)
+      of MultiStream:
+        waitFor modeMultiStream(
+          serverAddr, numStreams, uploadSize, downloadSize, chunkSize, runs
+        )
+      of MultiConn:
+        waitFor modeMultiConn(
+          serverAddr, numConns, uploadSize, downloadSize, chunkSize, runs
+        )
+      of Stress:
+        waitFor modeStress(
+          serverAddr, numConns, numStreams, uploadSize, downloadSize, chunkSize, runs
+        )
+      of RampUp:
+        waitFor modeRampUp(serverAddr, downloadSize, chunkSize)
+  except CancelledError:
+    echo "benchmark cancelled"
+    cleanupLsquic()
+    quit(1)
+  except IOError, QuicError, TransportError:
+    echo "benchmark failed: ", getCurrentExceptionMsg()
+    cleanupLsquic()
+    quit(1)
+
+  benchResult.usage = resourceUsage()
+
+  var completedStreams = 0
+  for cr in benchResult.connResults:
+    completedStreams += cr.streamResults.len
+
+  # Emitting a result set in which every stream failed would report zeroes as if
+  # they were measurements, so fail the run instead.
+  if completedStreams == 0:
+    echo "benchmark failed: no streams completed"
+    for e in benchResult.errors:
+      echo "  ", e
+    cleanupLsquic()
+    quit(1)
 
   if jsonOutput:
     echo benchResult.toJson().pretty()

--- a/benchmarks/bench_client.nim
+++ b/benchmarks/bench_client.nim
@@ -30,6 +30,19 @@ proc tryStream(
   except IOError, QuicError, TransportError:
     return err(getCurrentExceptionMsg())
 
+proc recordStream(
+    runResult: var RunResult,
+    connResult: var ConnectionResult,
+    streamResult: Result[StreamResult, string],
+    context = "",
+) =
+  if streamResult.isOk:
+    connResult.streamResults.add(streamResult.get())
+  elif context.len > 0:
+    runResult.errors.add(context & ": " & streamResult.error())
+  else:
+    runResult.errors.add(streamResult.error())
+
 # -- Throughput on a single stream --
 
 proc runThroughputStream(
@@ -80,7 +93,7 @@ proc runLatencyStream(conn: Connection, runs: int): Future[StreamResult] {.async
 
   let payload = newSeq[byte](64) # small ping payload
   let payloadLenBytes = toSeq(payload.len.uint32.toBytesBE())
-  var samples: seq[LatencySample]
+  var samples = newSeqOfCap[LatencySample](runs)
 
   for i in 0 ..< runs:
     let start = Moment.now()
@@ -135,20 +148,18 @@ proc modeThroughput(
     uploadSize: uploadSize,
     downloadSize: downloadSize,
     chunkSize: chunkSize,
+    connResults: newSeqOfCap[ConnectionResult](1),
   )
 
   let client = makeClient()
   let conn = await client.dial(serverAddr)
   let start = Moment.now()
 
-  var connRes = ConnectionResult()
+  var connRes = ConnectionResult(streamResults: newSeqOfCap[StreamResult](runs))
   for i in 0 ..< runs:
     let sr =
       await tryStream(runThroughputStream(conn, uploadSize, downloadSize, chunkSize))
-    if sr.isOk:
-      connRes.streamResults.add(sr.get())
-    else:
-      runResult.errors.add("run " & $(i + 1) & ": " & sr.error())
+    recordStream(runResult, connRes, sr, "run " & $(i + 1))
 
   connRes.durationNs = (Moment.now() - start).nanoseconds
   runResult.connResults.add(connRes)
@@ -161,18 +172,20 @@ proc modeThroughput(
 # -- Mode: latency (1 conn, 1 stream) --
 
 proc modeLatency(serverAddr: TransportAddress, runs: int): Future[RunResult] {.async.} =
-  var runResult = RunResult(mode: Latency, connections: 1, streamsPerConn: 1)
+  var runResult = RunResult(
+    mode: Latency,
+    connections: 1,
+    streamsPerConn: 1,
+    connResults: newSeqOfCap[ConnectionResult](1),
+  )
 
   let client = makeClient()
   let conn = await client.dial(serverAddr)
   let start = Moment.now()
 
-  var connRes = ConnectionResult()
+  var connRes = ConnectionResult(streamResults: newSeqOfCap[StreamResult](1))
   let sr = await tryStream(runLatencyStream(conn, runs))
-  if sr.isOk:
-    connRes.streamResults.add(sr.get())
-  else:
-    runResult.errors.add(sr.error())
+  recordStream(runResult, connRes, sr)
   connRes.durationNs = (Moment.now() - start).nanoseconds
   runResult.connResults.add(connRes)
   runResult.durationNs = connRes.durationNs
@@ -194,17 +207,19 @@ proc modeMultiStream(
     uploadSize: uploadSize,
     downloadSize: downloadSize,
     chunkSize: chunkSize,
+    connResults: newSeqOfCap[ConnectionResult](1),
   )
 
   let client = makeClient()
   let conn = await client.dial(serverAddr)
   let start = Moment.now()
 
-  var connRes = ConnectionResult()
+  var connRes =
+    ConnectionResult(streamResults: newSeqOfCap[StreamResult](runs * numStreams))
 
   for run in 0 ..< runs:
     # Launch K-1 throughput streams + 1 latency probe in parallel
-    var futs: seq[Future[StreamResult]]
+    var futs = newSeqOfCap[Future[StreamResult]](numStreams)
     for s in 0 ..< numStreams - 1:
       futs.add(runThroughputStream(conn, uploadSize, downloadSize, chunkSize))
 
@@ -214,10 +229,7 @@ proc modeMultiStream(
     # Wait for all streams to complete
     for f in futs:
       let sr = await tryStream(f)
-      if sr.isOk:
-        connRes.streamResults.add(sr.get())
-      else:
-        runResult.errors.add(sr.error())
+      recordStream(runResult, connRes, sr)
 
   connRes.durationNs = (Moment.now() - start).nanoseconds
   runResult.connResults.add(connRes)
@@ -240,22 +252,26 @@ proc modeMultiConn(
     uploadSize: uploadSize,
     downloadSize: downloadSize,
     chunkSize: chunkSize,
+    connResults: newSeq[ConnectionResult](numConns),
   )
 
   # Create N separate clients (each gets its own engine context)
-  var clients: seq[QuicClient]
-  var conns: seq[Connection]
+  var clients = newSeqOfCap[QuicClient](numConns)
+  var conns = newSeqOfCap[Connection](numConns)
   for i in 0 ..< numConns:
     let client = makeClient()
     let conn = await client.dial(serverAddr)
     clients.add(client)
     conns.add(conn)
 
+  for cr in runResult.connResults.mitems:
+    cr.streamResults = newSeqOfCap[StreamResult](runs)
+
   let start = Moment.now()
 
   for run in 0 ..< runs:
     # Launch throughput on N-1 connections + latency probe on last
-    var futs: seq[Future[StreamResult]]
+    var futs = newSeqOfCap[Future[StreamResult]](numConns)
     for i in 0 ..< numConns - 1:
       futs.add(runThroughputStream(conns[i], uploadSize, downloadSize, chunkSize))
 
@@ -264,13 +280,7 @@ proc modeMultiConn(
 
     for i, f in futs:
       let sr = await tryStream(f)
-      # Associate with the right connection metrics
-      while runResult.connResults.len <= i:
-        runResult.connResults.add(ConnectionResult())
-      if sr.isOk:
-        runResult.connResults[i].streamResults.add(sr.get())
-      else:
-        runResult.errors.add("conn " & $(i + 1) & ": " & sr.error())
+      recordStream(runResult, runResult.connResults[i], sr, "conn " & $(i + 1))
 
   let totalDur = (Moment.now() - start).nanoseconds
   for cr in runResult.connResults.mitems:
@@ -297,21 +307,25 @@ proc modeStress(
     uploadSize: uploadSize,
     downloadSize: downloadSize,
     chunkSize: chunkSize,
+    connResults: newSeq[ConnectionResult](numConns),
   )
 
-  var clients: seq[QuicClient]
-  var conns: seq[Connection]
+  var clients = newSeqOfCap[QuicClient](numConns)
+  var conns = newSeqOfCap[Connection](numConns)
   for i in 0 ..< numConns:
     let client = makeClient()
     let conn = await client.dial(serverAddr)
     clients.add(client)
     conns.add(conn)
 
+  for cr in runResult.connResults.mitems:
+    cr.streamResults = newSeqOfCap[StreamResult](runs * numStreams)
+
   let start = Moment.now()
 
   for run in 0 ..< runs:
-    var allFuts: seq[Future[StreamResult]]
-    var futConnIdx: seq[int] # track which connection each future belongs to
+    var allFuts = newSeqOfCap[Future[StreamResult]](numConns * numStreams)
+    var futConnIdx = newSeqOfCap[int](numConns * numStreams)
 
     for ci in 0 ..< numConns:
       # On each connection: K-1 throughput streams + 1 latency probe
@@ -324,16 +338,12 @@ proc modeStress(
       allFuts.add(runLatencyStream(conns[ci], 50))
       futConnIdx.add(ci)
 
-    # Ensure we have connResults slots
-    while runResult.connResults.len < numConns:
-      runResult.connResults.add(ConnectionResult())
-
     for i, f in allFuts:
       let sr = await tryStream(f)
-      if sr.isOk:
-        runResult.connResults[futConnIdx[i]].streamResults.add(sr.get())
-      else:
-        runResult.errors.add("conn " & $(futConnIdx[i] + 1) & ": " & sr.error())
+      let connIdx = futConnIdx[i]
+      recordStream(
+        runResult, runResult.connResults[connIdx], sr, "conn " & $(connIdx + 1)
+      )
 
   let totalDur = (Moment.now() - start).nanoseconds
   for cr in runResult.connResults.mitems:
@@ -355,13 +365,21 @@ const
 
 proc modeRampUp(
     serverAddr: TransportAddress, downloadSize: int, chunkSize: int
-): Future[RunResult] {.async.} =
+): Future[RunResult] {.
+    async: (
+      raises: [
+        CancelledError, QuicConfigError, QuicError, TransportOsError, IOError,
+        TransportError,
+      ]
+    )
+.} =
   var runResult = RunResult(
     mode: RampUp,
     connections: 1,
     streamsPerConn: 1,
     downloadSize: downloadSize,
     chunkSize: chunkSize,
+    connResults: newSeqOfCap[ConnectionResult](1),
   )
 
   let client = makeClient()
@@ -382,7 +400,7 @@ proc modeRampUp(
 
   var buf = newSeq[byte](chunkSize)
   var totalDown = 0
-  var points: seq[DataPoint]
+  var points = newSeqOfCap[DataPoint](downloadSize div chunkSize + 1)
 
   let start = Moment.now()
 
@@ -394,8 +412,6 @@ proc modeRampUp(
       totalDown += n
       let elapsed = Moment.now() - start
       points.add(DataPoint(elapsedNs: elapsed.nanoseconds, cumulativeBytes: totalDown))
-  except CancelledError as e:
-    raise e
   except IOError, QuicError, TransportError:
     # Keep the samples collected so far - a truncated ramp-up curve is still
     # informative about slow-start behaviour.
@@ -404,7 +420,7 @@ proc modeRampUp(
   let totalDuration = Moment.now() - start
 
   # Bucket into time windows
-  var samples: seq[RampUpSample]
+  var samples = newSeqOfCap[RampUpSample](points.len)
   let windowNs = RampUpWindowMs.int64 * 1_000_000
 
   if points.len > 0:
@@ -662,7 +678,7 @@ when isMainModule:
     echo "benchmark cancelled"
     cleanupLsquic()
     quit(1)
-  except IOError, QuicError, TransportError:
+  except IOError, QuicConfigError, QuicError, TransportError, TransportOsError:
     echo "benchmark failed: ", getCurrentExceptionMsg()
     cleanupLsquic()
     quit(1)
@@ -671,7 +687,10 @@ when isMainModule:
 
   var completedStreams = 0
   for cr in benchResult.connResults:
-    completedStreams += cr.streamResults.len
+    for sr in cr.streamResults:
+      if sr.uploadBytes > 0 or sr.downloadBytes > 0 or sr.latencySamples.len > 0 or
+          sr.rampUpSamples.len > 0:
+        inc completedStreams
 
   # Emitting a result set in which every stream failed would report zeroes as if
   # they were measurements, so fail the run instead.

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -144,6 +144,29 @@ proc percentile*(samples: seq[int64], p: float): int64 =
   let idx = min(int(float(sorted.len - 1) * p), sorted.len - 1)
   sorted[idx]
 
+# -- Stall counts --
+#
+# On shaped links the latency tail is not continuous: samples pile up on the
+# rungs of lsquic's exponential retransmission backoff (observed around 6s, 12s,
+# 25s and 50s under 2% loss). A percentile over a few hundred samples therefore
+# reports *which rung one particular sample landed on*, which moves by 2-3x
+# between runs of identical code. Counting how many samples cleared a fixed
+# threshold is stable to about +/-1 over the same runs, because it aggregates
+# the whole tail instead of indexing into it.
+#
+# Three thresholds rather than one: a cell's meaningful rung depends on its
+# shaping. wan_multistream never stalls past 1s (so only the 100ms bucket
+# carries information there), while lossy_stress routinely stalls past 10s.
+
+const StallThresholdsNs* = [100_000_000'i64, 1_000_000_000'i64, 10_000_000_000'i64]
+
+proc stallCounts*(samples: seq[int64]): seq[int] =
+  result = newSeq[int](StallThresholdsNs.len)
+  for s in samples:
+    for i, threshold in StallThresholdsNs:
+      if s > threshold:
+        result[i].inc
+
 proc mean*(samples: seq[int64]): float =
   if samples.len == 0:
     return 0.0
@@ -177,12 +200,14 @@ proc formatDuration*(ns: int64): string =
 
 proc toJson*(r: RunResult): JsonNode =
   var connArr = newJArray()
+  var allLatencies: seq[int64]
   for cr in r.connResults:
     var streamArr = newJArray()
     for sr in cr.streamResults:
       var latArr = newJArray()
       for l in sr.latencySamples:
         latArr.add(%l.rttNs)
+        allLatencies.add(l.rttNs)
       var rampArr = newJArray()
       for s in sr.rampUpSamples:
         rampArr.add(
@@ -213,6 +238,9 @@ proc toJson*(r: RunResult): JsonNode =
     "duration_ns": r.durationNs,
     "connections_results": connArr,
     "errors": %r.errors,
+    "latency_sample_count": allLatencies.len,
+    "stall_thresholds_ns": %(@StallThresholdsNs),
+    "stall_counts": %stallCounts(allLatencies),
     "client_cpu_user_ns": r.usage.cpuUserNs,
     "client_cpu_sys_ns": r.usage.cpuSysNs,
     "client_max_rss_bytes": r.usage.maxRssBytes,

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -2,6 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 import std/[json, sets, sequtils, os, algorithm, math, strutils]
+from std/posix import Rusage, RUSAGE_SELF, getrusage
 import chronos, results, stew/endians2, chronicles
 import lsquic
 
@@ -50,6 +51,11 @@ type
     rampUpSamples*: seq[RampUpSample]
     timeToP90Ns*: int64 ## time to reach 90% of peak throughput (rampup only)
 
+  ResourceUsage* = object
+    cpuUserNs*: int64
+    cpuSysNs*: int64
+    maxRssBytes*: int64
+
   ConnectionResult* = object
     streamResults*: seq[StreamResult]
     durationNs*: int64
@@ -63,6 +69,28 @@ type
     chunkSize*: int
     connResults*: seq[ConnectionResult]
     durationNs*: int64
+    errors*: seq[string] ## streams that failed; the run continued without them
+    usage*: ResourceUsage ## CPU/memory consumed by this process
+
+# -- Resource usage --
+#
+# Taken from getrusage(RUSAGE_SELF) rather than sampled externally: the LAN runs
+# finish in ~100ms, far too short for `docker stats` (1s granularity) to see,
+# and the kernel's counters are exact rather than an average of samples.
+
+proc resourceUsage*(): ResourceUsage =
+  var ru: Rusage
+  if getrusage(RUSAGE_SELF, addr ru) != 0:
+    return ResourceUsage()
+
+  ResourceUsage(
+    cpuUserNs:
+      ru.ru_utime.tv_sec.int64 * 1_000_000_000 + ru.ru_utime.tv_usec.int64 * 1_000,
+    cpuSysNs:
+      ru.ru_stime.tv_sec.int64 * 1_000_000_000 + ru.ru_stime.tv_usec.int64 * 1_000,
+    # Linux reports ru_maxrss in kilobytes.
+    maxRssBytes: ru.ru_maxrss.int64 * 1024,
+  )
 
 # Certificate loading - embedded test certs
 const certDir = parentDir(parentDir(currentSourcePath())) / "tests" / "helpers"
@@ -184,5 +212,9 @@ proc toJson*(r: RunResult): JsonNode =
     "chunk_size": r.chunkSize,
     "duration_ns": r.durationNs,
     "connections_results": connArr,
+    "errors": %r.errors,
+    "client_cpu_user_ns": r.usage.cpuUserNs,
+    "client_cpu_sys_ns": r.usage.cpuSysNs,
+    "client_max_rss_bytes": r.usage.maxRssBytes,
   }
   json

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -129,10 +129,10 @@ SUMMARY_FILE="$RESULTS_DIR/summary_${TIMESTAMP}.txt"
 JSON_DIR="$RESULTS_DIR/json_${TIMESTAMP}"
 mkdir -p "$JSON_DIR"
 
-printf "\n%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
-  "Scenario" "Mode" "Conns" "Strms" "Upload" "Download" "Lat p50" "Lat p95" "Duration" \
-  "CPU cli" "CPU srv" "Peak RSS" | tee "$SUMMARY_FILE"
-printf "%s\n" "$(printf '=%.0s' {1..155})" | tee -a "$SUMMARY_FILE"
+printf "\n%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
+  "Scenario" "Mode" "Conns" "Strms" "Upload" "Download" "Lat p50" "Lat p95" "Stalls" \
+  "Duration" "CPU cli" "CPU srv" "Peak RSS" | tee "$SUMMARY_FILE"
+printf "%s\n" "$(printf '=%.0s' {1..168})" | tee -a "$SUMMARY_FILE"
 
 run_bench() {
   local scenario_str="$1"
@@ -185,8 +185,8 @@ run_bench() {
       --wait-timeout "$WAIT_TIMEOUT" \
       bench-server >/dev/null 2>&1; then
     echo "FAILED (server startup)"
-    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
-      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" \
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" "-" \
       | tee -a "$SUMMARY_FILE"
     env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans \
       >/dev/null 2>&1 || true
@@ -243,8 +243,8 @@ run_bench() {
     else
       echo "FAILED (no JSON output, see $log_file)"
     fi
-    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
-      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" \
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" "-" \
       | tee -a "$SUMMARY_FILE"
     return
   fi
@@ -350,15 +350,21 @@ def fmt_mib(b):
 cli_cpu_str = fmt_dur(cli_cpu) if cli_cpu > 0 else '-'
 srv_cpu_str = fmt_dur(srv_cpu) if srv_cpu > 0 else '-'
 
-print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{dur_str}'
+# Stall counts (>100ms / >1s / >10s). Unlike p95/p99 these are stable across
+# repeated runs of identical code, so they are what a regression check should
+# read on shaped scenarios. See README, 'Reading the tail'.
+stalls = d.get('stall_counts', [])
+stalls_str = '/'.join(str(c) for c in stalls) if stalls else '-'
+
+print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{stalls_str}|{dur_str}'
       f'|{cli_cpu_str}|{srv_cpu_str}|{fmt_mib(peak_rss)}')
 " < "$JSON_DIR/${run_name}.json" 2>/dev/null | {
-    IFS='|' read -r upload_str download_str lat_p50_str lat_p95_str dur_str \
-      cli_cpu_str srv_cpu_str peak_rss_str
+    IFS='|' read -r upload_str download_str lat_p50_str lat_p95_str stalls_str \
+      dur_str cli_cpu_str srv_cpu_str peak_rss_str
     echo "done"
-    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
       "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "$upload_str" "$download_str" \
-      "$lat_p50_str" "$lat_p95_str" "$dur_str" \
+      "$lat_p50_str" "$lat_p95_str" "$stalls_str" "$dur_str" \
       "$cli_cpu_str" "$srv_cpu_str" "$peak_rss_str" \
       | tee -a "$SUMMARY_FILE"
   }

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -185,8 +185,8 @@ run_bench() {
       --wait-timeout "$WAIT_TIMEOUT" \
       bench-server >/dev/null 2>&1; then
     echo "FAILED (server startup)"
-    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s\n" \
-      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" "-" \
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" "-" "-" "-" "-" \
       | tee -a "$SUMMARY_FILE"
     env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans \
       >/dev/null 2>&1 || true
@@ -243,8 +243,8 @@ run_bench() {
     else
       echo "FAILED (no JSON output, see $log_file)"
     fi
-    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s\n" \
-      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" "-" \
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
+      "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" "-" "-" "-" "-" \
       | tee -a "$SUMMARY_FILE"
     return
   fi

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -129,9 +129,10 @@ SUMMARY_FILE="$RESULTS_DIR/summary_${TIMESTAMP}.txt"
 JSON_DIR="$RESULTS_DIR/json_${TIMESTAMP}"
 mkdir -p "$JSON_DIR"
 
-printf "\n%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
-  "Scenario" "Mode" "Conns" "Strms" "Upload" "Download" "Lat p50" "Lat p95" "Duration" | tee "$SUMMARY_FILE"
-printf "%s\n" "$(printf '=%.0s' {1..120})" | tee -a "$SUMMARY_FILE"
+printf "\n%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
+  "Scenario" "Mode" "Conns" "Strms" "Upload" "Download" "Lat p50" "Lat p95" "Duration" \
+  "CPU cli" "CPU srv" "Peak RSS" | tee "$SUMMARY_FILE"
+printf "%s\n" "$(printf '=%.0s' {1..155})" | tee -a "$SUMMARY_FILE"
 
 run_bench() {
   local scenario_str="$1"
@@ -193,30 +194,54 @@ run_bench() {
   fi
 
   # Only attach to bench-client so the output contains bench_client logs only.
-  local raw_output client_status output
+  # Keep the client's stderr: an unhandled exception traceback is the only clue
+  # to why a run died, and discarding it makes failures undiagnosable.
+  #
+  # `run` rather than `up --abort-on-container-exit`: the latter tears down the
+  # server as part of the same invocation, destroying its cgroup before the
+  # server-side CPU/memory counters can be read.
+  local raw_output client_status output log_file
+  log_file="$JSON_DIR/${run_name}.log"
   set +e
   raw_output=$(
-    env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" up \
+    env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" run \
+      --rm \
       --no-deps \
-      --abort-on-container-exit \
-      --exit-code-from bench-client \
-      --no-color \
-      --no-log-prefix \
-      bench-client 2>/dev/null
+      -T \
+      bench-client 2>"$log_file"
   )
   client_status=$?
   set -e
 
   output=$(printf "%s\n" "$raw_output" | sed -n '/^{/,/^}/p' || true)
 
+  # Server-side CPU/memory, read while the container is still alive. Much of the
+  # send path (GSO/USO, engine tick coalescing, sink writes) runs on the server,
+  # so the client's own getrusage would miss it. These cgroup counters are
+  # cumulative since container start and the server is recreated for every cell,
+  # so they cover exactly this run.
+  local srv_id srv_cpu_us srv_user_us srv_sys_us srv_mem_peak cpu_stat
+  srv_id=$(env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" ps -q bench-server \
+    2>/dev/null | head -1)
+  srv_cpu_us=""; srv_user_us=""; srv_sys_us=""; srv_mem_peak=""
+  if [ -n "$srv_id" ]; then
+    cpu_stat=$(docker exec "$srv_id" cat /sys/fs/cgroup/cpu.stat 2>/dev/null || true)
+    srv_cpu_us=$(awk '/^usage_usec/{print $2}' <<< "$cpu_stat")
+    srv_user_us=$(awk '/^user_usec/{print $2}' <<< "$cpu_stat")
+    srv_sys_us=$(awk '/^system_usec/{print $2}' <<< "$cpu_stat")
+    srv_mem_peak=$(docker exec "$srv_id" cat /sys/fs/cgroup/memory.peak 2>/dev/null || true)
+  fi
+
   env "${env_args[@]}" docker compose "${COMPOSE_ARGS[@]}" down --remove-orphans \
     >/dev/null 2>&1 || true
 
   if [ -z "$output" ]; then
+    # Preserve stdout too - the client reports fatal errors there.
+    printf "%s\n" "$raw_output" >> "$log_file"
     if [ "$client_status" -ne 0 ]; then
-      echo "FAILED (bench-client exit $client_status)"
+      echo "FAILED (bench-client exit $client_status, see $log_file)"
     else
-      echo "FAILED (no JSON output)"
+      echo "FAILED (no JSON output, see $log_file)"
     fi
     printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
       "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "FAILED" "-" "-" "-" "-" \
@@ -224,8 +249,27 @@ run_bench() {
     return
   fi
 
-  # Save raw JSON
-  echo "$output" > "$JSON_DIR/${run_name}.json"
+  # Successful runs leave no log behind unless something was written to stderr.
+  [ -s "$log_file" ] || rm -f "$log_file"
+
+  # Save JSON with the server-side counters merged in. Values are passed through
+  # the environment so no shell text ends up inside the python source.
+  SRV_CPU_US="$srv_cpu_us" SRV_USER_US="$srv_user_us" SRV_SYS_US="$srv_sys_us" \
+  SRV_MEM_PEAK="$srv_mem_peak" python3 -c "
+import os, sys, json
+
+def num(name):
+    v = os.environ.get(name, '').strip()
+    return int(v) if v.isdigit() else 0
+
+d = json.load(sys.stdin)
+d['server_cpu_ns'] = num('SRV_CPU_US') * 1000
+d['server_cpu_user_ns'] = num('SRV_USER_US') * 1000
+d['server_cpu_sys_ns'] = num('SRV_SYS_US') * 1000
+d['server_max_rss_bytes'] = num('SRV_MEM_PEAK')
+json.dump(d, sys.stdout, indent=2)
+print()
+" <<< "$output" > "$JSON_DIR/${run_name}.json"
 
   # Parse key metrics with a simple approach
   local duration_ns upload_bps download_bps lat_p50 lat_p95
@@ -294,13 +338,28 @@ if d.get('mode') == 'rampup':
 
 dur_str = fmt_dur(dur_ns)
 
-print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{dur_str}')
-" <<< "$output" 2>/dev/null | {
-    IFS='|' read -r upload_str download_str lat_p50_str lat_p95_str dur_str
+# CPU is user+sys for the client (getrusage) and the whole cgroup for the
+# server. Peak RSS is the larger of the two sides.
+cli_cpu = d.get('client_cpu_user_ns', 0) + d.get('client_cpu_sys_ns', 0)
+srv_cpu = d.get('server_cpu_ns', 0)
+peak_rss = max(d.get('client_max_rss_bytes', 0), d.get('server_max_rss_bytes', 0))
+
+def fmt_mib(b):
+    return '-' if b <= 0 else f'{b/1048576:.1f} MiB'
+
+cli_cpu_str = fmt_dur(cli_cpu) if cli_cpu > 0 else '-'
+srv_cpu_str = fmt_dur(srv_cpu) if srv_cpu > 0 else '-'
+
+print(f'{up_str}|{down_str}|{lat_p50_str}|{lat_p95_str}|{dur_str}'
+      f'|{cli_cpu_str}|{srv_cpu_str}|{fmt_mib(peak_rss)}')
+" < "$JSON_DIR/${run_name}.json" 2>/dev/null | {
+    IFS='|' read -r upload_str download_str lat_p50_str lat_p95_str dur_str \
+      cli_cpu_str srv_cpu_str peak_rss_str
     echo "done"
-    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s\n" \
+    printf "%-15s %-14s %-6s %-6s %-15s %-15s %-12s %-12s %-12s %-11s %-11s %-9s\n" \
       "$sc_name" "$bm_mode" "$bm_conns" "$bm_streams" "$upload_str" "$download_str" \
       "$lat_p50_str" "$lat_p95_str" "$dur_str" \
+      "$cli_cpu_str" "$srv_cpu_str" "$peak_rss_str" \
       | tee -a "$SUMMARY_FILE"
   }
 


### PR DESCRIPTION
## Summary

- **Per-stream error handling** in `bench_client.nim`: transport failures are recorded per stream and the run continues, instead of aborting the whole cell on the first `StreamError`/`ConnectionError`. Defects still crash loudly.
- **Fatal-error path** now prints a readable message on stdout and exits 1, instead of an unhandled-exception traceback that `run.sh` would discard.
- **Resource-usage capture**: client CPU (`getrusage`) + peak RSS added to the JSON output and the human-readable summary; server-side CPU and peak RSS are read from the container's cgroup (`cpu.stat`, `memory.peak`) and merged into the JSON.
- **`run.sh` diagnostics**: client stderr preserved to `results/json_*/<cell>.log` (previously discarded); switched from `docker compose up --abort-on-container-exit` to `docker compose run --rm --no-deps` so the server container survives long enough to read its cgroup counters; summary table gains `CPU cli`, `CPU srv`, `Peak RSS` columns.
- **README** refreshed with a fresh full-matrix measurement, per-column documentation, updated JSON output shape, and rewritten per-scenario analysis + takeaways.

## Why

The old harness silently discarded client stderr, so any unhandled exception left an empty `FAILED` cell with no diagnostic. It also had no view into CPU or memory cost — throughput and latency were the only signals, which makes it hard to tell whether a change trades CPU for something else.
