### PR TITLE
docs(io): correct packetIn return contract

### DIFF
--- a/lsquic/context/io.nim
+++ b/lsquic/context/io.nim
@@ -102,8 +102,8 @@ proc packetIn*(
     remote: TransportAddress,
     ecn: cint = 0,
 ): bool {.discardable.} =
-  ## Returns false when the engine did not take the datagram, so that a caller
-  ## draining a burst knows whether it has to tick at all.
+  ## Returns false when the datagram was not handed to the engine because it is
+  ## empty or the context has stopped. The engine's return code is not exposed.
   if data.len == 0 or not ctx.isRunning():
     return false
 


### PR DESCRIPTION
## Summary

Correct the `packetIn` return-value documentation to match its implementation. The result reports whether a non-empty datagram was handed to a running engine; it does not expose lsquic's packet-processing return code.

## Impact on Library Users

This is a contract documentation correction only; packet routing and engine ticking behavior are unchanged.

## References

Closes #139.
