### PR TITLE
perf: skip CID routing and the sockaddr bounce buffer on the packet-in path

### DIFF
--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -142,6 +142,15 @@ proc routeDatagram(
     hasClientContext = not endpoint.clientContext.isNil
     hasServerContext = not endpoint.serverContext.isNil
 
+  # Only one engine on this socket, so there is nothing to disambiguate: skip
+  # parsing the connection id out of every datagram and probing the CID set.
+  if hasClientContext != hasServerContext:
+    if hasClientContext:
+      endpoint.clientContext.packetIn(data, local, remote)
+      return {rtClient}
+    endpoint.serverContext.packetIn(data, local, remote)
+    return {rtServer}
+
   var cid: CidKey
   if endpoint.packetDcid(data, cid):
     if hasClientContext and endpoint.clientContext.ownsCid(cid):
@@ -153,14 +162,6 @@ proc routeDatagram(
       trace "Routing datagram to server context", cid
       endpoint.serverContext.packetIn(data, local, remote)
       return {rtServer}
-
-  if hasClientContext and not hasServerContext:
-    endpoint.clientContext.packetIn(data, local, remote)
-    return {rtClient}
-
-  if hasServerContext and not hasClientContext:
-    endpoint.serverContext.packetIn(data, local, remote)
-    return {rtServer}
 
   if hasServerContext and data.isIetfInitial():
     trace "Routing initial datagram with unknown CID to server context",

--- a/lsquic/helpers/transportaddr.nim
+++ b/lsquic/helpers/transportaddr.nim
@@ -26,9 +26,8 @@ proc sockAddrLen*(family: int): SockLen {.inline.} =
     raiseAssert "invalid socket address family"
 
 proc toTransportAddress*(sock: ptr SockAddr): TransportAddress =
-  var destAddress: Sockaddr_storage
-  let destAddrLen: SockLen = sockAddrLen(sock.sa_family.int)
-  copyMem(addr destAddress, sock, destAddrLen)
+  # `fromSAddr` only reads through the pointer, so the sockaddr does not need
+  # to be copied into a Sockaddr_storage first.
   var taddr: TransportAddress
-  fromSAddr(addr destAddress, destAddrLen, taddr)
+  fromSAddr(cast[ptr Sockaddr_storage](sock), sockAddrLen(sock.sa_family.int), taddr)
   taddr


### PR DESCRIPTION
Extracted from #122, which mixed cross-platform cleanups with Windows send-path work and GSO-dependent commits. These two are the cross-platform, non-GSO half; the rest went to #131 (`prepareDestAddr`) and #132 (Windows WSABUF). Rebased onto `main` (`e1fa8b8`).

Both commits remove work from the per-packet path without changing behaviour.

### `perf: skip CID routing when the socket carries one engine`

`routeDatagram` parsed the connection ID out of every inbound datagram and probed the CID set before deciding where to send it. When the socket carries only one engine — the common case — that work never changed the outcome: on a CID miss the old code fell through to `if hasClientContext and not hasServerContext` (and its server twin) and delivered to the only context that existed anyway. The `isIetfInitial` fallback below it was already unreachable in that configuration.

So the fast path added here short-circuits to the same destination the old code always reached, and skips a parse plus a set probe per datagram. The shared-socket path, where both contexts exist and the CID actually disambiguates, is untouched.

### `perf: drop the bounce buffer in toTransportAddress`

`toTransportAddress` copied the `sockaddr` into a stack `Sockaddr_storage` before handing it to `fromSAddr`. `fromSAddr` only reads through the pointer, so the copy was never needed.

### Benchmarks

**None of the matrix numbers support a performance claim, and this PR does not make one.**

A single full-matrix run showed `lan_multistream` +19.7% download / −15.1% client CPU, which looked like a clean win. It does not survive repetition. Eight runs per arm of `lan multistream`, alternating in blocks of four so the arm is not confounded with elapsed time, on `e1fa8b8` versus this branch:

| metric | main (n=8) | this branch (n=8) | delta | permutation p |
|---|---|---|---|---|
| Download Mbit/s | 2869 ± 193 | 3008 ± 202 | +4.9% | 0.184 |
| CPU client ms | 123.6 ± 6.6 | 117.9 ± 6.0 | −4.6% | 0.092 |
| CPU server ms | 244.7 ± 15.8 | 237.9 ± 13.9 | −2.7% | 0.386 |

Zero errors across all 16 runs. Directionally favourable on all three metrics, statistically significant on none. At this spread the test resolves roughly ±10% on download, so a real effect smaller than that would not show up here — but the +19.7% from the single run is refuted.

`lan_multistream` is one of the better-behaved cells in the harness (download coefficient of variation 5.5%, against 14.6% on `wan_multistream`), so this is a reasonably sensitive test rather than a hand-wave.

The case for merging is that both changes delete work that provably cannot affect the result, on a path that runs once per datagram. That stands on its own; it does not need a benchmark number, and attaching one that the data will not support is how the earlier verdicts on #125, #126 and #131 went wrong.

Context on why the matrix numbers get treated this way: #129 now documents which harness columns can carry a regression signal and which cannot, after a variance investigation found p95 spreads of up to 2.9x on unchanged code.
