### PR TITLE
fix(stream): distinguish EOF from connection teardown

### DIFF
--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -236,7 +236,7 @@ proc cancelPending*(quicConn: QuicConnection) =
 
     pending.stream.closedByEngine = true
     pending.stream.closeWrite = true
-    pending.stream.isEof = true
+    pending.stream.markReadFailed("connection closed before stream opened")
     if not pending.stream.closed.isSet():
       pending.stream.closed.fire()
     unpin(pending.stream)

--- a/lsquic/context/stream.nim
+++ b/lsquic/context/stream.nim
@@ -44,9 +44,6 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
 
   streamCtx.abortPendingWrites("stream closed")
 
-  if not streamCtx.readResetByPeer():
-    streamCtx.isEof = true
-
   # Always signal closure so waiters are released, even if we already shut down
   # the write side locally.
   if not streamCtx.closed.isSet():
@@ -54,9 +51,11 @@ proc onClose*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl
 
   if streamCtx.readResetByPeer():
     streamCtx.failPendingRead(streamCtx.newStreamResetError("stream read"))
-  else:
-    # A clean close is end of stream: report 0 rather than failing.
+  elif streamCtx.isEof:
     streamCtx.completePendingRead()
+  else:
+    streamCtx.markReadFailed("stream closed before end of stream")
+    streamCtx.failPendingRead(newException(StreamError, streamCtx.readFailure))
 
   unpin(streamCtx)
 
@@ -74,7 +73,8 @@ proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.
       streamCtx.abort()
     return
 
-  let n = lsquic_stream_read(stream, task.data, task.dataLen.csize_t)
+  var receivedFin = false
+  let n = readFromStream(stream, task.data, task.dataLen, receivedFin)
 
   if n < 0:
     if errno == EWOULDBLOCK:
