### PR TITLE
docs(connection): clarify shutdown semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ The snippet expects `cert.pem` and `key.pem` in PEM format and embeds them at co
 - `cleanupLsquic()` is idempotent and can be safely called during shutdown.
 - Server-side `TLSConfig` must include both a certificate and a private key.
 - Client and server ALPN values must match or the handshake will fail.
-- `Connection.close()` and `Stream.close()` perform a graceful shutdown. `abort()` is the hard-stop path.
+- `Stream.close()` gracefully shuts down its write side. `Connection.close()`
+  resets open bidirectional streams before closing the connection, while
+  `Connection.abort()` skips those per-stream resets. Neither connection method
+  drains open streams; close them first when graceful delivery is required.
 - UDP sockets request an 8 MiB receive buffer by default. Pass `QuicSocketConfig(receiveBufferBytes: 0)` to keep the OS default, or set another byte value; Linux may cap the effective size at `net.core.rmem_max`.
 
 For more complete usage patterns, see:


### PR DESCRIPTION
## Summary

Clarify the shutdown behavior exposed by the current lsquic-backed API:

- `Stream.close()` gracefully shuts down the write side.
- `Connection.close()` resets open bidirectional streams before closing.
- `Connection.abort()` skips those per-stream resets.

Neither connection operation drains open streams, so callers that require graceful delivery must close their streams first.

## Impact on Library Users

This is a documentation correction only; runtime behavior is unchanged.

## References

Closes #136.
