### PR TITLE
test: empty serverName and eof after a vanished peer

### DIFF
--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -390,6 +390,37 @@ suite "lifecycle":
 
     check isReset
 
+  asyncTest "vanished peer ends the stream at eof without a fin":
+    # TODO: vacp2p/nim-lsquic#140
+    # Skipped: reaching the case costs the 30s fixed lsquic idle timeout
+    skip()
+    return
+
+    # The peer's socket disappears mid-stream, so it never sends a FIN, yet the
+    # reader is handed the same end of stream a FIN produces.
+    let server = makeEndpoint(AutoAddressIP4)
+    let client = makeDialEndpoint(AddressFamily.IPv4)
+    defer:
+      await allFutures(client.stop(), server.stop())
+
+    let accepting = server.accept()
+    let outgoing = await client.dial(server.localAddress())
+    let incoming = await accepting
+
+    let serverStream = await incoming.openStream()
+    await serverStream.write(@[1'u8])
+
+    let clientStream = await outgoing.incomingStream()
+    var firstByte = newSeq[byte](1)
+    check (await clientStream.readOnce(firstByte)) == 1
+
+    await server.datagramTransport().closeWait()
+
+    var buf = newSeq[byte](8)
+    check (await clientStream.readOnce(buf).wait(45.seconds)) == 0
+    check clientStream.isEof
+    check not clientStream.resetByPeer
+
   asyncTest "zero length reads return zero":
     let stream = Stream.new()
     defer:

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -17,6 +17,11 @@ type VerifierRecorder = ref object
   count: int
   fired: AsyncEvent
 
+type ServerNameRecorder = ref object
+  serverName: string
+  count: int
+  fired: AsyncEvent
+
 proc acceptingCertificateCb(
     serverName: string, derCertificates: seq[seq[byte]]
 ): bool {.gcsafe.} =
@@ -55,6 +60,13 @@ proc makeCertificateCb(
       derCertificates.len > 0
     else:
       false
+
+proc makeRecordingCertificateCb(recorder: ServerNameRecorder): certificateVerifierCB =
+  return proc(serverName: string, _: seq[seq[byte]]): bool {.gcsafe.} =
+    recorder.serverName = serverName
+    inc recorder.count
+    recorder.fired.fire()
+    true
 
 proc makeClientWithoutVerifier(): QuicClient {.raises: [QuicConfigError].} =
   QuicClient.new(
@@ -103,6 +115,34 @@ suite "certificate verifier":
     check:
       outgoing.certificates().len == 1
       incoming.certificates().len == 1
+
+    outgoing.close()
+    incoming.close()
+
+  asyncTest "verifier receives an empty server name":
+    # TODO: vacp2p/nim-lsquic#138
+    let clientRecorder = ServerNameRecorder(fired: newAsyncEvent())
+    let serverRecorder = ServerNameRecorder(fired: newAsyncEvent())
+    let client = makeClient(
+      CustomCertificateVerifier.init(clientRecorder.makeRecordingCertificateCb())
+    )
+    let server = makeServer(
+      CustomCertificateVerifier.init(serverRecorder.makeRecordingCertificateCb())
+    )
+    let listener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), listener.stop())
+
+    let accepting = listener.accept()
+    let outgoing = await client.dial(listener.localAddress())
+    let incoming = await accepting
+    check (await serverRecorder.fired.wait().withTimeout(2.seconds))
+
+    check:
+      clientRecorder.count == 1
+      clientRecorder.serverName == ""
+      serverRecorder.count == 1
+      serverRecorder.serverName == ""
 
     outgoing.close()
     incoming.close()


### PR DESCRIPTION
Two tests, one per open issue.

`tests/test_verifier.nim` "verifier receives an empty server name" pins that both the client side and server side verifier callbacks get `serverName == ""`, since the client sends no SNI. vacp2p/nim-lsquic#138.

`tests/test_lifecycle.nim` "vanished peer ends the stream at eof without a fin" pins that when the peer's socket disappears mid-stream the reader gets the same eof a FIN produces, with `isEof` set and `resetByPeer` clear. vacp2p/nim-lsquic#140. It calls `skip()` because reaching the case costs the 30s fixed lsquic idle timeout.
