### PR TITLE
test: sendPacketsOut return contract and parked-write cleanup

### DIFF
--- a/tests/helpers/address.nim
+++ b/tests/helpers/address.nim
@@ -1,7 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import chronos
+import chronos, chronos/osdefs
+
+proc toSockaddrStorage*(address: TransportAddress): Sockaddr_storage =
+  ## Returns storage the caller owns, so a `ptr SockAddr` into it stays valid.
+  var
+    storage: Sockaddr_storage
+    length: SockLen
+  address.toSAddr(storage, length)
+  storage
 
 template AutoAddressIP4*(): TransportAddress =
   initTAddress("127.0.0.1:0")

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -5,7 +5,7 @@
 
 import
   test_connection, test_perf, test_tlsconfig, test_verifier, test_lifecycle,
-  test_timeout, test_stress, test_runtime, test_routing, test_destaddr
+  test_timeout, test_stress, test_runtime, test_routing, test_destaddr, test_send
 
 from ./helpers/trackers import finalCheckTrackers
 finalCheckTrackers()

--- a/tests/test_destaddr.nim
+++ b/tests/test_destaddr.nim
@@ -6,15 +6,12 @@
 import unittest2
 import chronos, chronos/osdefs
 import ../lsquic/context/io
-
-proc sa(address: string): Sockaddr_storage =
-  var length: SockLen
-  initTAddress(address).toSAddr(result, length)
+import ./helpers/address
 
 proc prepared(local, dest: string): TransportAddress =
   var
