### PR TITLE
feat(client): pass server name when dialing

### DIFF
--- a/lsquic/certificateverifier/certificateverifier.nim
+++ b/lsquic/certificateverifier/certificateverifier.nim
@@ -3,6 +3,8 @@
 
 type CertificateVerifier* = ref object of RootObj
 
+## `serverName` is the expected server identity on clients and the requested
+## SNI value on servers; it is not the client's certificate identity.
 method verify*(
     self: CertificateVerifier, serverName: string, derCertificates: seq[seq[byte]]
 ): bool {.base.} =

--- a/lsquic/certificateverifier/certificateverifier.nim
+++ b/lsquic/certificateverifier/certificateverifier.nim
@@ -3,8 +3,6 @@
 
 type CertificateVerifier* = ref object of RootObj
 
-## `serverName` is the expected server identity on clients and the requested
-## SNI value on servers; it is not the client's certificate identity.
 method verify*(
     self: CertificateVerifier, serverName: string, derCertificates: seq[seq[byte]]
 ): bool {.base.} =

--- a/lsquic/client.nim
+++ b/lsquic/client.nim
@@ -48,6 +48,23 @@ proc dial*(
 .} =
   await self.getEndpoint(address.family).dial(address, certVerifier)
 
+proc dial*(
+    self: QuicClient, address: TransportAddress, serverName: string
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  await self.getEndpoint(address.family).dial(address, serverName)
+
+proc dial*(
+    self: QuicClient,
+    address: TransportAddress,
+    serverName: string,
+    certVerifier: CertificateVerifier,
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  await self.getEndpoint(address.family).dial(address, serverName, certVerifier)
+
 proc stop*(self: QuicClient) {.async: (raises: [CancelledError]).} =
   var stops: seq[Future[void]]
   if not self.ip4Endpoint.isNil:

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -21,6 +21,7 @@ type
   IncomingConnection = ref object of Connection
 
   OutgoingConnection = ref object of Connection
+    serverName: string
     certVerifier: Opt[CertificateVerifier]
 
 proc ensureClosed(connection: Connection) {.async: (raises: [CancelledError]).} =
@@ -50,6 +51,7 @@ proc newOutgoingConnection*(
     quicContext: QuicContext,
     local: TransportAddress,
     remote: TransportAddress,
+    serverName: string = "",
     certVerifier: Opt[CertificateVerifier] = Opt.none(CertificateVerifier),
 ): OutgoingConnection =
   let closed = newAsyncEvent()
@@ -59,6 +61,7 @@ proc newOutgoingConnection*(
     local: local,
     remote: remote,
     closed: closed,
+    serverName: serverName,
     certVerifier: certVerifier,
     closedWaiter: closedWaiter,
   )
@@ -99,7 +102,12 @@ proc dial*(
     connection.closed.fire()
 
   connection.quicConn = connection.quicContext.dial(
-    connection.local, connection.remote, retFut, onClose, connection.certVerifier
+    connection.local,
+    connection.remote,
+    retFut,
+    onClose,
+    connection.serverName,
+    connection.certVerifier,
   ).valueOr:
     retFut.fail(newException(DialError, "could not dial: " & error))
     nil

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -102,11 +102,7 @@ proc dial*(
     connection.closed.fire()
 
   connection.quicConn = connection.quicContext.dial(
-    connection.local,
-    connection.remote,
-    retFut,
-    onClose,
-    connection.serverName,
+    connection.local, connection.remote, retFut, onClose, connection.serverName,
     connection.certVerifier,
   ).valueOr:
     retFut.fail(newException(DialError, "could not dial: " & error))

--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -76,6 +76,7 @@ method dial*(
     remote: TransportAddress,
     connectedFut: Future[void],
     onClose: proc() {.gcsafe, raises: [].},
+    serverName: string,
     certVerifier: Opt[CertificateVerifier],
 ): Result[QuicConnection, string] {.raises: [], gcsafe.} =
   var
@@ -105,7 +106,7 @@ method dial*(
     cast[ptr SockAddr](addr remoteAddress),
     cast[pointer](ctx),
     cast[ptr lsquic_conn_ctx_t](quicClientConn),
-    nil,
+    if serverName.len == 0: nil else: serverName.cstring,
     0,
     nil,
     0,

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -397,6 +397,7 @@ method dial*(
     remote: TransportAddress,
     connectedFut: Future[void],
     onClose: proc() {.gcsafe, raises: [].},
+    serverName: string,
     certVerifier: Opt[CertificateVerifier],
 ): Result[QuicConnection, string] {.base, gcsafe, raises: [].} =
   raiseAssert "dial not implemented"

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -401,13 +401,15 @@ proc accept*(
 proc dial(
     endpoint: QuicEndpoint,
     address: TransportAddress,
+    serverName: string,
     certVerifier: Opt[CertificateVerifier],
 ): Future[Connection] {.
     async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
 .} =
   let ctx = endpoint.ensureClientContext()
-  let connection =
-    newOutgoingConnection(ctx, endpoint.udp.localAddress(), address, certVerifier)
+  let connection = newOutgoingConnection(
+    ctx, endpoint.udp.localAddress(), address, serverName, certVerifier
+  )
   endpoint.connman.addConnection(connection)
   var connected = false
   try:
@@ -419,6 +421,13 @@ proc dial(
 
   connection
 
+proc validateServerName(serverName: string) {.raises: [QuicError].} =
+  if serverName.len == 0:
+    raise newException(QuicError, "server name is empty")
+  for c in serverName:
+    if c == '\0':
+      raise newException(QuicError, "server name contains a null byte")
+
 proc dial*(
     endpoint: QuicEndpoint, address: TransportAddress
 ): Future[Connection] {.
@@ -429,7 +438,21 @@ proc dial*(
       QuicError, "certificate verifier is required; use dial(address, certVerifier)"
     )
 
-  await endpoint.dial(address, Opt.none(CertificateVerifier))
+  await endpoint.dial(address, "", Opt.none(CertificateVerifier))
+
+proc dial*(
+    endpoint: QuicEndpoint, address: TransportAddress, serverName: string
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  validateServerName(serverName)
+
+  if endpoint.tlsConfig.certVerifier.isNone:
+    raise newException(
+      QuicError, "certificate verifier is required; use dial(address, serverName, certVerifier)"
+    )
+
+  await endpoint.dial(address, serverName, Opt.none(CertificateVerifier))
 
 proc dial*(
     endpoint: QuicEndpoint, address: TransportAddress, certVerifier: CertificateVerifier
@@ -439,7 +462,21 @@ proc dial*(
   if certVerifier.isNil:
     raise newException(QuicError, "certificate verifier is nil")
 
-  await endpoint.dial(address, Opt.some(certVerifier))
+  await endpoint.dial(address, "", Opt.some(certVerifier))
+
+proc dial*(
+    endpoint: QuicEndpoint,
+    address: TransportAddress,
+    serverName: string,
+    certVerifier: CertificateVerifier,
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  validateServerName(serverName)
+  if certVerifier.isNil:
+    raise newException(QuicError, "certificate verifier is nil")
+
+  await endpoint.dial(address, serverName, Opt.some(certVerifier))
 
 proc localAddress*(
     endpoint: QuicEndpoint

--- a/lsquic/endpoint.nim
+++ b/lsquic/endpoint.nim
@@ -449,7 +449,8 @@ proc dial*(
 
   if endpoint.tlsConfig.certVerifier.isNone:
     raise newException(
-      QuicError, "certificate verifier is required; use dial(address, serverName, certVerifier)"
+      QuicError,
+      "certificate verifier is required; use dial(address, serverName, certVerifier)",
     )
 
   await endpoint.dial(address, serverName, Opt.none(CertificateVerifier))

--- a/lsquic/server.nim
+++ b/lsquic/server.nim
@@ -71,6 +71,26 @@ proc dial*(
 
   await listener.endpoint.dial(address, certVerifier)
 
+proc dial*(
+    listener: Listener, address: TransportAddress, serverName: string
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  await listener.endpoint.dial(address, serverName)
+
+proc dial*(
+    listener: Listener,
+    address: TransportAddress,
+    serverName: string,
+    certVerifier: CertificateVerifier,
+): Future[Connection] {.
+    async: (raises: [CancelledError, QuicError, DialError, TransportOsError])
+.} =
+  if certVerifier.isNil:
+    raise newException(QuicError, "certificate verifier is nil")
+
+  await listener.endpoint.dial(address, serverName, certVerifier)
+
 proc localAddress*(
     listener: Listener
 ): TransportAddress {.raises: [TransportOsError].} =

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -153,12 +153,10 @@ suite "certificate verifier":
   asyncTest "dial hostname is sent as SNI and reaches both verifiers":
     let clientRecorder = VerifierRecorder(fired: newAsyncEvent())
     let serverRecorder = VerifierRecorder(fired: newAsyncEvent())
-    let client = makeClient(
-      CustomCertificateVerifier.init(clientRecorder.makeCertificateCb(true))
-    )
-    let server = makeServer(
-      CustomCertificateVerifier.init(serverRecorder.makeCertificateCb(true))
-    )
+    let client =
+      makeClient(CustomCertificateVerifier.init(clientRecorder.makeCertificateCb(true)))
+    let server =
+      makeServer(CustomCertificateVerifier.init(serverRecorder.makeCertificateCb(true)))
     let listener = server.listen(AutoAddressIP4)
     defer:
       await allFutures(client.stop(), listener.stop())

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -18,6 +18,7 @@ type RejectVerifierRecorder = ref object
 type VerifierRecorder = ref object
   count: int
   fired: AsyncEvent
+  serverNames: seq[string]
 
 type ServerNameRecorder = ref object
   serverName: string
@@ -55,8 +56,9 @@ proc makeRejectingCertificateCb(
 proc makeCertificateCb(
     recorder: VerifierRecorder, accepted: bool
 ): certificateVerifierCB =
-  return proc(_: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
+  return proc(serverName: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =
     inc recorder.count
+    recorder.serverNames.add(serverName)
     recorder.fired.fire()
     if accepted:
       derCertificates.len > 0
@@ -121,8 +123,7 @@ suite "certificate verifier":
     outgoing.close()
     incoming.close()
 
-  asyncTest "verifier receives an empty server name":
-    # TODO: vacp2p/nim-lsquic#138
+  asyncTest "verifier receives an empty server name without explicit SNI":
     let clientRecorder = ServerNameRecorder(fired: newAsyncEvent())
     let serverRecorder = ServerNameRecorder(fired: newAsyncEvent())
     let client = makeClient(
@@ -148,6 +149,40 @@ suite "certificate verifier":
 
     outgoing.close()
     incoming.close()
+
+  asyncTest "dial hostname is sent as SNI and reaches both verifiers":
+    let clientRecorder = VerifierRecorder(fired: newAsyncEvent())
+    let serverRecorder = VerifierRecorder(fired: newAsyncEvent())
+    let client = makeClient(
+      CustomCertificateVerifier.init(clientRecorder.makeCertificateCb(true))
+    )
+    let server = makeServer(
+      CustomCertificateVerifier.init(serverRecorder.makeCertificateCb(true))
+    )
+    let listener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), listener.stop())
+
+    let accepting = listener.accept()
+    let outgoing = await client.dial(listener.localAddress(), "example.com")
+    let incoming = await accepting
+
+    check:
+      clientRecorder.serverNames == @["example.com"]
+      serverRecorder.serverNames == @["example.com"]
+
+    outgoing.close()
+    incoming.close()
+
+  asyncTest "explicit hostname rejects empty and embedded null values":
+    let client = makeClient()
+    defer:
+      await client.stop()
+
+    expect QuicError:
+      discard await client.dial(AutoAddressIP4, "")
+    expect QuicError:
+      discard await client.dial(AutoAddressIP4, "example.com\0invalid")
 
   asyncTest "rejecting client verifier rejects handshake":
     let client = makeClient(CustomCertificateVerifier.init(rejectingCertificateCb))


### PR DESCRIPTION
## Summary

- Add per-dial server-name overloads to clients, endpoints, and listeners.
- Pass the supplied name to lsquic so it is sent as SNI and reaches certificate verifiers.
- Reject empty explicit names and embedded NUL bytes before entering the native API.
- Document the role-dependent meaning of the verifier's `serverName` argument.

## Impact on Library Users

Callers can now perform hostname-aware certificate verification when dialing an address. Existing address-only overloads remain available and continue to provide an empty server name.

## Risk Assessment

The API change is additive. TLS handshake behavior changes only when callers opt into an explicit server name.

## References

Closes #138.
