### PR TITLE
test: improvements + lifecycle tests

### DIFF
--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -9,7 +9,9 @@ import ./helpers/[address, clientserver, futures, stream, trackers]
 
 initializeLsquic(true, true)
 
-const dialTimeout = 5.seconds
+const
+  dialTimeout = 5.seconds
+  streamTimeout = 5.seconds
 
 proc runConnectionTest(
     listenAddress: TransportAddress, dialAddress: TransportAddress
@@ -59,7 +61,7 @@ proc runConnectionTest(
 
     await stream.close()
 
-  await allFuturesRaising(outgoingBehaviour(), incomingBehaviour())
+  await allFuturesRaising(outgoingBehaviour(), incomingBehaviour()).wait(streamTimeout)
 
   outgoingConn.close()
   incomingConn.close()
@@ -218,7 +220,7 @@ proc runConcurrentStreamOpenTest(address: TransportAddress) {.async.} =
       )(i)
     )
 
-  await allFutures(receiveAll(), allFutures(sendAll))
+  await allFutures(receiveAll(), allFutures(sendAll)).wait(streamTimeout)
 
   for seen in received:
     check seen
@@ -260,7 +262,7 @@ proc runServerInitiatedStreamTest(address: TransportAddress) {.async.} =
 
     await stream.close()
 
-  await allFuturesRaising(serverBehaviour(), clientBehaviour())
+  await allFuturesRaising(serverBehaviour(), clientBehaviour()).wait(streamTimeout)
 
   outgoingConn.close()
   incomingConn.close()
