### PR TITLE
fix(connection): preserve queued streams after peer close

### DIFF
--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -1,5 +1,5 @@
 packageName = "lsquic"
-version = "0.8.0"
+version = "0.8.1"
 author = "Status Research & Development GmbH"
 description = "Nim wrapper around the lsquic library"
 license = "MIT"

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -108,21 +108,31 @@ proc dial*(
 proc incomingStream*(
     connection: Connection
 ): Future[Stream] {.async: (raises: [CancelledError, ConnectionError]).} =
-  let hasQueuedStream = connection.quicConn.incoming.len > 0
-  if connection.isClosed and not hasQueuedStream:
+  if connection.quicConn.closedLocal:
     raise newException(ConnectionClosedError, "connection closed")
 
-  let incomingFut = connection.quicConn.incomingStream()
-  let raceFut =
-    if hasQueuedStream:
-      incomingFut
-    else:
-      await race(connection.closedWaiter, incomingFut)
-  if raceFut == connection.closedWaiter:
-    await incomingFut.cancelAndWait()
-    raise newException(ConnectionClosedError, "connection closed")
+  var stream: Stream
+  try:
+    stream = connection.quicConn.incoming.getNoWait()
+  except AsyncQueueEmptyError:
+    if connection.isClosed:
+      raise newException(ConnectionClosedError, "connection closed")
 
-  let stream = await incomingFut
+    let incomingFut = connection.quicConn.incomingStream()
+    try:
+      let raceFut = await race(incomingFut, connection.closedWaiter)
+      if raceFut == connection.closedWaiter and not incomingFut.finished:
+        await incomingFut.cancelAndWait()
+        try:
+          stream = connection.quicConn.incoming.getNoWait()
+        except AsyncQueueEmptyError:
+          raise newException(ConnectionClosedError, "connection closed")
+      else:
+        stream = await incomingFut
+    except CancelledError:
+      if not incomingFut.finished:
+        await incomingFut.cancelAndWait()
+      raise
   stream.doProcess = proc(urgent: bool) {.gcsafe, raises: [].} =
     if urgent:
       connection.quicContext.processWhenReady()

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -77,10 +77,14 @@ proc newIncomingConnection*(
     closedWaiter: closedWaiter,
     local: quicConn.local,
     remote: quicConn.remote,
+    isClosed: quicConn.lsquicConn.isNil,
   )
   conn.ensureClosedFut = conn.ensureClosed()
-  conn.quicConn.onClose = proc() {.raises: [].} =
+  if conn.isClosed:
     conn.closed.fire()
+  else:
+    conn.quicConn.onClose = proc() {.raises: [].} =
+      conn.closed.fire()
   conn
 
 proc closedFuture*(connection: Connection): Future[void] {.raises: [].} =
@@ -104,11 +108,16 @@ proc dial*(
 proc incomingStream*(
     connection: Connection
 ): Future[Stream] {.async: (raises: [CancelledError, ConnectionError]).} =
-  if connection.isClosed:
+  let hasQueuedStream = connection.quicConn.incoming.len > 0
+  if connection.isClosed and not hasQueuedStream:
     raise newException(ConnectionClosedError, "connection closed")
 
   let incomingFut = connection.quicConn.incomingStream()
-  let raceFut = await race(connection.closedWaiter, incomingFut)
+  let raceFut =
+    if hasQueuedStream:
+      incomingFut
+    else:
+      await race(connection.closedWaiter, incomingFut)
   if raceFut == connection.closedWaiter:
     await incomingFut.cancelAndWait()
     raise newException(ConnectionClosedError, "connection closed")

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -129,10 +129,10 @@ proc incomingStream*(
           raise newException(ConnectionClosedError, "connection closed")
       else:
         stream = await incomingFut
-    except CancelledError:
+    except CancelledError as exc:
       if not incomingFut.finished:
         await incomingFut.cancelAndWait()
-      raise
+      raise exc
   stream.doProcess = proc(urgent: bool) {.gcsafe, raises: [].} =
     if urgent:
       connection.quicContext.processWhenReady()

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -105,34 +105,48 @@ proc dial*(
     nil
   retFut
 
+proc takeQueuedStream(connection: Connection): Opt[Stream] {.raises: [].} =
+  try:
+    Opt.some(connection.quicConn.incoming.getNoWait())
+  except AsyncQueueEmptyError:
+    Opt.none(Stream)
+
+proc waitForIncomingStream(
+    connection: Connection
+): Future[Stream] {.async: (raises: [CancelledError, ConnectionError]).} =
+  let incomingFut = connection.quicConn.incomingStream()
+
+  try:
+    discard await race(incomingFut, connection.closedWaiter)
+    if incomingFut.finished:
+      return await incomingFut
+
+    await incomingFut.cancelAndWait()
+  except CancelledError as exc:
+    if not incomingFut.finished:
+      await incomingFut.cancelAndWait()
+    raise exc
+
+  let queued = connection.takeQueuedStream()
+  if queued.isSome:
+    return queued.get()
+
+  raise newException(ConnectionClosedError, "connection closed")
+
 proc incomingStream*(
     connection: Connection
 ): Future[Stream] {.async: (raises: [CancelledError, ConnectionError]).} =
   if connection.quicConn.closedLocal:
     raise newException(ConnectionClosedError, "connection closed")
 
-  var stream: Stream
-  try:
-    stream = connection.quicConn.incoming.getNoWait()
-  except AsyncQueueEmptyError:
-    if connection.isClosed:
+  let queued = connection.takeQueuedStream()
+  let stream =
+    if queued.isSome:
+      queued.get()
+    elif connection.isClosed:
       raise newException(ConnectionClosedError, "connection closed")
-
-    let incomingFut = connection.quicConn.incomingStream()
-    try:
-      let raceFut = await race(incomingFut, connection.closedWaiter)
-      if raceFut == connection.closedWaiter and not incomingFut.finished:
-        await incomingFut.cancelAndWait()
-        try:
-          stream = connection.quicConn.incoming.getNoWait()
-        except AsyncQueueEmptyError:
-          raise newException(ConnectionClosedError, "connection closed")
-      else:
-        stream = await incomingFut
-    except CancelledError as exc:
-      if not incomingFut.finished:
-        await incomingFut.cancelAndWait()
-      raise exc
+    else:
+      await connection.waitForIncomingStream()
   stream.doProcess = proc(urgent: bool) {.gcsafe, raises: [].} =
     if urgent:
       connection.quicContext.processWhenReady()

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -390,7 +390,7 @@ proc accept*(
       raise newException(TransportError, "endpoint is stopped")
 
     let quicConn = await incomingFut
-    if quicConn.lsquicConn.isNil:
+    if quicConn.lsquicConn.isNil and quicConn.incoming.len == 0:
       debug "Dropping already closed incoming connection"
       continue
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -148,9 +148,28 @@ suite "lifecycle":
 
     check (await accepted.withTimeout(timeout))
     let incoming = await accepted
-    let incomingStream = await incoming.incomingStream()
+    check (await incoming.closedFuture().withTimeout(timeout))
+    let incomingStream = incoming.incomingStream()
+    expect ConnectionClosedError:
+      discard await incoming.incomingStream().wait(timeout)
+
+    let stream = await incomingStream
     var buf = newSeq[byte](1)
-    check (await incomingStream.readOnce(buf)) == 0
+    check (await stream.readOnce(buf)) == 0
+
+  asyncTest "pending incoming stream survives immediate client close":
+    let peers = await connectPeers()
+    defer:
+      await peers.stop()
+
+    let incomingStream = peers.incoming.incomingStream()
+    let outgoingStream = await peers.outgoing.openStream()
+    await outgoingStream.close()
+    peers.outgoing.close()
+
+    let stream = await incomingStream.wait(timeout)
+    var buf = newSeq[byte](1)
+    check (await stream.readOnce(buf)) == 0
 
   asyncTest "client stop closes active connections":
     let peers = await connectPeers()

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -131,6 +131,27 @@ suite "lifecycle":
     outgoing.close()
     incoming.close()
 
+  asyncTest "pending accept observes connection before immediate client close":
+    let server = makeServer()
+    let listener = server.listen(AutoAddressIP4)
+    let client = makeClient()
+    let accepted = listener.accept()
+    defer:
+      if not accepted.finished:
+        await accepted.cancelAndWait()
+      await allFutures(client.stop(), listener.stop())
+
+    let outgoing = await client.dial(listener.localAddress())
+    let outgoingStream = await outgoing.openStream()
+    await outgoingStream.close()
+    outgoing.close()
+
+    check (await accepted.withTimeout(timeout))
+    let incoming = await accepted
+    let incomingStream = await incoming.incomingStream()
+    var buf = newSeq[byte](1)
+    check (await incomingStream.readOnce(buf)) == 0
+
   asyncTest "client stop closes active connections":
     let peers = await connectPeers()
 


### PR DESCRIPTION
## Summary

- preserve incoming connections that already contain queued peer streams when the peer closes before `accept` resumes
- allow queued streams to be consumed through EOF while later stream requests still fail on the closed connection
- continue skipping closed incoming connections that contain no streams
- bump the package patch version to 0.8.1

## Affected Areas

- [x] Transports — incoming QUIC connection and stream lifecycle
- [x] Build / Tooling — package version metadata

## Impact on Library Users

Consumers can observe already-received streams and their EOF instead of losing them when connection establishment, stream FIN, and peer close are processed in one engine pass. There are no API changes.

## Risk Assessment

Closed connections without queued streams retain the existing skip behavior. Receive batching is unchanged.

## References

- [nim-libp2p integration PR #2925](https://github.com/vacp2p/nim-libp2p/pull/2925)
- [Original macOS failure](https://github.com/vacp2p/nim-libp2p/actions/runs/31420234492/job/93558998791)
