### PR TITLE
fix(connection): report current remote address

### DIFF
--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -3,8 +3,10 @@
 
 import chronicles
 import chronos, results
+import chronos/osdefs
 import ./[errors, stream, lsquic_ffi, certificateverifier]
 import ./context/context
+import ./helpers/transportaddr
 
 type
   Connection* = ref object of RootObj
@@ -179,4 +181,16 @@ proc localAddress*(connection: Connection): TransportAddress {.raises: [].} =
   connection.local
 
 proc remoteAddress*(connection: Connection): TransportAddress {.raises: [].} =
+  if not connection.quicConn.isNil and not connection.quicConn.lsquicConn.isNil:
+    var local, remote: ptr SockAddr
+    if lsquic_conn_get_sockaddr(
+      connection.quicConn.lsquicConn, addr local, addr remote
+    ) == 0 and not remote.isNil:
+      connection.remote = remote.toTransportAddress()
   connection.remote
+
+when defined(lsquic_testing):
+  proc setCachedRemoteAddressForTest*(
+      connection: Connection, remote: TransportAddress
+  ) {.raises: [].} =
+    connection.remote = remote

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -181,11 +181,16 @@ proc localAddress*(connection: Connection): TransportAddress {.raises: [].} =
   connection.local
 
 proc remoteAddress*(connection: Connection): TransportAddress {.raises: [].} =
-  if not connection.quicConn.isNil and not connection.quicConn.lsquicConn.isNil:
-    var local, remote: ptr SockAddr
-    if lsquic_conn_get_sockaddr(connection.quicConn.lsquicConn, addr local, addr remote) ==
-        0 and not remote.isNil:
-      connection.remote = remote.toTransportAddress()
+  ## Returns the current remote address while the connection is live, falling
+  ## back to the last cached address after closure.
+  if connection.quicConn.isNil or connection.quicConn.lsquicConn.isNil:
+    return connection.remote
+
+  var local, remote: ptr SockAddr
+  if lsquic_conn_get_sockaddr(connection.quicConn.lsquicConn, addr local, addr remote) ==
+      0 and not remote.isNil:
+    connection.remote = remote.toTransportAddress()
+
   connection.remote
 
 when defined(lsquic_testing):

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -183,9 +183,8 @@ proc localAddress*(connection: Connection): TransportAddress {.raises: [].} =
 proc remoteAddress*(connection: Connection): TransportAddress {.raises: [].} =
   if not connection.quicConn.isNil and not connection.quicConn.lsquicConn.isNil:
     var local, remote: ptr SockAddr
-    if lsquic_conn_get_sockaddr(
-      connection.quicConn.lsquicConn, addr local, addr remote
-    ) == 0 and not remote.isNil:
+    if lsquic_conn_get_sockaddr(connection.quicConn.lsquicConn, addr local, addr remote) ==
+        0 and not remote.isNil:
       connection.remote = remote.toTransportAddress()
   connection.remote
 

--- a/tests/test_connection.nim
+++ b/tests/test_connection.nim
@@ -31,6 +31,10 @@ proc runConnectionTest(
   let outgoingConn = await dialing
   let incomingConn = await accepting
 
+  var staleRemote = effectiveDialAddress
+  staleRemote.port = Port(1)
+  outgoingConn.setCachedRemoteAddressForTest(staleRemote)
+
   check:
     outgoingConn.certificates().len == 1
     incomingConn.certificates().len == 1


### PR DESCRIPTION
## Summary

Refresh `Connection.remoteAddress()` from lsquic's current network path while the native connection is live. After closure, retain the most recently observed address as a safe fallback.

## Impact on Library Users

Connections that migrate paths now report the current peer address rather than the original dial or accept snapshot.

## References

Closes #143.