@@ -293,7 +295,7 @@ proc runChunkedReadTest(peers: ConnectedPeers, bufSize, payloadSize: int) {.asyn
 
     await stream.close()
 
-  await allFuturesRaising(sender(), receiver())
+  await allFuturesRaising(sender(), receiver()).wait(streamTimeout)
 
 suite "connection":
   teardown:

--- a/tests/test_destaddr.nim
+++ b/tests/test_destaddr.nim
@@ -6,7 +6,7 @@
 import unittest2
 import chronos, chronos/osdefs
 import ../lsquic/context/io
-import ./helpers/address
+import ./helpers/[address, trackers]
 
 proc prepared(local, dest: string): TransportAddress =
   var
@@ -23,6 +23,9 @@ proc prepared(local, dest: string): TransportAddress =
   fromSAddr(addr outStorage, outLen, result)
 
 suite "destination address preparation":
+  teardown:
+    checkTrackers()
+
   test "IPv4 local keeps an IPv4 destination":
     check prepared("192.168.1.10:1000", "192.168.1.20:4433") ==
       initTAddress("192.168.1.20:4433")

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -573,6 +573,21 @@ suite "lifecycle":
     expect AssertionDefect:
       discard await stream.readOnce(nil, 8)
 
+  asyncTest "nil write source is rejected":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+
+    expect AssertionDefect:
+      await stream.write(nil, 8)
+
+  asyncTest "zero length writes ignore a nil source":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+
+    await stream.write(nil, 0)
+
   asyncTest "read waiting for the read lock sees the stream closed by the engine":
     let stream = Stream.new()
     defer:
@@ -647,10 +662,8 @@ suite "lifecycle":
     onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # also releases the pin
 
     check stream.toRead.isNone()
-    # guarded so a regression fails this test instead of parking the suite
     check doneFut.finished
-    if doneFut.finished:
-      check (await doneFut) == 0
+    check (await doneFut.wait(timeout)) == 0
 
   asyncTest "engine close fails a parked read after a peer read reset":
     let stream = Stream.new()
@@ -666,9 +679,9 @@ suite "lifecycle":
 
     check stream.toRead.isNone()
     check doneFut.finished
-    if doneFut.finished:
-      expect StreamResetError:
-        discard await doneFut
+
+    expect StreamResetError:
+      discard await doneFut.wait(timeout)
 
   asyncTest "engine close fails a parked write after a local write shutdown":
     let stream = Stream.new()
@@ -683,9 +696,9 @@ suite "lifecycle":
 
     check stream.toWrite.isNone()
     check doneFut.finished
-    if doneFut.finished:
-      expect StreamError:
-        await doneFut
+
+    expect StreamError:
+      await doneFut.wait(timeout)
 
   asyncTest "abort settles a parked read and a parked write":
     let stream = Stream.new()
@@ -710,11 +723,10 @@ suite "lifecycle":
     check stream.toWrite.isNone()
     check readFut.finished
     check writeFut.finished
-    if readFut.finished:
-      check (await readFut) == 0
-    if writeFut.finished:
-      expect StreamError:
-        await writeFut
+    check (await readFut.wait(timeout)) == 0
+
+    expect StreamError:
+      await writeFut.wait(timeout)
 
   asyncTest "connection close settles a parked write":
     let peers = await connectPeers()

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -6,7 +6,6 @@
 import std/sets
 import chronos, chronos/unittest2/asynctests, results
 import lsquic
-import lsquic/[datagram]
 import lsquic/context/[client, context, io, stream]
 import ./helpers/[address, certificate, clientserver, stream, trackers]
 from lsquic/lsquic_ffi import lsquic_stream_ctx_t, lsquic_conn_t
@@ -414,11 +413,11 @@ suite "lifecycle":
     let remote = initTAddress("127.0.0.1:54321")
 
     ctx.stop()
-    ctx.receive(Datagram(data: @[1'u8, 2, 3]), local, remote)
+    check not ctx.packetIn([1'u8, 2, 3], local, remote)
     ctx.processWhenReady()
 
     ctx.destroy()
-    ctx.receive(Datagram(data: @[4'u8, 5, 6]), local, remote)
+    check not ctx.packetIn([4'u8, 5, 6], local, remote)
     ctx.processWhenReady()
 
   asyncTest "connection operations are guarded after context stops":

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -27,7 +27,7 @@ suite "lifecycle":
     await listener.stop()
 
     expect TransportError:
-      discard await accepting
+      discard await accepting.wait(timeout)
 
   asyncTest "listener stop fails all pending accepts":
     let server = makeServer()
@@ -39,11 +39,11 @@ suite "lifecycle":
     await listener.stop()
 
     expect TransportError:
-      discard await accepting1
+      discard await accepting1.wait(timeout)
     expect TransportError:
-      discard await accepting2
+      discard await accepting2.wait(timeout)
     expect TransportError:
-      discard await accepting3
+      discard await accepting3.wait(timeout)
 
   asyncTest "connection close propagates to peer":
     let peers = await connectPeers()
@@ -129,7 +129,7 @@ suite "lifecycle":
     peers.outgoing.abort()
 
     expect ConnectionClosedError:
-      discard await incomingWaiting
+      discard await incomingWaiting.wait(timeout)
 
   asyncTest "cancel pending outgoing streams clears queue":
     let quicConn = QuicConnection(incoming: newAsyncQueue[Stream]())
@@ -141,9 +141,9 @@ suite "lifecycle":
     quicConn.cancelPending()
 
     expect ConnectionError:
-      await pending1
+      await pending1.wait(timeout)
     expect ConnectionError:
-      await pending2
+      await pending2.wait(timeout)
     check quicConn.popPendingStream(nil).isNone()
 
   asyncTest "abort after open stream still closes connection":
@@ -533,7 +533,7 @@ suite "lifecycle":
       stream.toRead.isNone()
 
     expect StreamResetError:
-      discard await doneFut
+      discard await doneFut.wait(timeout)
 
   asyncTest "peer write reset fails a parked write":
     let stream = Stream.new()
@@ -618,7 +618,7 @@ suite "lifecycle":
     stream.readLock.release()
 
     expect StreamResetError:
-      discard await reading
+      discard await reading.wait(timeout)
 
   asyncTest "write waiting for the write lock sees the stream closed by the engine":
     let stream = Stream.new()
@@ -632,7 +632,7 @@ suite "lifecycle":
     stream.writeLock.release()
 
     expect StreamError:
-      await writing
+      await writing.wait(timeout)
 
   asyncTest "write waiting for the write lock sees a peer reset":
     let stream = Stream.new()
@@ -646,7 +646,7 @@ suite "lifecycle":
     stream.writeLock.release()
 
     expect StreamResetError:
-      await writing
+      await writing.wait(timeout)
 
   # One test per close path, pinning the rule that each settles the parked
   # operation itself.

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -462,6 +462,33 @@ suite "lifecycle":
     expect QuicConfigError:
       discard QuicEndpoint.new(TLSConfig.new(), AutoAddressIP4, {CanListen})
 
+  asyncTest "dial-only endpoint rejects accept":
+    let endpoint = makeDialEndpoint(AddressFamily.IPv4)
+    defer:
+      await endpoint.stop()
+
+    var rejected = false
+    var message = ""
+    try:
+      discard await endpoint.accept()
+    except TransportError as exc:
+      rejected = true
+      message = exc.msg
+
+    # The stopped endpoint raises TransportError too, so the message is all
+    # that separates it from a capability rejection.
+    check:
+      rejected
+      message == "endpoint is not listen-capable"
+
+  asyncTest "listen-only endpoint rejects dial":
+    let endpoint = makeEndpoint(AutoAddressIP4, {CanListen})
+    defer:
+      await endpoint.stop()
+
+    expect QuicError:
+      discard await endpoint.dial(endpoint.localAddress()).wait(timeout)
+
   asyncTest "endpoint stop is idempotent":
     let endpoint = makeEndpoint(AutoAddressIP4)
 

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -13,6 +13,7 @@
 import chronos, chronos/unittest2/asynctests
 import lsquic/[endpoint, lsquic_ffi]
 import lsquic/context/context
+import ./helpers/trackers
 
 func makeCid(bytes: openArray[byte]): CidKey =
   var cid = CidKey(len: bytes.len.uint8)
@@ -53,6 +54,9 @@ proc newTrackingContext(T: typedesc): T =
   ctx
 
 suite "cid ownership":
+  teardown:
+    checkTrackers()
+
   test "registered cids are owned, unknown ones are not":
     let ctx = newTrackingContext(ClientContext)
 
@@ -162,6 +166,9 @@ func shortHeaderPacket(dcid: CidKey, firstByte: byte = ShortFirstByte): seq[byte
   packet
 
 suite "datagram header parsing":
+  teardown:
+    checkTrackers()
+
   test "the short header cid is read at the engine's cid width":
     # a short header carries no length byte, so this width is the only thing
     # that tells the endpoint where the routing cid ends

--- a/tests/test_runtime.nim
+++ b/tests/test_runtime.nim
@@ -19,6 +19,11 @@ proc socketReceiveBufferBytes(
     raiseTransportOsError(res.error())
   int(res.get())
 
+proc ignoreDatagram(
+    udp: DatagramTransport, remote: TransportAddress
+) {.async: (raises: []).} =
+  discard
+
 suite "runtime":
   teardown:
     checkTrackers()
@@ -60,9 +65,10 @@ suite "runtime":
 
     check endpoint.datagramTransport().socketReceiveBufferBytes() > 0
 
-  asyncTest "socket receive buffer can be disabled":
+  asyncTest "zero receive buffer keeps the OS default":
     cleanupLsquic()
     initializeLsquic(true, true)
+    let unconfigured = newDatagramTransport(ignoreDatagram, local = AutoAddressIP4)
     let endpoint = QuicEndpoint.new(
       makeTLSConfig(),
       AutoAddressIP4,
@@ -71,9 +77,11 @@ suite "runtime":
     )
     defer:
       await endpoint.stop()
+      await unconfigured.closeWait()
       cleanupLsquic()
 
-    check endpoint.datagramTransport().socketReceiveBufferBytes() > 0
+    check endpoint.datagramTransport().socketReceiveBufferBytes() ==
+      unconfigured.socketReceiveBufferBytes()
 
   asyncTest "socket receive buffer setting is readable":
     cleanupLsquic()

--- a/tests/test_timeout.nim
+++ b/tests/test_timeout.nim
@@ -7,7 +7,10 @@ import chronos, chronos/unittest2/asynctests
 import lsquic/timeout
 import ./helpers/trackers
 
-const fireTimeout = 2.seconds
+const
+  earlyDeadline = 50.milliseconds
+  lateDeadline = 2.seconds
+  fireTimeout = 1.seconds
 
 suite "timeout":
   teardown:
@@ -22,8 +25,8 @@ suite "timeout":
         fired.fire()
     )
 
-    timeout.set(400.milliseconds)
-    timeout.set(50.milliseconds)
+    timeout.set(lateDeadline)
+    timeout.set(earlyDeadline)
 
     check (await fired.wait().withTimeout(fireTimeout))
     check fireCount == 1
@@ -37,8 +40,8 @@ suite "timeout":
         fired.fire()
     )
 
-    timeout.set(50.milliseconds)
-    timeout.set(400.milliseconds)
+    timeout.set(earlyDeadline)
+    timeout.set(lateDeadline)
 
     check (await fired.wait().withTimeout(fireTimeout))
     check fireCount == 1


### PR DESCRIPTION
Test suite hardening.

`test_lifecycle.nim`
- Bounded 11 awaits with the existing `timeout` where the future's settlement is the property under test.
- Dropped 4 `if fut.finished:` guards so the checks inside them always run.
- "late datagrams are ignored after context stops" now checks `not ctx.packetIn(...)` instead of calling `ctx.receive` and asserting nothing. `packetIn` is also what production calls, so the `lsquic/datagram` import is gone.
- New: "nil write source is rejected" and "zero length writes ignore a nil source", mirroring the existing `readOnce` pair.
- New: "dial-only endpoint rejects accept" and "listen-only endpoint rejects dial", covering the two capability guards in `endpoint.nim`. The accept test asserts the message, because another check in `accept` raises `TransportError` as well.

`test_connection.nim`
- New `streamTimeout = 5.seconds`, applied to the 4 stream roundtrips.

`test_timeout.nim`
- Deadlines moved to `earlyDeadline` and `lateDeadline` consts, `fireTimeout` lowered from 2s to 1s. The wait is now shorter than the later deadline, so a test fails if the timer fires on the wrong one. At 2s both tests passed either way.

`test_runtime.nim`
- "socket receive buffer can be disabled" renamed to "zero receive buffer keeps the OS default" and now compares `SO_RCVBUF` against an unconfigured chronos transport. It previously asserted `> 0`, the same assertion as the default buffer test.

`test_destaddr.nim`, `test_routing.nim`
- Added the `checkTrackers()` teardown the other suites already have.