### PR TITLE
fix(tlsconfig)!: preserve ALPN preference order

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The project links through a C++ linker profile on non-Windows platforms, so `g++
 The main entry point is [`lsquic.nim`](lsquic.nim):
 
 ```nim
-import std/[sequtils, sets]
+import std/sequtils
 import chronos
 import results
 import lsquic
@@ -72,7 +72,7 @@ proc main() {.async.} =
   defer:
     cleanupLsquic()
 
-  let alpn = ["echo"].toHashSet()
+  let alpn = @["echo"]
 
   let server = QuicServer.new(
     TLSConfig.new(

--- a/benchmarks/bench_common.nim
+++ b/benchmarks/bench_common.nim
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import std/[json, sets, sequtils, os, algorithm, math, strutils]
+import std/[json, sequtils, os, algorithm, math, strutils]
 from std/posix import Rusage, RUSAGE_SELF, getrusage
 import chronos, results, stew/endians2, chronicles
 import lsquic
 
-export json, sets, sequtils, os, algorithm, math, strutils
+export json, sequtils, os, algorithm, math, strutils
 export chronos, results, endians2, chronicles
 export lsquic
 
@@ -117,10 +117,7 @@ proc makeClient*(): QuicClient {.
   let customCertVerif: CertificateVerifier =
     CustomCertificateVerifier.init(certificateCb)
   let clientTLSConfig = TLSConfig.new(
-    testCertificate(),
-    testPrivateKey(),
-    @["bench"].toHashSet(),
-    Opt.some(customCertVerif),
+    testCertificate(), testPrivateKey(), @["bench"], Opt.some(customCertVerif)
   )
   return QuicClient.new(clientTLSConfig)
 
@@ -128,10 +125,7 @@ proc makeServer*(): QuicServer {.raises: [QuicConfigError].} =
   let customCertVerif: CertificateVerifier =
     CustomCertificateVerifier.init(certificateCb)
   let serverTLSConfig = TLSConfig.new(
-    testCertificate(),
-    testPrivateKey(),
-    @["bench"].toHashSet(),
-    Opt.some(customCertVerif),
+    testCertificate(), testPrivateKey(), @["bench"], Opt.some(customCertVerif)
   )
   return QuicServer.new(serverTLSConfig)
 

--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -181,6 +181,9 @@ proc openStream*(
 proc certificates*(conn: Connection): seq[seq[byte]] {.raises: [].} =
   conn.quicContext.certificates(conn.quicConn)
 
+proc negotiatedProtocol*(conn: Connection): string {.raises: [].} =
+  conn.quicConn.negotiatedProtocol
+
 proc localAddress*(connection: Connection): TransportAddress {.raises: [].} =
   connection.local
 

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import std/[deques, hashes, sets, strutils]
+import std/[deques, hashes, sets, strutils, tables]
 import boringssl
 import chronos
 import chronos/osdefs
@@ -176,11 +176,13 @@ type QuicConnection* = ref object of RootObj
   connectedFut*: Future[void]
   pendingStreams: Deque[PendingStream] = initDeque[PendingStream]()
   certChain*: seq[seq[byte]]
+  negotiatedProtocol*: string
 
 type ClientContext* = ref object of QuicContext
 
 type ServerContext* = ref object of QuicContext
   incoming*: AsyncQueue[QuicConnection]
+  pendingNegotiatedProtocols: Table[CidKey, string] = initTable[CidKey, string]()
 
 proc processWhenReady*(quicContext: QuicContext) =
   if quicContext.isNil or quicContext.engine.isNil:
@@ -228,6 +230,37 @@ proc popPendingStream*(
   pending.created.complete()
   Opt.some(pending.stream)
 
+proc storeNegotiatedProtocol(
+    ssl: ptr SSL, protocol: ptr uint8, protocolLen: int
+) {.raises: [].} =
+  if protocol.isNil or protocolLen == 0:
+    return
+
+  let conn = lsquic_ssl_to_conn(ssl)
+  if conn.isNil:
+    return
+  let connCtx = lsquic_conn_get_ctx(conn)
+  if connCtx.isNil:
+    return
+
+  let quicConn = cast[QuicConnection](connCtx)
+  quicConn.negotiatedProtocol = newString(protocolLen)
+  copyMem(addr quicConn.negotiatedProtocol[0], protocol, protocolLen)
+
+proc copyProtocol(protocol: ptr uint8, protocolLen: int): string {.raises: [].} =
+  if protocol.isNil or protocolLen == 0:
+    return
+  result = newString(protocolLen)
+  copyMem(addr result[0], protocol, protocolLen)
+
+proc takeNegotiatedProtocol*(
+    ctx: ServerContext, conn: ptr lsquic_conn_t
+): string {.raises: [].} =
+  let cid = lsquic_conn_id(conn)
+  var key: CidKey
+  if not cid.isNil and toCidKey(cid[], key):
+    discard ctx.pendingNegotiatedProtocols.pop(key, result)
+
 proc cancelPending*(quicConn: QuicConnection) =
   while quicConn.pendingStreams.len > 0:
     let pending = quicConn.pendingStreams.popFirst()
@@ -261,6 +294,13 @@ proc alpnSelectProtoCB(
       inlen,
     ) == OPENSSL_NPN_NEGOTIATED
   ):
+    # Passing the local list first deliberately applies server preference.
+    let conn = lsquic_ssl_to_conn(ssl)
+    if not conn.isNil:
+      let cid = lsquic_conn_id(conn)
+      var key: CidKey
+      if not cid.isNil and toCidKey(cid[], key):
+        serverCtx.pendingNegotiatedProtocols[key] = copyProtocol(outv[], outlen[].int)
     return SSL_TLSEXT_ERR_OK
 
   return SSL_TLSEXT_ERR_ALERT_FATAL
@@ -280,6 +320,11 @@ proc verifyCertificate(
       if not out_alert.isNil:
         out_alert[] = SSL_AD_INTERNAL_ERROR
       return ssl_verify_invalid
+
+    var selected: ptr uint8
+    var selectedLen: cuint
+    SSL_get0_alpn_selected(ssl, addr selected, addr selectedLen)
+    storeNegotiatedProtocol(ssl, selected, selectedLen.int)
 
     var certVerifier = quicCtx.tlsConfig.certVerifier
     let conn = lsquic_ssl_to_conn(ssl)

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -14,6 +14,7 @@ proc onNewConn(
     stream_if_ctx: pointer, conn: ptr lsquic_conn_t
 ): ptr lsquic_conn_ctx_t {.cdecl.} =
   debug "New connection established: server"
+  let serverCtx = cast[ServerContext](stream_if_ctx)
   var local: ptr SockAddr
   var remote: ptr SockAddr
   discard lsquic_conn_get_sockaddr(conn, addr local, addr remote)
@@ -30,10 +31,10 @@ proc onNewConn(
     remote: remote.toTransportAddress(),
     lsquicConn: conn,
     certChain: certChain,
+    negotiatedProtocol: serverCtx.takeNegotiatedProtocol(conn),
     onClose: proc() =
       discard,
   )
-  let serverCtx = cast[ServerContext](stream_if_ctx)
   serverCtx.trackConnectionCid(conn)
   pin(quicConn) # Keep it pinned until on_conn_closed is called
   serverCtx.incoming.putNoWait(quicConn)

--- a/lsquic/tlsconfig.nim
+++ b/lsquic/tlsconfig.nim
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import std/sets
 import boringssl
 import results
 import ./[errors, certificateverifier, lsquic_ffi]
@@ -16,7 +15,7 @@ proc new*(
     T: typedesc[TLSConfig],
     certificate: seq[byte] = @[],
     key: seq[byte] = @[],
-    alpn: HashSet[string] = initHashSet[string](),
+    alpn: seq[string] = @[],
     certVerifier: Opt[CertificateVerifier] = Opt.none(CertificateVerifier),
 ): T =
   # In a config, certificate and keys are optional, but if using them, both must

--- a/tests/helpers/certificate.nim
+++ b/tests/helpers/certificate.nim
@@ -3,7 +3,6 @@
 
 import sequtils
 import os
-import std/sets
 
 const certificateStr =
   staticRead(parentDir(currentSourcePath()) / "testCertificate.pem")
@@ -18,7 +17,5 @@ proc testCertificate*(): seq[byte] =
 proc testPrivateKey*(): seq[byte] =
   strToSeq(privateKeyStr)
 
-proc makeAlpn*(name: string = "test"): HashSet[string] =
-  var alpn = initHashSet[string]()
-  alpn.incl(name)
-  alpn
+proc makeAlpn*(name: string = "test"): seq[string] =
+  @[name]

--- a/tests/helpers/clientserver.nim
+++ b/tests/helpers/clientserver.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import results, std/sets, chronos, chronicles
+import results, chronos, chronicles
 import lsquic
 import ./[address, certificate]
 
@@ -17,19 +17,19 @@ proc defaultCertificateVerifier*(): CertificateVerifier =
 
 proc makeTLSConfig*(
     verifier: CertificateVerifier = defaultCertificateVerifier(),
-    alpn: HashSet[string] = makeAlpn(),
+    alpn: seq[string] = makeAlpn(),
 ): TLSConfig {.raises: [QuicConfigError].} =
   TLSConfig.new(testCertificate(), testPrivateKey(), alpn, Opt.some(verifier))
 
 proc makeClient*(
     verifier: CertificateVerifier = defaultCertificateVerifier(),
-    alpn: HashSet[string] = makeAlpn(),
+    alpn: seq[string] = makeAlpn(),
 ): QuicClient {.raises: [QuicConfigError, QuicError, TransportOsError].} =
   return QuicClient.new(makeTLSConfig(verifier, alpn))
 
 proc makeServer*(
     verifier: CertificateVerifier = defaultCertificateVerifier(),
-    alpn: HashSet[string] = makeAlpn(),
+    alpn: seq[string] = makeAlpn(),
 ): QuicServer {.raises: [QuicConfigError].} =
   return QuicServer.new(makeTLSConfig(verifier, alpn))
 

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -3,7 +3,6 @@
 
 {.used.}
 
-import std/sets
 import chronos, chronos/unittest2/asynctests, results
 import lsquic
 import lsquic/context/[client, context, io, stream]
@@ -621,9 +620,8 @@ suite "lifecycle":
         discard serverName
         derCertificates.len > 0
     )
-    let tlsConfig = TLSConfig.new(
-      testCertificate(), testPrivateKey(), @["test"].toHashSet(), Opt.some(verifier)
-    )
+    let tlsConfig =
+      TLSConfig.new(testCertificate(), testPrivateKey(), @["test"], Opt.some(verifier))
     let ctx = ClientContext.new(tlsConfig).valueOr:
       raiseAssert error
     let local = initTAddress("127.0.0.1:12345")

--- a/tests/test_tlsconfig.nim
+++ b/tests/test_tlsconfig.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import std/[sets, strutils]
+import std/strutils
 import results
 import unittest2
 import boringssl
@@ -11,33 +11,6 @@ import lsquic
 import lsquic/certificates
 import lsquic/lsquic_ffi
 import ./helpers/[certificate, trackers]
-
-proc decodeAlpnWire(wire: string): HashSet[string] =
-  ## Reverses the ALPN encoding that TLSConfig.new applies, so a test can check
-  ## which protocol names ended up on the wire.
-  ##
-  ## Each name is stored as one byte holding its length followed by the name
-  ## itself, and those pairs are concatenated:
-  ##
-  ##   {"test", "quic-echo"}  ->  "\x04test" & "\x09quic-echo"
-  ##
-  ## A length byte that points past the end of the buffer means the encoding is
-  ## broken, so decoding stops there and the caller gets the names read so far.
-  var decoded = initHashSet[string]()
-  var i = 0
-  while i < wire.len:
-    let length = wire[i].byte.int
-    if i + 1 + length > wire.len:
-      return decoded
-    decoded.incl(wire[i + 1 ..< i + 1 + length])
-    i += 1 + length
-  decoded
-
-proc makeAlpnSet(protocols: varargs[string]): HashSet[string] =
-  var alpn = initHashSet[string]()
-  for protocol in protocols:
-    alpn.incl(protocol)
-  alpn
 
 suite "tls config":
   teardown:
@@ -57,45 +30,39 @@ suite "tls config":
       discard QuicServer.new(cfg)
 
   test "single alpn value is encoded":
-    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpn())
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), @["test"])
 
     check cfg.alpnWire == "\x04test"
 
   test "every alpn value gets its own length prefix":
-    let alpn = makeAlpnSet("test", "quic-echo")
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), @["test", "quic-echo"])
 
