### PR TITLE
perf: compare address families directly in prepareDestAddr

### DIFF
--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -56,12 +56,8 @@ proc prepareDestAddr(
   ## When lsquic later asks us to send on that IPv6 socket, sending directly to
   ## an AF_INET destination can fail with EINVAL. Re-map the destination to an
   ## IPv6-mapped address when the local path is IPv6.
-  let
-    localAddress = localSa.toTransportAddress()
-    destAddress = destSa.toTransportAddress()
-  if localAddress.family == AddressFamily.IPv6 and
-      destAddress.family == AddressFamily.IPv4:
-    let mappedDest = destAddress.toIPv6()
+  if localSa.isIPv6Family() and destSa.isIPv4Family():
+    let mappedDest = destSa.toTransportAddress().toIPv6()
     mappedDest.toSAddr(destStorage, destAddrLen)
   else:
     destAddrLen = sockAddrLen(destSa.sa_family.int)
@@ -235,3 +231,13 @@ proc sendPacketsOut*(
       sent.inc
 
     sent.cint
+
+when defined(lsquic_testing):
+  proc prepareDestAddrForTest*(
+      localSa: ptr SockAddr,
+      destSa: ptr SockAddr,
+      destStorage: var Sockaddr_storage,
+      destAddrLen: var SockLen,
+  ) =
+    ## Test-only accessor for the destination remapping.
+    prepareDestAddr(localSa, destSa, destStorage, destAddrLen)

--- a/lsquic/helpers/transportaddr.nim
+++ b/lsquic/helpers/transportaddr.nim
@@ -32,3 +32,9 @@ proc toTransportAddress*(sock: ptr SockAddr): TransportAddress =
   var taddr: TransportAddress
   fromSAddr(addr destAddress, destAddrLen, taddr)
   taddr
+
+proc isIPv6Family*(sock: ptr SockAddr): bool {.inline.} =
+  sock.sa_family.int == fixed_AF_INET6
+
+proc isIPv4Family*(sock: ptr SockAddr): bool {.inline.} =
+  sock.sa_family.int == AF_INET.int

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -5,7 +5,7 @@
 
 import
   test_connection, test_perf, test_tlsconfig, test_verifier, test_lifecycle,
-  test_timeout, test_stress, test_runtime, test_routing
+  test_timeout, test_stress, test_runtime, test_routing, test_destaddr
 
 from ./helpers/trackers import finalCheckTrackers
 finalCheckTrackers()

--- a/tests/test_destaddr.nim
+++ b/tests/test_destaddr.nim
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import unittest2
+import chronos, chronos/osdefs
+import ../lsquic/context/io
+
+proc sa(address: string): Sockaddr_storage =
+  var length: SockLen
+  initTAddress(address).toSAddr(result, length)
+
+proc prepared(local, dest: string): TransportAddress =
+  var
+    localStorage = sa(local)
+    destStorage = sa(dest)
+    outStorage: Sockaddr_storage
+    outLen: SockLen
+  prepareDestAddrForTest(
+    cast[ptr SockAddr](addr localStorage),
+    cast[ptr SockAddr](addr destStorage),
+    outStorage,
+    outLen,
+  )
+  fromSAddr(addr outStorage, outLen, result)
+
+suite "destination address preparation":
+  test "IPv4 local keeps an IPv4 destination":
+    check prepared("192.168.1.10:1000", "192.168.1.20:4433") ==
+      initTAddress("192.168.1.20:4433")
+
+  test "IPv6 local keeps an IPv6 destination":
+    check prepared("[::1]:1000", "[2001:db8::2]:4433") ==
+      initTAddress("[2001:db8::2]:4433")
+
+  test "IPv6 local maps an IPv4 destination into IPv6":
+    # A dual-stack `::` socket cannot sendmsg to a bare AF_INET destination.
+    let mapped = prepared("[::]:1000", "192.168.1.20:4433")
+    check mapped.family == AddressFamily.IPv6
+    check mapped.port == Port(4433)
+    check mapped == initTAddress("192.168.1.20:4433").toIPv6()
+
+  test "IPv4 local leaves an IPv6 destination alone":
+    check prepared("192.168.1.10:1000", "[2001:db8::2]:4433") ==
+      initTAddress("[2001:db8::2]:4433")


### PR DESCRIPTION
## Extraction from #122

This is the address-family portion of #122, extracted onto post-revert `main` and preserved as its own PR because #122 has other commits that depend on the reverted #115 GSO code and cannot cleanly rebase.

Original commit: `cea02ac` on `perf/per-packet-cleanups` (see #122).

## What it does

`prepareDestAddr` built two 112-byte `TransportAddress` values on every packet just to read two `sa_family` fields, and discarded both in the common case where no remapping was needed. This PR compares the sockaddr families directly and only converts on the dual-stack path that actually remaps.

**Isolated cost, 2×10⁶ iterations, from the original commit:** 132.5 ns → 3.7 ns per call. Runs once per GSO group on Linux and once per spec otherwise.

Adds `isIPv4Family`/`isIPv6Family` helpers in `transportaddr.nim` and a `test_destaddr.nim` test that exercises both branches of the remapping.

## Benchmark

Full 36-cell matrix vs main is running now; results will follow as a comment.