### PR TITLE
fix(tlsconfig): validate ALPN protocol lengths

### DIFF
--- a/lsquic/tlsconfig.nim
+++ b/lsquic/tlsconfig.nim
@@ -30,6 +30,12 @@ proc new*(
 
   var alpnWire = newString(0)
   for a in alpn:
+    if a.len == 0 or a.len > 255:
+      raise newException(
+        QuicConfigError, "ALPN protocol names must contain 1 to 255 bytes"
+      )
+    if alpnWire.len > high(uint16).int - (a.len + 1):
+      raise newException(QuicConfigError, "ALPN protocol list is too long")
     alpnWire.add chr(a.len)
     alpnWire.add a
 

--- a/lsquic/tlsconfig.nim
+++ b/lsquic/tlsconfig.nim
@@ -31,9 +31,8 @@ proc new*(
   var alpnWire = newString(0)
   for a in alpn:
     if a.len == 0 or a.len > 255:
-      raise newException(
-        QuicConfigError, "ALPN protocol names must contain 1 to 255 bytes"
-      )
+      raise
+        newException(QuicConfigError, "ALPN protocol names must contain 1 to 255 bytes")
     if alpnWire.len > high(uint16).int - (a.len + 1):
       raise newException(QuicConfigError, "ALPN protocol list is too long")
     alpnWire.add chr(a.len)

--- a/lsquic/tlsconfig.nim
+++ b/lsquic/tlsconfig.nim
@@ -33,10 +33,11 @@ proc new*(
     if a.len == 0 or a.len > 255:
       raise
         newException(QuicConfigError, "ALPN protocol names must contain 1 to 255 bytes")
-    if alpnWire.len > high(uint16).int - (a.len + 1):
-      raise newException(QuicConfigError, "ALPN protocol list is too long")
     alpnWire.add chr(a.len)
     alpnWire.add a
+
+  if alpnWire.len > high(uint16).int:
+    raise newException(QuicConfigError, "ALPN protocol list is too long")
 
   TLSConfig(
     alpnWire: alpnWire, certVerifier: certVerifier, certificate: certificate, key: key

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -82,22 +82,23 @@ suite "tls config":
       cfg.alpnWire.decodeAlpnWire() == makeAlpnSet(protocol)
 
   test "alpn value over 255 bytes is not encodable":
-    # TODO: vacp2p/nim-lsquic#113
-    # TLSConfig.new does not validate the protocol length, so chr(len) trips the range check
-    # and a RangeDefect escapes an API that reports every other misconfiguration as a QuicConfigError.
     let alpn = makeAlpnSet(repeat('a', 256))
 
-    expect RangeDefect:
+    expect QuicConfigError:
       discard TLSConfig.new(testCertificate(), testPrivateKey(), alpn)
 
-  test "empty alpn value encodes to a zero length entry":
-    # TODO: vacp2p/nim-lsquic#113
-    # RFC 7301 forbids an empty protocol name, but TLSConfig.new emits one and
-    # reports nothing. BoringSSL rejects the buffer later, at dial time, where it
-    # surfaces as AssertionDefect instead of a QuicConfigError.
-    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpnSet(""))
+  test "empty alpn value is not encodable":
+    expect QuicConfigError:
+      discard TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpnSet(""))
 
-    check cfg.alpnWire == "\x00"
+  test "alpn protocol list cannot exceed 65535 bytes":
+    var alpn = initHashSet[string]()
+    for i in 0 .. 256:
+      let prefix = $i
+      alpn.incl(prefix & repeat('a', 255 - prefix.len))
+
+    expect QuicConfigError:
+      discard TLSConfig.new(testCertificate(), testPrivateKey(), alpn)
 
   test "valid pem certificate parses":
     let parsed = testCertificate().toX509()


### PR DESCRIPTION
## Summary

- Reject empty ALPN protocol names and names longer than 255 bytes.
- Reject encoded ALPN lists larger than the RFC 7301 16-bit vector limit.
- Report invalid input as `QuicConfigError` instead of allowing a range defect or later TLS setup failure.

## Impact on Library Users

Invalid ALPN configurations now fail immediately during `TLSConfig` construction. Valid configurations and an entirely empty ALPN set are unchanged.

## References

Closes #113.
