### PR TITLE
fix(stream): handle peer unidirectional streams

### DIFF
--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -424,7 +424,7 @@ proc onNewStream*(
     return nil
 
   let quicConn = cast[QuicConnection](conn_ctx)
-  let stream_id = lsquic_stream_id(stream).int
+  let stream_id = lsquic_stream_id(stream)
   let isLocal =
     if quicConn.isOutgoing:
       (stream_id and 1) == 0
@@ -440,7 +440,7 @@ proc onNewStream*(
       discard lsquic_stream_wantwrite(stream, 1)
       s
     else:
-      let s = Stream.new(stream, canWrite = not isUnidirectional(stream_id.uint64))
+      let s = Stream.new(stream, canWrite = not isUnidirectional(stream_id))
       quicConn.incoming.putNoWait(s)
       # Whoever opens the stream reads first
       discard lsquic_stream_wantread(stream, 1)

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -410,6 +410,9 @@ proc makeStream*(
     raise newException(ConnectionClosedError, "connection closed")
   lsquic_conn_make_stream(quicConn.lsquicConn)
 
+func isUnidirectional*(streamId: lsquic_stream_id_t): bool {.raises: [].} =
+  (streamId and 2) != 0
+
 proc onNewStream*(
     stream_if_ctx: pointer, stream: ptr lsquic_stream_t
 ): ptr lsquic_stream_ctx_t {.cdecl.} =
@@ -437,7 +440,7 @@ proc onNewStream*(
       discard lsquic_stream_wantwrite(stream, 1)
       s
     else:
-      let s = Stream.new(stream)
+      let s = Stream.new(stream, canWrite = not isUnidirectional(stream_id.uint64))
       quicConn.incoming.putNoWait(s)
       # Whoever opens the stream reads first
       discard lsquic_stream_wantread(stream, 1)

--- a/lsquic/stream.nim
+++ b/lsquic/stream.nim
@@ -22,6 +22,8 @@ type ReadTask* = object
 
 type Stream* = ref object
   quicStream*: ptr lsquic_stream_t
+  canRead*: bool
+  canWrite*: bool
   closedByEngine*: bool
   closeWrite*: bool
   closeRequested: bool
@@ -38,10 +40,18 @@ type Stream* = ref object
   toRead*: Opt[ReadTask]
   doProcess*: proc(urgent: bool) {.gcsafe, raises: [].}
 
-proc new*(T: typedesc[Stream], quicStream: ptr lsquic_stream_t = nil): T =
+proc new*(
+    T: typedesc[Stream],
+    quicStream: ptr lsquic_stream_t = nil,
+    canRead = true,
+    canWrite = true,
+): T =
   let closed = newAsyncEvent()
   let s = Stream(
     quicStream: quicStream,
+    canRead: canRead,
+    canWrite: canWrite,
+    closeWrite: not canWrite,
     closed: closed,
     readLock: newAsyncLock(),
     writeLock: newAsyncLock(),
@@ -200,6 +210,9 @@ proc close*(stream: Stream) {.async: (raises: [StreamError, CancelledError]).} =
 proc readOnce*(
     stream: Stream, dst: ptr byte, dstLen: int
 ): Future[int] {.async: (raises: [CancelledError, StreamError]).} =
+  if not stream.canRead:
+    raise newException(StreamError, "stream is write-only")
+
   if dstLen == 0:
     return 0
 
@@ -277,6 +290,9 @@ proc write*(
   ## when this proc resumes on a later poll tick. Freeing the buffer between
   ## `cancel()` and that tick is a use-after-free - use `await fut.cancelAndWait()`
   ## or otherwise wait for the future to finish before releasing it.
+  if not stream.canWrite:
+    raise newException(StreamError, "stream is read-only")
+
   if srcLen == 0:
     return
 
@@ -342,6 +358,9 @@ proc write*(
   ##
   ## A caller that keeps its own buffer still pays one copy here, and should use
   ## the pointer overload instead if it can honour that overload's contract.
+  if not stream.canWrite:
+    raise newException(StreamError, "stream is read-only")
+
   if data.len == 0:
     return
   await stream.write(data[0].addr, data.len)

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -507,6 +507,28 @@ suite "lifecycle":
 
     check (await stream.readOnce(empty)) == 0
 
+  test "stream id direction bit identifies unidirectional streams":
+    check:
+      not isUnidirectional(0)
+      not isUnidirectional(1)
+      isUnidirectional(2)
+      isUnidirectional(3)
+
+  asyncTest "receive-only stream rejects writes locally":
+    let stream = Stream.new(canWrite = false)
+    defer:
+      onClose(nil, cast[ptr lsquic_stream_ctx_t](stream)) # release the pin
+
+    check:
+      stream.canRead
+      not stream.canWrite
+      stream.closeWrite
+
+    expect StreamError:
+      await stream.write(@[])
+
+    await stream.close()
+
   asyncTest "late datagrams are ignored after context stops":
     let verifier: CertificateVerifier = CustomCertificateVerifier.init(
       proc(serverName: string, derCertificates: seq[seq[byte]]): bool {.gcsafe.} =


### PR DESCRIPTION
## Summary

- Detect the direction bit in peer-created QUIC stream IDs.
- Expose stream read/write capabilities.
- Represent peer unidirectional streams as receive-only and reject writes locally.
- Avoid invoking a write-side shutdown for receive-only streams.

## Impact on Library Users

Standards-compliant peers can open unidirectional streams without those streams being treated as bidirectional. Writes to receive-only streams fail with `StreamError` before entering lsquic.

## References

Closes #142.
