### PR TITLE
fix(stream): preserve credit after cancelled openStream

### DIFF
--- a/lsquic/connection.nim
+++ b/lsquic/connection.nim
@@ -166,6 +166,10 @@ proc openStream*(
   if connection.isClosed:
     raise newException(ConnectionClosedError, "connection closed")
 
+  let available = connection.quicConn.takeAvailableStream()
+  if available.isSome:
+    return available.get()
+
   let s = Stream.new()
   s.doProcess = proc(urgent: bool) {.gcsafe, raises: [].} =
     if urgent:

--- a/lsquic/context/context.nim
+++ b/lsquic/context/context.nim
@@ -175,6 +175,7 @@ type QuicConnection* = ref object of RootObj
   incoming*: AsyncQueue[Stream]
   connectedFut*: Future[void]
   pendingStreams: Deque[PendingStream] = initDeque[PendingStream]()
+  availableStreams: Deque[Stream] = initDeque[Stream]()
   certChain*: seq[seq[byte]]
 
 type ClientContext* = ref object of QuicContext
@@ -225,8 +226,17 @@ proc popPendingStream*(
 
   let pending = quicConn.pendingStreams.popFirst()
   pending.stream.quicStream = stream
-  pending.created.complete()
+  if pending.created.cancelled():
+    quicConn.availableStreams.addLast(pending.stream)
+  else:
+    pending.created.complete()
   Opt.some(pending.stream)
+
+proc takeAvailableStream*(quicConn: QuicConnection): Opt[Stream] {.raises: [].} =
+  if quicConn.availableStreams.len == 0:
+    Opt.none(Stream)
+  else:
+    Opt.some(quicConn.availableStreams.popFirst())
 
 proc cancelPending*(quicConn: QuicConnection) =
   while quicConn.pendingStreams.len > 0:
@@ -240,6 +250,7 @@ proc cancelPending*(quicConn: QuicConnection) =
     if not pending.stream.closed.isSet():
       pending.stream.closed.fire()
     unpin(pending.stream)
+  quicConn.availableStreams.clear()
 
 proc alpnSelectProtoCB(
     ssl: ptr SSL,

--- a/tests/test_lifecycle.nim
+++ b/tests/test_lifecycle.nim
@@ -226,8 +226,7 @@ suite "lifecycle":
       await pending2.wait(timeout)
     check quicConn.popPendingStream(nil).isNone()
 
-  asyncTest "a cancelled pending stream stays in the queue":
-    # TODO: vacp2p/nim-lsquic#154
+  asyncTest "a cancelled pending stream is available to the next caller":
     let quicConn = QuicConnection(incoming: newAsyncQueue[Stream]())
     let stream = Stream.new()
     defer:
@@ -237,11 +236,13 @@ suite "lifecycle":
     await pending.cancelAndWait()
     check pending.cancelled()
 
-    # popPendingStream hands the engine's new stream to a caller that is gone.
     var nativeStream = 0
     let native = cast[ptr lsquic_stream_t](addr nativeStream)
     let popped = quicConn.popPendingStream(native)
     check popped.isSome()
+    let available = quicConn.takeAvailableStream()
+    check available.isSome()
+    check available.get() == stream
     check stream.quicStream == native
 
   asyncTest "openStream parks once the peer's stream credit is exhausted":
@@ -258,8 +259,7 @@ suite "lifecycle":
 
     await parked.cancelAndWait()
 
-  asyncTest "a cancelled parked openStream costs a stream credit slot":
-    # TODO: vacp2p/nim-lsquic#154
+  asyncTest "a cancelled parked openStream returns its stream credit slot":
     # Returns the stream credit available once every stream opened here is retired.
     proc creditAfterRetiringAll(cancellations: int): Future[int] {.async.} =
       let peers = await connectPeers()
@@ -285,7 +285,6 @@ suite "lifecycle":
       for _ in 0 ..< cancellations:
         let parked = peers.outgoing.openStream()
         check not (await parked.withTimeout(timeout))
-        # The cancelled openStream stays in pendingStreams, holding its slot.
         await parked.cancelAndWait()
 
       # Close+EOF every stream, retiring the stream credit they hold.
@@ -311,8 +310,7 @@ suite "lifecycle":
 
     check (await creditAfterRetiringAll(0)) == LSQUIC_DF_INIT_MAX_STREAMS_BIDI
 
-    # The engine creates the stream anyway, and nothing ever retires it.
-    check (await creditAfterRetiringAll(1)) == LSQUIC_DF_INIT_MAX_STREAMS_BIDI - 1
+    check (await creditAfterRetiringAll(1)) == LSQUIC_DF_INIT_MAX_STREAMS_BIDI
 
   asyncTest "abort after open stream still closes connection":
     let peers = await connectPeers()


### PR DESCRIPTION
## Summary

Preserve bidirectional stream credit when a parked `openStream` call is cancelled. Streams created later for cancelled requests are retained by the connection and reused by the next caller instead of becoming unreachable.

## Affected Areas

- [x] Transports

## Impact on Library Users

Cancelling a pending stream open no longer permanently reduces the number of streams available on the connection.

## Risk Assessment

The reuse queue is connection-owned and cleared with other pending stream state when the connection closes.

## References

Closes #154.