-    localStorage = sa(local)
-    destStorage = sa(dest)
+    localStorage = toSockaddrStorage(initTAddress(local))
+    destStorage = toSockaddrStorage(initTAddress(dest))
     outStorage: Sockaddr_storage
     outLen: SockLen
   prepareDestAddrForTest(

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -535,6 +535,25 @@ suite "lifecycle":
     expect StreamResetError:
       discard await doneFut
 
+  asyncTest "peer write reset fails a parked write":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+    var data = @[1'u8, 2, 3]
+    let doneFut =
+      Future[void].Raising([CancelledError, StreamError]).init("test parked write")
+    stream.toWrite =
+      Opt.some(WriteTask(data: data[0].addr, dataLen: data.len, doneFut: doneFut))
+
+    onReset(nil, cast[ptr lsquic_stream_ctx_t](stream), 1.cint)
+
+    check:
+      stream.resetHow == ResetWrite
+      stream.toWrite.isNone()
+
+    expect StreamResetError:
+      await doneFut.wait(timeout)
+
   asyncTest "read after read reset raises":
     let stream = Stream.new()
     defer:
@@ -696,6 +715,22 @@ suite "lifecycle":
     if writeFut.finished:
       expect StreamError:
         await writeFut
+
+  asyncTest "connection close settles a parked write":
+    let peers = await connectPeers()
+    defer:
+      await peers.stop()
+
+    let outgoingStream = await peers.outgoing.openStream()
+    # 16 MB exceeds the send window, so the write parks with a pending write task
+    let writing = outgoingStream.write(makeData(16 * 1024 * 1024))
+
+    check outgoingStream.toWrite.isSome
+
+    peers.outgoing.close()
+
+    expect StreamError:
+      await writing.wait(timeout)
 
   asyncTest "concurrent reads on one stream are serialized":
     let peers = await connectPeers()

--- a/tests/test_send.nim
+++ b/tests/test_send.nim
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos, chronos/osdefs, nativesockets, unittest2
+import lsquic/[lsquic_ffi, context/context, context/io]
+import ./helpers/[address, trackers]
+
+when not defined(windows):
+  from posix import EAGAIN, EBADF, errno
+
+proc makeOutSpec(
+    iov: ptr struct_iovec, local, dest: ptr Sockaddr_storage
+): struct_lsquic_out_spec =
+  struct_lsquic_out_spec(
+    iov: iov,
+    iovlen: 1,
+    local_sa: cast[ptr SockAddr](local),
+    dest_sa: cast[ptr SockAddr](dest),
+  )
+
+suite "packets out":
+  teardown:
+    checkTrackers()
+
+  test "a send with no packets sent out reports -1":
+    let ctx = QuicContext(fd: -1)
+    var
+      payload = @[1'u8, 2, 3]
+      localStorage = toSockaddrStorage(initTAddress("127.0.0.1:1000"))
+      destStorage = toSockaddrStorage(initTAddress("127.0.0.1:4433"))
+      iov = struct_iovec(iov_base: addr payload[0], iov_len: payload.len.csize_t)
+      spec = makeOutSpec(addr iov, addr localStorage, addr destStorage)
+
+    let res = sendPacketsOut(cast[pointer](ctx), addr spec, 1)
+    let savedErrno = errno
+
+    check res == -1
+    # The engine reads errno to decide whether to retry or close the connection.
+    when not defined(windows):
+      check savedErrno == EBADF
+
+  test "a send with some packets sent out reports the count":
+    # Returning -1 would make the engine resend a datagram that already went out.
+    let fd = createNativeSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+    defer:
+      nativesockets.close(fd)
+
+    let ctx = QuicContext(fd: cint(fd))
+    var
+      payload = @[1'u8, 2, 3]
+      localStorage = toSockaddrStorage(initTAddress("127.0.0.1:1000"))
+      ipv4DestStorage = toSockaddrStorage(initTAddress("127.0.0.1:4433"))
+      ipv6DestStorage = toSockaddrStorage(initTAddress("[::1]:4433"))
+      iov = struct_iovec(iov_base: addr payload[0], iov_len: payload.len.csize_t)
+      specs = [
+        makeOutSpec(addr iov, addr localStorage, addr ipv4DestStorage),
+        makeOutSpec(addr iov, addr localStorage, addr ipv6DestStorage),
+      ]
+
+    let res = sendPacketsOut(cast[pointer](ctx), addr specs[0], 2)
+    let savedErrno = errno
+
+    check res == 1
+    # Linux overwrites errno with EAGAIN here, the other platforms leave alone
+    # whatever the failed send set.
+    when defined(linux):
+      check savedErrno == EAGAIN
+
+  test "a batch larger than one sendmmsg call sends every packet":
+    # SendmmsgBatchSize is 64, so 65 specs take two sendmmsg calls.
+    const SpecCount = 65
+
+    let fd = createNativeSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+    defer:
+      nativesockets.close(fd)
+
+    let ctx = QuicContext(fd: cint(fd))
+    var
+      payload = @[1'u8, 2, 3]
+      localStorage = toSockaddrStorage(initTAddress("127.0.0.1:1000"))
+      destStorage = toSockaddrStorage(initTAddress("127.0.0.1:4433"))
+      iov = struct_iovec(iov_base: addr payload[0], iov_len: payload.len.csize_t)
+      specs = newSeq[struct_lsquic_out_spec](SpecCount)
+    for spec in specs.mitems:
+      spec = makeOutSpec(addr iov, addr localStorage, addr destStorage)
+
+    check sendPacketsOut(cast[pointer](ctx), addr specs[0], SpecCount.cuint) == SpecCount

--- a/tests/test_send.nim
+++ b/tests/test_send.nim
@@ -67,8 +67,8 @@ suite "packets out":
     check res == 1
 
   test "a batch larger than one sendmmsg call sends every packet":
-    # SendmmsgBatchSize is 64, so 65 specs take two sendmmsg calls.
-    const SpecCount = 65
+    # SendmmsgBatchSize is 64, so +1 specs take two sendmmsg calls.
+    const SpecCount = 64 + 1 # const is not exported
 
     let fd = createNativeSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
     defer:

--- a/tests/test_send.nim
+++ b/tests/test_send.nim
@@ -34,12 +34,11 @@ suite "packets out":
       spec = makeOutSpec(addr iov, addr localStorage, addr destStorage)
 
     let res = sendPacketsOut(cast[pointer](ctx), addr spec, 1)
-    let savedErrno = errno
-
-    check res == -1
     # The engine reads errno to decide whether to retry or close the connection.
     when not defined(windows):
-      check savedErrno == EBADF
+      check errno == EBADF
+
+    check res == -1
 
   test "a send with some packets sent out reports the count":
     # Returning -1 would make the engine resend a datagram that already went out.
@@ -60,13 +59,12 @@ suite "packets out":
       ]
 
     let res = sendPacketsOut(cast[pointer](ctx), addr specs[0], 2)
-    let savedErrno = errno
-
-    check res == 1
     # Linux overwrites errno with EAGAIN here, the other platforms leave alone
     # whatever the failed send set.
     when defined(linux):
-      check savedErrno == EAGAIN
+      check errno == EAGAIN
+
+    check res == 1
 
   test "a batch larger than one sendmmsg call sends every packet":
     # SendmmsgBatchSize is 64, so 65 specs take two sendmmsg calls.


### PR DESCRIPTION
Adds new tests:

`test_send`:
- a total failure returns -1, 
- a partial send returns the count, 
- a batch past `SendmmsgBatchSize` sends every packet.

`test_lifecycle`:
- peer write reset fails a parked write
- connection close settles a parked write

`helpers/address` - `toSockaddrStorage` moves out of `test_destaddr.nim`, now shared with `test_send.nim`.