### PR TITLE
perf: reuse a stack WSABUF and heap-fall-back on the Windows send path

### DIFF
--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -195,9 +195,9 @@ proc sendPacketsOut*(
     sent.cint
   else:
     when defined(windows):
-      # Reused across specs rather than allocated per packet. Bounded like the
-      # segmented path's bufPool, which makes the same assumption about iovlen.
-      var bufs {.noinit.}: array[MaxBatch, WSABUF]
+      var
+        bufs {.noinit.}: array[MaxBatch, WSABUF]
+        overflow: seq[WSABUF]
     var sent = 0
     for i in 0 ..< nspecs.int:
       let curr = specsArr[i]
@@ -207,18 +207,26 @@ proc sendPacketsOut*(
       prepareDestAddr(curr.local_sa, curr.dest_sa, destStorage, destAddrLen)
 
       when defined(windows):
-        let iovArr = cast[ptr UncheckedArray[struct_iovec]](curr.iov)
+        let
+          iovArr = cast[ptr UncheckedArray[struct_iovec]](curr.iov)
+          iovlen = curr.iovlen.int
+          dst =
+            if iovlen <= bufs.len:
+              cast[ptr UncheckedArray[WSABUF]](addr bufs[0])
+            else:
+              overflow.setLen(iovlen)
+              cast[ptr UncheckedArray[WSABUF]](addr overflow[0])
 
-        for j in 0 ..< curr.iovlen.int:
+        for j in 0 ..< iovlen:
           let src = iovArr[j]
-          bufs[j].len = culong(src.iov_len)
-          bufs[j].buf = cast[ptr char](src.iov_base)
+          dst[j].len = culong(src.iov_len)
+          dst[j].buf = cast[ptr char](src.iov_base)
 
         var bytesSent: culong = 0
         let res = WSASendTo(
           SocketHandle(quicCtx.fd),
-          addr bufs[0],
-          culong(curr.iovlen),
+          addr dst[0],
+          culong(iovlen),
           addr bytesSent,
           0, # flags
           cast[ptr SockAddr](addr destStorage),

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -13,9 +13,9 @@ when not defined(windows):
   import posix
 
 const MaxBatch = 1024
-  ## Upper bound on the stack WSABUF array in `sendPlain` (Windows). lsquic
-  ## coalesces within one datagram, so `iovlen` stays well under this in
-  ## practice; if it does not, `sendPlain` falls back to a heap-allocated seq.
+  ## Upper bound on the stack WSABUF array in the Windows send path (`sendPacketsOut`).
+  ## In practice `iovlen` is small; if it exceeds this bound, `sendPacketsOut`
+  ## falls back to a heap-allocated seq.
 
 when defined(linux):
   {.passc: "-D_GNU_SOURCE".}

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -194,6 +194,10 @@ proc sendPacketsOut*(
 
     sent.cint
   else:
+    when defined(windows):
+      # Reused across specs rather than allocated per packet. Bounded like the
+      # segmented path's bufPool, which makes the same assumption about iovlen.
+      var bufs {.noinit.}: array[MaxBatch, WSABUF]
     var sent = 0
     for i in 0 ..< nspecs.int:
       let curr = specsArr[i]
@@ -205,7 +209,6 @@ proc sendPacketsOut*(
       when defined(windows):
         let iovArr = cast[ptr UncheckedArray[struct_iovec]](curr.iov)
 
-        var bufs = newSeq[WSABUF](curr.iovlen.int)
         for j in 0 ..< curr.iovlen.int:
           let src = iovArr[j]
           bufs[j].len = culong(src.iov_len)

--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -12,6 +12,11 @@ when not defined(windows):
   import chronicles
   import posix
 
+const MaxBatch = 1024
+  ## Upper bound on the stack WSABUF array in `sendPlain` (Windows). lsquic
+  ## coalesces within one datagram, so `iovlen` stays well under this in
+  ## practice; if it does not, `sendPlain` falls back to a heap-allocated seq.
+
 when defined(linux):
   {.passc: "-D_GNU_SOURCE".}
 


### PR DESCRIPTION
## Extraction from #122

This is the Windows-send-path portion of #122, extracted onto post-revert \`main\` and preserved as its own PR because #122 has other commits that depend on the reverted #115 GSO code and cannot cleanly rebase.

Original commits: \`e946741\` + \`302bb29\` (+ \`1143ae2\`, a cosmetic comment removal that was folded in during extraction) on \`perf/per-packet-cleanups\` (see #122).

## What it does

\`sendPlain\` on Windows allocated a fresh \`seq[WSABUF]\` for every packet. This PR hoists it out of the loop as a stack array bounded by \`MaxBatch\`, and adds a heap-allocated \`overflow\` seq that grows once when a spec's \`iovlen\` exceeds the stack bound.

Two commits:

1. \`perf: reuse a stack buffer for WSABUF on the Windows send path\` (original \`e946741\`). Author's isolated cost, 5×10⁶ iterations on Linux: **42.9 ns → 2.0 ns per packet** at iovlen=1.
2. \`fix(send): fall back to the heap when a spec's iovlen exceeds MaxBatch\` (original \`302bb29\`). Correctness follow-up — \`MaxBatch\` bounds the specs in one lsquic callback, not the iovecs within one spec.

Plus a small **prep commit** at the top of the branch that declares \`MaxBatch = 1024\` locally in \`io.nim\`. The revert of #115 (\`609b7db\`) removed \`gso.nim\` which was the previous home for this constant. The extracted change re-declares it with the same value so the branch stays self-contained.

## Scope

**Narrow than it looks:** with USO available, \`sendPacketsOut\` takes the segmented path (which used its own stack array), so this only affects Windows without USO. And #115 is currently reverted, so the segmented path is disabled entirely on \`main\` — meaning this optimization *is* the current Windows send path.

## Testing

- Linux compile: \`nim c --threads:on -d:release\` — succeeds.
- Windows cross-check: \`nim check --os:windows --threads:on --path:. lsquic/context/io.nim\` — no errors (only the two pre-existing \`boringssl_prefix_symbols_internal_*.inc\` errors that are present on \`main\` too).

## Benchmark

**Not runnable on the Linux matrix** — this code path is guarded by \`when defined(windows)\`. The isolated microbenchmark from the original author is the best signal we have without a Windows CI runner.

If a Windows benchmark environment appears, the natural test would be Windows without USO enabled on \`throughput\` and \`stress\` — the extra alloc per packet compounds with per-packet cost.