### PR TITLE
fix(context): pin transport defaults

### DIFF
--- a/lsquic/context/client.nim
+++ b/lsquic/context/client.nim
@@ -140,6 +140,13 @@ proc new*(T: typedesc[ClientContext], tlsConfig: TLSConfig): Result[T, string] =
   ctx.settings.es_base_plpmtu = 1280
   ctx.settings.es_max_plpmtu = 0
   ctx.settings.es_pace_packets = 1
+  ctx.settings.es_handshake_to = 10 * 1000 * 1000
+  ctx.settings.es_idle_conn_to = 30 * 1000 * 1000
+  ctx.settings.es_idle_timeout = 30
+  ctx.settings.es_ping_period = 15
+  ctx.settings.es_max_streams_in = 100
+  ctx.settings.es_init_max_streams_bidi = 100
+  ctx.settings.es_init_max_streams_uni = 100
 
   ctx.settings.es_cfcw = 4 * 1024 * 1024
   ctx.settings.es_max_cfcw = 8 * 1024 * 1024

--- a/lsquic/context/server.nim
+++ b/lsquic/context/server.nim
@@ -69,6 +69,13 @@ proc new*(T: typedesc[ServerContext], tlsConfig: TLSConfig): Result[T, string] =
   ctx.settings.es_base_plpmtu = 1280
   ctx.settings.es_max_plpmtu = 0
   ctx.settings.es_pace_packets = 1
+  ctx.settings.es_handshake_to = 10 * 1000 * 1000
+  ctx.settings.es_idle_conn_to = 30 * 1000 * 1000
+  ctx.settings.es_idle_timeout = 30
+  ctx.settings.es_ping_period = 0
+  ctx.settings.es_max_streams_in = 100
+  ctx.settings.es_init_max_streams_bidi = 100
+  ctx.settings.es_init_max_streams_uni = 3
 
   ctx.settings.es_cfcw = 1536 * 1024
   ctx.settings.es_max_cfcw = 1536 * 1024


### PR DESCRIPTION
## Summary

Explicitly configure the handshake timeout, idle timeouts, ping period, and inbound stream limits in both QUIC contexts. The assigned values match the vendored lsquic defaults currently in force, making future vendor-default changes visible during review.

## Affected Areas

- [x] Transports

## Impact on Library Users

No intended behavior change. Existing transport defaults are now pinned in nim-lsquic.

## Risk Assessment

The settings match the current client and server defaults, including their distinct unidirectional stream limits and server ping behavior.

## References

Closes #145.
