### PR TITLE
test: datagram routing, dropped initial retransmission, close vs abort

### DIFF
--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -477,4 +477,4 @@ when defined(lsquic_testing):
     ## Test-only: number of connections tracked by this endpoint's manager.
     endpoint.connman.len
 
-  export scidLen, packetDcid, isIetfInitial
+  export scidLen, packetDcid, isIetfInitial, routeDatagram, RouteTarget

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -74,6 +74,53 @@ proc runConnectionTest(
 proc runConnectionTest(address: TransportAddress) {.async.} =
   await runConnectionTest(address, address)
 
+proc runLostInitialDialTest(address: TransportAddress) {.async.} =
+  let server = makeServer()
+  let listener = server.listen(address)
+  let serverAddress = listener.localAddress()
+
+  var
+    clientAddress: TransportAddress
+    dropped = 0
+    proxyError: string
+
+  # Drops the client's first datagram: the Initial that opens the handshake.
+  proc onReceive(
+      proxy: DatagramTransport, remote: TransportAddress
+  ) {.async: (raises: []).} =
+    try:
+      let msg = proxy.getMessage()
+      if remote != serverAddress:
+        clientAddress = remote
+        if dropped == 0:
+          dropped.inc
+          return
+        await proxy.sendTo(serverAddress, msg)
+      else:
+        await proxy.sendTo(clientAddress, msg)
+    except CatchableError as exc:
+      proxyError = exc.msg
+
+  let proxy = newDatagramTransport(onReceive, local = address)
+  let client = makeClient()
+  defer:
+    await allFutures(client.stop(), listener.stop())
+    await proxy.closeWait()
+
+  let accepting = listener.accept()
+
+  # The handshake gets through only if the engine retransmits the dropped Initial.
+  let outgoingConn = await client.dial(proxy.localAddress()).wait(dialTimeout)
+  let incomingConn = await accepting.wait(dialTimeout)
+
+  check:
+    dropped == 1
+    proxyError.len == 0
+
+  outgoingConn.close()
+  incomingConn.close()
+  await allFutures(outgoingConn.closedFuture(), incomingConn.closedFuture())
+
 proc runEndpointAcceptTest(address: TransportAddress) {.async.} =
   let client = makeClient()
   let endpoint = makeEndpoint(address, {CanListen})
@@ -325,6 +372,9 @@ suite "connection":
 
   asyncTest "ipv6 dual-stack listener accepts ipv4 dial":
     await runConnectionTest(WildcardIP6, AutoAddressIP4)
+
+  asyncTest "dial completes when the initial packet is dropped":
+    await runLostInitialDialTest(AutoAddressIP4)
 
   asyncTest "multiple concurrent stream opens":
     await runConcurrentStreamOpenTest(AutoAddressIP4)

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -9,7 +9,9 @@ import ./helpers/[address, clientserver, futures, stream, trackers]
 
 initializeLsquic(true, true)
 
-const dialTimeout = 5.seconds
+const
+  dialTimeout = 5.seconds
+  streamTimeout = 5.seconds
 
 proc runConnectionTest(
     listenAddress: TransportAddress, dialAddress: TransportAddress
@@ -106,6 +108,22 @@ proc runEndpointSharedSocketDialTest(address: TransportAddress) {.async.} =
     outgoingConn.localAddress().port == boundAddress.port
     incomingConn.localAddress().port == boundAddress.port
     incomingConn.remoteAddress().port == boundAddress.port
+
+  # The handshake completes without the cid lookup that later packets need.
+  let outgoingBehaviour = proc() {.async.} =
+    let stream = await outgoingConn.openStream()
+
+    await stream.write(@[1'u8, 2, 3, 4, 5])
+    await stream.close()
+
+  let incomingBehaviour = proc() {.async.} =
+    let stream = await incomingConn.incomingStream()
+
+    check (await readStreamTillEOF(stream)) == @[1'u8, 2, 3, 4, 5]
+
+    await stream.close()
+
+  await allFuturesRaising(outgoingBehaviour(), incomingBehaviour()).wait(streamTimeout)
 
   outgoingConn.close()
   incomingConn.close()

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -56,6 +56,44 @@ suite "lifecycle":
     check (await peers.incoming.closedFuture().withTimeout(timeout))
     check peers.incoming.isClosed
 
+  asyncTest "connection close resets the peer's stream":
+    # TODO: vacp2p/nim-lsquic#136
+    let peers = await connectPeers()
+    defer:
+      await peers.stop()
+
+    let outgoingStream = await peers.outgoing.openStream()
+    await outgoingStream.write(@[1'u8])
+    let incomingStream = await peers.incoming.incomingStream()
+    var firstByte = newSeq[byte](1)
+    check (await incomingStream.readOnce(firstByte)) == 1
+
+    peers.outgoing.close()
+    check (await peers.incoming.closedFuture().withTimeout(timeout))
+
+    var buf = newSeq[byte](8)
+
+    expect StreamResetError:
+      discard await incomingStream.readOnce(buf).wait(timeout)
+
+  asyncTest "connection abort ends the peer's stream at eof":
+    # TODO: vacp2p/nim-lsquic#136
+    let peers = await connectPeers()
+    defer:
+      await peers.stop()
+
+    let outgoingStream = await peers.outgoing.openStream()
+    await outgoingStream.write(@[1'u8])
+    let incomingStream = await peers.incoming.incomingStream()
+    var firstByte = newSeq[byte](1)
+    check (await incomingStream.readOnce(firstByte)) == 1
+
+    peers.outgoing.abort()
+    check (await peers.incoming.closedFuture().withTimeout(timeout))
+
+    var buf = newSeq[byte](8)
+    check (await incomingStream.readOnce(buf).wait(timeout)) == 0
+
   asyncTest "accept skips closed connection and client redials":
     let server = makeServer()
     let listener = server.listen(AutoAddressIP4)
@@ -706,6 +744,8 @@ suite "lifecycle":
 
     stream.abort()
 
+    # Unlike close, abort takes the read side down too, so later reads end at eof.
+    check stream.isEof
     check stream.toRead.isNone()
     check stream.toWrite.isNone()
     check readFut.finished

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -1,13 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## Tests for CID ownership, datagram header parsing and `routeDatagram`, which
-## uses both to pick the context a datagram belongs to.
-##
-## These are internal; `-d:lsquic_testing` (set in tests/nim.cfg) publishes them,
-## so they are asserted directly instead of through a handshake that would only
-## fail as a timeout.
-
 {.used.}
 
 import chronos, chronos/unittest2/asynctests

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -1,18 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## Tests for CID ownership and datagram header parsing - the inputs
-## `receiveDatagram` uses to pick the context a datagram belongs to.
+## Tests for CID ownership, datagram header parsing and `routeDatagram`, which
+## uses both to pick the context a datagram belongs to.
 ##
-## `packetDcid` and `isIetfInitial` are internal; `-d:lsquic_testing`
-## (set in tests/nim.cfg) publishes them, so they are asserted directly instead
-## of through a handshake that would only fail as a timeout.
+## These are internal; `-d:lsquic_testing` (set in tests/nim.cfg) publishes them,
+## so they are asserted directly instead of through a handshake that would only
+## fail as a timeout.
 
 {.used.}
 
 import chronos, chronos/unittest2/asynctests
+import lsquic
 import lsquic/[endpoint, lsquic_ffi]
 import lsquic/context/context
+import ./helpers/[address, clientserver, trackers]
+
+initializeLsquic(true, true)
+
+const dialTimeout = 5.seconds
 
 func makeCid(bytes: openArray[byte]): CidKey =
   var cid = CidKey(len: bytes.len.uint8)
@@ -211,3 +217,51 @@ suite "datagram header parsing":
       not isIetfInitial(longHeaderPacket(ClientCid, firstByte = InitialWithoutFixedBit))
       not isIetfInitial(shortHeaderPacket(ClientCid))
       not isIetfInitial(newSeq[byte]())
+
+suite "datagram routing":
+  teardown:
+    checkTrackers()
+
+  asyncTest "the only engine on a socket takes every datagram":
+    let listenOnly = makeEndpoint(AutoAddressIP4, {CanListen})
+    let dialOnly = makeDialEndpoint(AddressFamily.IPv4)
+    defer:
+      await allFutures(listenOnly.stop(), dialOnly.stop())
+
+    # a dial-only endpoint has no client context until it dials
+    let accepting = listenOnly.accept()
+    let outgoing = await dialOnly.dial(listenOnly.localAddress()).wait(dialTimeout)
+    let incoming = await accepting.wait(dialTimeout)
+
+    let address = listenOnly.localAddress()
+    check:
+      # one engine on the socket, so the cid is never read
+      listenOnly.routeDatagram(shortHeaderPacket(UnknownCid), address, address) ==
+        {rtServer}
+      dialOnly.routeDatagram(shortHeaderPacket(UnknownCid), address, address) ==
+        {rtClient}
+
+    outgoing.close()
+    incoming.close()
+    await allFutures(outgoing.closedFuture(), incoming.closedFuture())
+
+  asyncTest "an unknown cid reaches the server context only in an initial packet":
+    # a self-dial puts both engines on one socket, so the cid decides
+    let endpoint = makeEndpoint(AutoAddressIP4)
+    defer:
+      await endpoint.stop()
+
+    let accepting = endpoint.accept()
+    let outgoing = await endpoint.dial(endpoint.localAddress()).wait(dialTimeout)
+    let incoming = await accepting.wait(dialTimeout)
+
+    let address = endpoint.localAddress()
+    check:
+      # an unknown cid is worth handing over only when it can open a connection
+      endpoint.routeDatagram(longHeaderPacket(UnknownCid), address, address) ==
+        {rtServer}
+      endpoint.routeDatagram(shortHeaderPacket(UnknownCid), address, address) == {}
+
+    outgoing.close()
+    incoming.close()
+    await allFutures(outgoing.closedFuture(), incoming.closedFuture())

--- a/tests/test_routing.nim
+++ b/tests/test_routing.nim
@@ -226,12 +226,15 @@ suite "datagram routing":
     let outgoing = await dialOnly.dial(listenOnly.localAddress()).wait(dialTimeout)
     let incoming = await accepting.wait(dialTimeout)
 
-    let address = listenOnly.localAddress()
+    let
+      listenAddress = listenOnly.localAddress()
+      dialAddress = dialOnly.localAddress()
     check:
       # one engine on the socket, so the cid is never read
-      listenOnly.routeDatagram(shortHeaderPacket(UnknownCid), address, address) ==
-        {rtServer}
-      dialOnly.routeDatagram(shortHeaderPacket(UnknownCid), address, address) ==
+      listenOnly.routeDatagram(
+        shortHeaderPacket(UnknownCid), listenAddress, dialAddress
+      ) == {rtServer}
+      dialOnly.routeDatagram(shortHeaderPacket(UnknownCid), dialAddress, listenAddress) ==
         {rtClient}
 
     outgoing.close()

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -9,6 +9,8 @@ import ./helpers/[address, certificate, clientserver, trackers]
 
 initializeLsquic(true, true)
 
+const dialTimeout = 5.seconds
+
 type RejectVerifierRecorder = ref object
   rejectCount: int
   fired: AsyncEvent
@@ -242,7 +244,7 @@ suite "certificate verifier":
       await allFutures(client.stop(), listener.stop())
 
     expect DialError:
-      discard await client.dial(listener.localAddress())
+      discard await client.dial(listener.localAddress()).wait(dialTimeout)
 
   asyncTest "server-side verifier callback does not fail handshake without client auth":
     let recorder = RejectVerifierRecorder(fired: newAsyncEvent())


### PR DESCRIPTION
- **`test_routing`** - New `datagram routing` suite. The single context fast path returns the right target, and an unknown cid reaches the server context only in a long header packet.
- **`test_connection`** - `dial completes when the initial packet is dropped`. A UDP proxy forwards both directions and drops the client's first datagram, so the dial succeeds only if the engine retransmits. Also adds a stream roundtrip to `runEndpointSharedSocketDialTest`, which stopped at the handshake and so never routed a datagram by the server context's cid.
- **`test_lifecycle`** - `connection close resets the peer's stream` and `connection abort ends the peer's stream at eof`, both pinning current behaviour for #136. Plus `check stream.isEof` on the existing abort unit test.
- **`test_verifier`** - Bounds the ALPN mismatch dial with `dialTimeout` so a regression fails instead of hanging.
- **`endpoint`** - Exports `routeDatagram` and `RouteTarget` under `-d:lsquic_testing`.