-    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), alpn)
-
-    # alpn is a HashSet, so the encoder has no order to preserve: decode the
-    # wire form back instead of pinning a byte string.
-    check:
-      cfg.alpnWire.len == (1 + "test".len) + (1 + "quic-echo".len)
-      cfg.alpnWire.decodeAlpnWire() == alpn
+    check cfg.alpnWire == "\x04test\x09quic-echo"
 
   test "alpn value of 255 bytes still encodes":
     let protocol = repeat('a', 255)
-    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpnSet(protocol))
+    let cfg = TLSConfig.new(testCertificate(), testPrivateKey(), @[protocol])
 
     check:
       cfg.alpnWire.len == 256
       cfg.alpnWire[0].byte.int == 255
-      cfg.alpnWire.decodeAlpnWire() == makeAlpnSet(protocol)
+      cfg.alpnWire[1 .. ^1] == protocol
 
   test "alpn value over 255 bytes is not encodable":
-    let alpn = makeAlpnSet(repeat('a', 256))
+    let alpn = @[repeat('a', 256)]
 
     expect QuicConfigError:
       discard TLSConfig.new(testCertificate(), testPrivateKey(), alpn)
 
   test "empty alpn value is not encodable":
     expect QuicConfigError:
-      discard TLSConfig.new(testCertificate(), testPrivateKey(), makeAlpnSet(""))
+      discard TLSConfig.new(testCertificate(), testPrivateKey(), @[""])
 
   test "alpn protocol list cannot exceed 65535 bytes":