@@ -90,16 +90,16 @@ proc onRead*(stream: ptr lsquic_stream_t, ctx: ptr lsquic_stream_ctx_t) {.cdecl.
       streamCtx.abort()
       return
 
-  if n == 0:
+  if receivedFin:
     streamCtx.isEof = true
+  if n == 0 and streamCtx.isEof:
     if not streamCtx.closeIfDone():
       trace "could not close stream after EOF", streamId = lsquic_stream_id(stream)
       streamCtx.failPendingRead(newException(StreamError, "could not close the stream"))
       streamCtx.abort()
       return
 
-  # abort settles a pending read with 0, so report the bytes first or they are
-  # lost. The guard covers closeIfDone above having re-entered onClose.
+  # Report bytes before clearing the task. closeIfDone above may re-enter onClose.
   if not task.doneFut.finished:
     task.doneFut.complete(int(n))
 

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -20,6 +20,12 @@ type ReadTask* = object
   dataLen*: int
   doneFut*: Future[int].Raising([CancelledError, StreamError])
 
+type ReadContext = object
+  data: ptr byte
+  dataLen: int
+  offset: int
+  receivedFin: bool
+
 type Stream* = ref object
   quicStream*: ptr lsquic_stream_t
   canRead*: bool
@@ -35,6 +41,7 @@ type Stream* = ref object
   toWrite*: Opt[WriteTask]
   readLock*: AsyncLock
   isEof*: bool # Received a FIN from remote
+  readFailure*: string
   # Every path that sets closedByEngine or fires `closed` must settle these;
   # missing one hangs the parked operation instead of failing it.
   toRead*: Opt[ReadTask]
@@ -83,6 +90,30 @@ proc newStreamResetError*(
   )
   exc.how = stream.resetHow
   exc
+
+proc markReadFailed*(stream: Stream, reason: string) {.raises: [].} =
+  if stream.readFailure.len == 0:
+    stream.readFailure = reason
+
+proc readToBuffer(
+    ctx: pointer, data: ptr uint8, dataLen: csize_t, fin: cint
+): csize_t {.cdecl, raises: [].} =
+  let readCtx = cast[ptr ReadContext](ctx)
+  let count = min(dataLen.int, readCtx.dataLen - readCtx.offset)
+  if count > 0:
+    let dst = cast[ptr UncheckedArray[byte]](readCtx.data)
+    copyMem(addr dst[readCtx.offset], data, count)
+    readCtx.offset += count
+  if fin != 0 and count == dataLen.int:
+    readCtx.receivedFin = true
+  count.csize_t
+
+proc readFromStream*(
+    stream: ptr lsquic_stream_t, data: ptr byte, dataLen: int, receivedFin: var bool
+): ssize_t {.raises: [].} =
+  var readCtx = ReadContext(data: data, dataLen: dataLen)
+  result = lsquic_stream_readf(stream, readToBuffer, addr readCtx)
+  receivedFin = readCtx.receivedFin
 
 proc failPendingRead*(stream: Stream, error: ref StreamError) {.raises: [].} =
   let task = stream.toRead.valueOr:
@@ -147,6 +178,10 @@ template raiseIfReadReset(stream: Stream) =
   if stream.readResetByPeer():
     raise stream.newStreamResetError("stream read")
 
+template raiseIfReadFailed(stream: Stream) =
+  if stream.readFailure.len > 0:
+    raise newException(StreamError, stream.readFailure)
+
 template raiseIfWriteReset(stream: Stream) =
   if stream.writeResetByPeer():
     raise stream.newStreamResetError("stream write")
@@ -183,9 +218,9 @@ proc closeIfDone*(stream: Stream): bool {.raises: [].} =
 
 proc abort*(stream: Stream) =
   stream.closeWrite = true
-  stream.isEof = true
+  stream.markReadFailed("stream aborted")
   stream.abortPendingWrites("stream aborted")
-  stream.completePendingRead()
+  stream.failPendingRead(newException(StreamError, stream.readFailure))
   discard stream.requestClose()
   if not stream.closed.isSet():
     stream.closed.fire()
@@ -220,9 +255,15 @@ proc readOnce*(
     raiseAssert "dst cannot be nil"
 
   raiseIfReadReset(stream)
+  raiseIfReadFailed(stream)
 
-  if stream.isEof or stream.closedByEngine:
+  if stream.isEof:
+    if not stream.closeIfDone():
+      stream.abort()
+      raise newException(StreamError, "could not close the stream")
     return 0
+  if stream.closedByEngine:
+    raise newException(StreamError, "stream closed before end of stream")
 
   await stream.readLock.acquire()
 
@@ -233,19 +274,23 @@ proc readOnce*(
       discard # should not happen - lock acquired directly above
 
   raiseIfReadReset(stream)
+  raiseIfReadFailed(stream)
 
   # In case stream was closed while waiting for lock being acquired
   if stream.closedByEngine:
-    return 0
+    raise newException(StreamError, "stream closed before end of stream")
 
-  let n = lsquic_stream_read(stream.quicStream, dst, dstLen.csize_t)
+  var receivedFin = false
+  let n = readFromStream(stream.quicStream, dst, dstLen, receivedFin)
+  if receivedFin:
+    stream.isEof = true
 
   if n == 0:
-    stream.isEof = true
-    if not stream.closeIfDone():
-      stream.abort()
-      raise newException(StreamError, "could not close the stream")
-    return 0
+    if stream.isEof:
+      if not stream.closeIfDone():
+        stream.abort()
+        raise newException(StreamError, "could not close the stream")
+      return 0
   elif n > 0:
     return n
 

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -111,6 +111,11 @@ proc readToBuffer(
 proc readFromStream*(
     stream: ptr lsquic_stream_t, data: ptr byte, dataLen: int, receivedFin: var bool
 ): ssize_t {.raises: [].} =
+  receivedFin = false
+  if dataLen < 0 or (dataLen > 0 and data.isNil):
+    errno = EINVAL
+    return -1
+
   var readCtx = ReadContext(data: data, dataLen: dataLen)
   let n = lsquic_stream_readf(stream, readToBuffer, addr readCtx)
   receivedFin = readCtx.receivedFin
@@ -248,6 +253,9 @@ proc readOnce*(
 ): Future[int] {.async: (raises: [CancelledError, StreamError]).} =
   if not stream.canRead:
     raise newException(StreamError, "stream is write-only")
+
+  if dstLen < 0:
+    raiseAssert "dstLen cannot be negative"
 
   if dstLen == 0:
     return 0

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -99,12 +99,13 @@ proc readToBuffer(
     ctx: pointer, data: ptr uint8, dataLen: csize_t, fin: cint
 ): csize_t {.cdecl, raises: [].} =
   let readCtx = cast[ptr ReadContext](ctx)
-  let count = min(dataLen.int, readCtx.dataLen - readCtx.offset)
+  let remaining = readCtx.dataLen - readCtx.offset
+  let count = min(dataLen, remaining.csize_t).int
   if count > 0:
     let dst = cast[ptr UncheckedArray[byte]](readCtx.data)
     copyMem(addr dst[readCtx.offset], data, count)
     readCtx.offset += count
-  if fin != 0 and count == dataLen.int:
+  if fin != 0 and count.csize_t == dataLen:
     readCtx.receivedFin = true
   count.csize_t
 

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -112,8 +112,9 @@ proc readFromStream*(
     stream: ptr lsquic_stream_t, data: ptr byte, dataLen: int, receivedFin: var bool
 ): ssize_t {.raises: [].} =
   var readCtx = ReadContext(data: data, dataLen: dataLen)
-  result = lsquic_stream_readf(stream, readToBuffer, addr readCtx)
+  let n = lsquic_stream_readf(stream, readToBuffer, addr readCtx)
   receivedFin = readCtx.receivedFin
+  return n
 
 proc failPendingRead*(stream: Stream, error: ref StreamError) {.raises: [].} =
   let task = stream.toRead.valueOr:

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import std/[posix, sets]
+import std/sets
 import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import lsquic/context/[client, context, io, stream]

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -75,8 +75,7 @@ suite "lifecycle":
     expect StreamResetError:
       discard await incomingStream.readOnce(buf).wait(timeout)
 
-  asyncTest "connection abort ends the peer's stream at eof":
-    # TODO: vacp2p/nim-lsquic#136
+  asyncTest "connection abort fails the peer's stream without fin":
     let peers = await connectPeers()
     defer:
       await peers.stop()
@@ -91,7 +90,8 @@ suite "lifecycle":
     check (await peers.incoming.closedFuture().withTimeout(timeout))
 
     var buf = newSeq[byte](8)
-    check (await incomingStream.readOnce(buf).wait(timeout)) == 0
+    expect StreamError:
+      discard await incomingStream.readOnce(buf).wait(timeout)
 
   asyncTest "accept skips closed connection and client redials":
     let server = makeServer()
@@ -155,7 +155,8 @@ suite "lifecycle":
 
     let stream = await incomingStream
     var buf = newSeq[byte](1)
-    check (await stream.readOnce(buf)) == 0
+    expect StreamError:
+      discard await stream.readOnce(buf)
 
   asyncTest "pending incoming stream survives immediate client close":
     let peers = await connectPeers()
@@ -169,7 +170,8 @@ suite "lifecycle":
 
     let stream = await incomingStream.wait(timeout)
     var buf = newSeq[byte](1)
-    check (await stream.readOnce(buf)) == 0
+    expect StreamError:
+      discard await stream.readOnce(buf)
 
   asyncTest "client stop closes active connections":
     let peers = await connectPeers()
@@ -760,7 +762,8 @@ suite "lifecycle":
 
     # the post-lock re-check keeps the read away from the freed native stream
     check (await reading.withTimeout(timeout))
-    check (await reading) == 0
+    expect StreamError:
+      discard await reading
 
   asyncTest "read waiting for the read lock sees a peer reset":
     let stream = Stream.new()
@@ -808,7 +811,7 @@ suite "lifecycle":
   # One test per close path, pinning the rule that each settles the parked
   # operation itself.
 
-  asyncTest "engine close completes a parked read with eof":
+  asyncTest "engine close without fin fails parked and later reads":
     let stream = Stream.new()
     var buf = newSeq[byte](8)
     let doneFut =
@@ -820,7 +823,13 @@ suite "lifecycle":
 
     check stream.toRead.isNone()
     check doneFut.finished
-    check (await doneFut.wait(timeout)) == 0
+    expect StreamError:
+      discard await doneFut.wait(timeout)
+
+    var laterBuf = newSeq[byte](1)
+    expect StreamError:
+      discard await stream.readOnce(laterBuf)
+    check not stream.isEof
 
   asyncTest "engine close fails a parked read after a peer read reset":
     let stream = Stream.new()
@@ -876,14 +885,15 @@ suite "lifecycle":
 
     stream.abort()
 
-    # Unlike close, abort takes the read side down too, so later reads end at eof.
-    check stream.isEof
+    # Unlike a received FIN, abort terminates the read side with an error.
+    check not stream.isEof
     check stream.toRead.isNone()
     check stream.toWrite.isNone()
     check readFut.finished
     check writeFut.finished
-    check (await readFut.wait(timeout)) == 0
 
+    expect StreamError:
+      discard await readFut.wait(timeout)
     expect StreamError:
       await writeFut.wait(timeout)
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -470,14 +470,8 @@ suite "lifecycle":
 
     check isReset
 
-  asyncTest "vanished peer ends the stream at eof without a fin":
-    # TODO: vacp2p/nim-lsquic#140
-    # Skipped: reaching the case costs the 30s fixed lsquic idle timeout
-    skip()
-    return
-
-    # The peer's socket disappears mid-stream, so it never sends a FIN, yet the
-    # reader is handed the same end of stream a FIN produces.
+  asyncTest "vanished peer fails the stream without a fin":
+    # The peer's socket disappears mid-stream, so it never sends a FIN.
     let server = makeEndpoint(AutoAddressIP4)
     let client = makeDialEndpoint(AddressFamily.IPv4)
     defer:
@@ -497,8 +491,9 @@ suite "lifecycle":
     await server.datagramTransport().closeWait()
 
     var buf = newSeq[byte](8)
-    check (await clientStream.readOnce(buf).wait(45.seconds)) == 0
-    check clientStream.isEof
+    expect StreamError:
+      discard await clientStream.readOnce(buf).wait(45.seconds)
+    check not clientStream.isEof
     check not clientStream.resetByPeer
 
   asyncTest "zero length reads return zero":

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import std/sets
+import std/[posix, sets]
 import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import lsquic/context/[client, context, io, stream]
@@ -726,6 +726,29 @@ suite "lifecycle":
 
     expect AssertionDefect:
       discard await stream.readOnce(nil, 8)
+
+  asyncTest "negative read length is rejected":
+    let stream = Stream.new()
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+    var data: byte
+
+    expect AssertionDefect:
+      discard await stream.readOnce(addr data, -1)
+
+  test "read helper rejects invalid buffers before ffi":
+    var receivedFin = true
+
+    check:
+      readFromStream(nil, nil, -1, receivedFin) == -1
+      errno == EINVAL
+      not receivedFin
+
+    receivedFin = true
+    check:
+      readFromStream(nil, nil, 1, receivedFin) == -1
+      errno == EINVAL
+      not receivedFin
 
   asyncTest "nil write source is rejected":
     let stream = Stream.new()

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -727,44 +727,6 @@ suite "lifecycle":
     expect AssertionDefect:
       discard await stream.readOnce(nil, 8)
 
-  asyncTest "negative read length is rejected":
-    let stream = Stream.new()
-    defer:
-      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
-    var data: byte
-
-    expect AssertionDefect:
-      discard await stream.readOnce(addr data, -1)
-
-  test "read helper rejects invalid buffers before ffi":
-    var receivedFin = true
-
-    check:
-      readFromStream(nil, nil, -1, receivedFin) == -1
-      errno == EINVAL
-      not receivedFin
-
-    receivedFin = true
-    check:
-      readFromStream(nil, nil, 1, receivedFin) == -1
-      errno == EINVAL
-      not receivedFin
-
-  asyncTest "nil write source is rejected":
-    let stream = Stream.new()
-    defer:
-      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
-
-    expect AssertionDefect:
-      await stream.write(nil, 8)
-
-  asyncTest "zero length writes ignore a nil source":
-    let stream = Stream.new()
-    defer:
-      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
-
-    await stream.write(nil, 0)
-
   asyncTest "read waiting for the read lock sees the stream closed by the engine":
     let stream = Stream.new()
     defer:


### PR DESCRIPTION
## Summary

- Track an observed QUIC FIN separately from stream or connection teardown.
- Use lsquic's FIN-aware read callback so FIN is retained when bytes and FIN arrive together.
- Fail parked and subsequent reads when a stream disappears before FIN instead of reporting a false EOF.
- Preserve reset-specific errors and make local abort terminate reads with an error.

## Impact on Library Users

`readOnce` returns zero only for a genuine peer FIN. Connection loss, timeout, abort, and other teardown before FIN now raise `StreamError`, allowing callers to detect truncated streams.

## Risk Assessment

Code that treated every connection teardown as a clean EOF must now handle `StreamError`. This is an intentional correction to prevent silent data truncation.

## References

Closes #140.
