### PR TITLE
fix(build): support disabling BoringSSL assembly

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -5,8 +5,8 @@ when not defined(windows):
   else:
     switch("gcc.linkerexe", "g++")
 
-const BORINGSS_USE_ASM {.booldefine.}: bool = true
-when not BORINGSS_USE_ASM:
+const BORINGSSL_USE_ASM {.booldefine.}: bool = true
+when not BORINGSSL_USE_ASM:
   switch("passC", "-DOPENSSL_NO_ASM")
 
 switch("warningAsError", "UnusedImport:on")

--- a/config.nims
+++ b/config.nims
@@ -5,6 +5,10 @@ when not defined(windows):
   else:
     switch("gcc.linkerexe", "g++")
 
+const BORINGSS_USE_ASM {.booldefine.}: bool = true
+when not BORINGSS_USE_ASM:
+  switch("passC", "-DOPENSSL_NO_ASM")
+
 switch("warningAsError", "UnusedImport:on")
 switch("warningAsError", "UseBase:on")
 

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -13,7 +13,7 @@ requires "chronos >= 4.0.4"
 requires "nimcrypto >= 0.6.0"
 requires "unittest2"
 requires "chronicles >= 0.11.0"
-requires "https://github.com/vacp2p/nim-boringssl >= 0.0.4"
+requires "https://github.com/vacp2p/nim-boringssl >= 0.0.11"
 
 import std/[os, strutils, sequtils]
 
@@ -32,7 +32,7 @@ task test, "Run tests":
   exec "./tests/test_all --output-level=VERBOSE"
 
 task test_no_asm, "Run tests without BoringSSL assembly":
-  flags = flags & " -d:BORINGSS_USE_ASM=false "
+  flags = flags & " -d:BORINGSSL_USE_ASM=false "
   testTask()
 
 task test_release, "Run tests - release":

--- a/lsquic.nimble
+++ b/lsquic.nimble
@@ -31,6 +31,10 @@ task test, "Run tests":
   exec nimc & " tests/test_all.nim"
   exec "./tests/test_all --output-level=VERBOSE"
 
+task test_no_asm, "Run tests without BoringSSL assembly":
+  flags = flags & " -d:BORINGSS_USE_ASM=false "
+  testTask()
+
 task test_release, "Run tests - release":
   flags = flags & " -d:release "
   testTask()


### PR DESCRIPTION
## Summary

Make `-d:BORINGSS_USE_ASM=false` select BoringSSL's portable C implementation as well as omit its assembly sources. Add a dedicated Nimble task for exercising this configuration.

## Affected Areas

- [x] Build / Tooling

## Impact on Library Users

Users can build nim-lsquic without BoringSSL assembly by setting `BORINGSS_USE_ASM=false`. Assembly remains enabled by default.

## Risk Assessment

The new compiler flag is applied only when assembly is explicitly disabled; the default build path is unchanged.

## References

Closes #47.