-    var alpn = initHashSet[string]()
+    var alpn: seq[string]
     for i in 0 .. 256:
       let prefix = $i
-      alpn.incl(prefix & repeat('a', 255 - prefix.len))
+      alpn.add(prefix & repeat('a', 255 - prefix.len))
 
     expect QuicConfigError:
       discard TLSConfig.new(testCertificate(), testPrivateKey(), alpn)

--- a/tests/test_verifier.nim
+++ b/tests/test_verifier.nim
@@ -319,6 +319,27 @@ suite "certificate verifier":
     expect DialError:
       discard await client.dial(listener.localAddress()).wait(dialTimeout)
 
+  asyncTest "alpn negotiation uses server preference and is readable":
+    let client = makeClient(
+      CustomCertificateVerifier.init(acceptingCertificateCb),
+      @["client-first", "shared"],
+    )
+    let server = makeServer(
+      CustomCertificateVerifier.init(acceptingCertificateCb),
+      @["shared", "client-first"],
+    )
+    let listener = server.listen(AutoAddressIP4)
+    defer:
+      await allFutures(client.stop(), listener.stop())
+
+    let accepting = listener.accept()
+    let outgoing = await client.dial(listener.localAddress())
+    let incoming = await accepting
+
+    check:
+      outgoing.negotiatedProtocol() == "shared"
+      incoming.negotiatedProtocol() == "shared"
+
   asyncTest "server-side verifier callback does not fail handshake without client auth":
     let recorder = RejectVerifierRecorder(fired: newAsyncEvent())
     let client = makeClient(CustomCertificateVerifier.init(acceptingCertificateCb))


### PR DESCRIPTION
## Summary

- Preserve caller-defined ALPN preference order on the wire.
- Keep server-side selection based on the server's preference order.
- Expose the negotiated ALPN protocol on `Connection`.

## Affected Areas

- [x] Transports

## Impact on Library Users

`TLSConfig.alpn` now accepts `seq[string]` instead of `HashSet[string]`, so callers must provide an ordered sequence. Consumers can read the selected value through `Connection.negotiatedProtocol`.

## Risk Assessment

This is a source-level API change. Negotiation behavior for single-protocol configurations is unchanged; multi-protocol configurations now use deterministic caller preference.

## References

Closes #146.
